### PR TITLE
Drekkar QoL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,22 @@
 default:
 	@echo no default
 
-story-compile:
+story-to-html:
 	WSLENV=$$WSLENV:TWEEGO_PATH/l \
 	TWEEGO_PATH=./assets \
 		tweego story.tw -o index.html
 
-story-decompile:
+story-to-tw:
 	WSLENV=$$WSLENV:TWEEGO_PATH/l \
 	TWEEGO_PATH=./assets \
 		tweego -d index.html -o story.tw
 
-nero-compile:
+nero-to-html:
 	WSLENV=$$WSLENV:TWEEGO_PATH/l \
 	TWEEGO_PATH=./assets \
 		tweego nero.tw -o nero.html
 
-nero-decompile:
+nero-to-tw:
 	WSLENV=$$WSLENV:TWEEGO_PATH/l \
 	TWEEGO_PATH=./assets \
 		tweego -d nero.html -o nero.tw

--- a/index.html
+++ b/index.html
@@ -98,7 +98,7 @@ var LZString={_keyStr:"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz01234
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<!-- UUID://F420476E-098A-46C9-9EFF-9652F277776A// --><tw-storydata name="The Mage&#39;s Tower" startnode="178" creator="Tweego" creator-version="2.1.1+81d1d71" ifid="F420476E-098A-46C9-9EFF-9652F277776A" zoom="1" format="SugarCube" format-version="2.36.1" options="" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">/* Title Screen - Start */
+	<!-- UUID://F420476E-098A-46C9-9EFF-9652F277776A// --><tw-storydata name="The Mage&#39;s Tower" startnode="169" creator="Tweego" creator-version="2.1.1+81d1d71" ifid="F420476E-098A-46C9-9EFF-9652F277776A" zoom="0.6" format="SugarCube" format-version="2.36.1" options="" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">/* Title Screen - Start */
 .title-container {
   position:relative;
 }
@@ -340,28 +340,28 @@ ul.actions li {
 
 /* Horizontal Health Bar - Start */
 .hzbarbkg {  /* default class for all horizontal bar backgrounds */
-	position: relative;
-	height: 15px;
-	width: 50%;
-	background-color: #111;
-	background-image: linear-gradient(to right, rgba(68, 68, 68, 0.5), rgba(34, 34, 34, 0.5) 5px), linear-gradient(to bottom, rgba(68, 68, 68, 0.5), rgba(0, 0, 0, 0) 5px), linear-gradient(to left, rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0) 5px), linear-gradient(to top, rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0) 5px);
+    position: relative;
+    height: 15px;
+    width: 50%;
+    background-color: #111;
+    background-image: linear-gradient(to right, rgba(68, 68, 68, 0.5), rgba(34, 34, 34, 0.5) 5px), linear-gradient(to bottom, rgba(68, 68, 68, 0.5), rgba(0, 0, 0, 0) 5px), linear-gradient(to left, rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0) 5px), linear-gradient(to top, rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0) 5px);
     border-radius: 10px;
-	z-index: 10;
-	visibility: visible;
+    z-index: 10;
+    visibility: visible;
 }
 .hzbar {  /* default class for all horizontal bars */
-	position: absolute;
-	bottom: 0px;
-	left: 0px;
-	height: 15px;
+    position: absolute;
+    bottom: 0px;
+    left: 0px;
+    height: 15px;
     border-radius: 10px;
-	background-color: transparent;
-	background-image: linear-gradient(to left, rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0) 5px), linear-gradient(to top, rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0) 5px), linear-gradient(to right, rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0) 5px), linear-gradient(to bottom, rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0) 5px);
-	z-index: 20;
-	transition: width ease 1s, background-color ease 1s;
+    background-color: transparent;
+    background-image: linear-gradient(to left, rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0) 5px), linear-gradient(to top, rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0) 5px), linear-gradient(to right, rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0) 5px), linear-gradient(to bottom, rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0) 5px);
+    z-index: 20;
+    transition: width ease 1s, background-color ease 1s;
 }
 #horizontalhealthbar {  /* colors for specific fixed-color horizontal bars */
-	background-image: linear-gradient(to left, rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0) 5px), linear-gradient(to top, rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0) 5px), linear-gradient(to right, rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0) 5px), linear-gradient(to bottom, rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0) 5px), radial-gradient( circle at bottom right, #a1001e, #a1001e 60% );
+    background-image: linear-gradient(to left, rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0) 5px), linear-gradient(to top, rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0) 5px), linear-gradient(to right, rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0) 5px), linear-gradient(to bottom, rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0) 5px), radial-gradient( circle at bottom right, #a1001e, #a1001e 60% );
 }
 .pulsingbar {
   box-shadow: 0 0 0 0 rgba(0, 0, 0, 1);
@@ -370,20 +370,20 @@ ul.actions li {
 }
 
 @keyframes pulse {
-	0% {
-		transform: scale(1.05);
-		box-shadow: 0 0 0 0 rgba(0, 0, 0, 0.7);
-	}
+    0% {
+        transform: scale(1.05);
+        box-shadow: 0 0 0 0 rgba(0, 0, 0, 0.7);
+    }
 
-	70% {
-		transform: scale(1);
-		box-shadow: 0 0 0 10px rgba(0, 0, 0, 0);
-	}
+    70% {
+        transform: scale(1);
+        box-shadow: 0 0 0 10px rgba(0, 0, 0, 0);
+    }
 
-	100% {
-		transform: scale(1.05);
-		box-shadow: 0 0 0 0 rgba(0, 0, 0, 0);
-	}
+    100% {
+        transform: scale(1.05);
+        box-shadow: 0 0 0 0 rgba(0, 0, 0, 0);
+    }
 }
 /* Horizontal Health Bar - End */
 
@@ -449,41 +449,41 @@ $(document.head).append("<link rel='icon' href='images/mt_icon_tr.png'>");
 predisplay["Menu Return"] = function (taskName) {
 	if (! tags().contains("noreturn")) {
 		State.variables.return = passage();
-	}
+    }
 };
 
 /* Health Bar code - Start */
 window.Health = function (CurHP, MaxHP, BarID, Horizontal, Container) {
-	if (Container == undefined) {
-		console.log("Container undefined!!");
-		Container = document;
-	}
-	var HP = parseInt((CurHP / MaxHP) * 100).clamp(0, 100);
-	var BarElement = $(Container).find("#" + BarID);
-	if (Horizontal) {
-		BarElement.css({ width: HP + "%" });
-	} else {
-		BarElement.css({ height: HP + "%" });
-	}
-	//BarElement.attr("title", CurHP + "/" + MaxHP);
-	//$(Container).find("#" + BarID + "bkg").attr("title", CurHP + "/" + MaxHP + " HP");
+    if (Container == undefined) {
+        console.log("Container undefined!!");
+        Container = document;
+    }
+    var HP = parseInt((CurHP / MaxHP) * 100).clamp(0, 100);
+    var BarElement = $(Container).find("#" + BarID);
+    if (Horizontal) {
+        BarElement.css({ width: HP + "%" });
+    } else {
+        BarElement.css({ height: HP + "%" });
+    }
+    //BarElement.attr("title", CurHP + "/" + MaxHP);
+    //$(Container).find("#" + BarID + "bkg").attr("title", CurHP + "/" + MaxHP + " HP");
 };
 /* Health Bar code - End */
 
 /* Arousal Bar Macro - Start */
 macros.arousalbar = {
-	handler: function(place, macroName, params, parser) {
-		var CurArousal = params[0];
-		var MaxArousal = params[1];
-		
-		$(document).one(':passagerender', function (ev) {
-			Health(CurArousal, MaxArousal, "horizontalhealthbar", true, ev.content);
-		});
-		
-		new Wikifier(place, "<div id=\"horizontalhealthbarbkg\" class=\"hzbarbkg\"><div id=\"horizontalhealthbar\" class=\"hzbar\"></div></div>");
-	}
+    handler: function(place, macroName, params, parser) {
+        var CurArousal = params[0];
+        var MaxArousal = params[1];
+        
+        $(document).one(':passagerender', function (ev) {
+            Health(CurArousal, MaxArousal, "horizontalhealthbar", true, ev.content);
+        });
+        
+        new Wikifier(place, "<div id=\"horizontalhealthbarbkg\" class=\"hzbarbkg\"><div id=\"horizontalhealthbar\" class=\"hzbar\"></div></div>");
+    }
 }
-/* Arousal Bar Macro - End */</script><tw-tag name="hub" color="purple"></tw-tag><tw-tag name="incomplete" color="red"></tw-tag><tw-tag name="key" color="red"></tw-tag><tw-tag name="noreturn" color="red"></tw-tag><tw-tag name="start" color="green"></tw-tag><tw-tag name="text" color="blue"></tw-tag><tw-passagedata pid="1" name="Bound" tags="start" position="24,188" size="100,100">The sound of snapping fingers feels distant at first. As consciousness returns, it grows closer and closer until it starts becoming loud.
+/* Arousal Bar Macro - End */</script><tw-tag name="incomplete" color="red"></tw-tag><tw-tag name="key" color="red"></tw-tag><tw-tag name="noreturn" color="red"></tw-tag><tw-tag name="start" color="green"></tw-tag><tw-tag name="text" color="blue"></tw-tag><tw-tag name="hub" color="purple"></tw-tag><tw-passagedata pid="1" name="Bound" tags="" position="2500,175" size="100,100">The sound of snapping fingers feels distant at first. As consciousness returns, it grows closer and closer until it starts becoming loud.
 
 The snapping comes from right beside his ear. The adventurer frowns, but consciousness has not returned in its entirety just yet. He feels as if... as if he had fallen down a well. At least that&#39;s all he can remember, sort of. It was bright, it was sudden, and now...
 
@@ -491,9 +491,9 @@ The snapping comes from right beside his ear. The adventurer frowns, but conscio
 
 The bound wolf only lets out a pained groan at first. Everything hurts. Slowly but surely, memories start to return. Memories of who he is...
 
-[[Continue|Wolf Warrior Chosen]]</tw-passagedata><tw-passagedata pid="2" name="StoryAuthor" tags="" position="24,8" size="100,100">by &lt;a href=&quot;http://www.slethstories.com/&quot; target=&quot;_blank&quot;&gt;Sleth&lt;/a&gt;</tw-passagedata><tw-passagedata pid="3" name="StoryBanner" tags="" position="248,8" size="100,100">&lt;img src=&quot;images/logo_tr.png&quot; width=&quot;220&quot;&gt;\
-&lt;div class=&quot;divider div-transparent div-arrow-down&quot;&gt;&lt;/div&gt;</tw-passagedata><tw-passagedata pid="4" name="StoryDisplayTitle" tags="" position="137,8" size="100,100">The Mage&#39;s Tower</tw-passagedata><tw-passagedata pid="5" name="StoryMenu" tags="" position="103,2545" size="100,100">[[Archives]]
-[[Credits]]</tw-passagedata><tw-passagedata pid="6" name="Soft Awakening" tags="" position="543,221" size="100,100">&lt;&lt;set $warrior = true&gt;&gt;\
+[[Continue|Wolf Warrior Chosen]]</tw-passagedata><tw-passagedata pid="2" name="StoryAuthor" tags="" position="1825,150" size="100,100">by &lt;a href=&quot;http://www.slethstories.com/&quot; target=&quot;_blank&quot;&gt;Sleth&lt;/a&gt;</tw-passagedata><tw-passagedata pid="3" name="StoryBanner" tags="" position="2075,150" size="100,100">&lt;img src=&quot;images/logo_tr.png&quot; width=&quot;220&quot;&gt;\
+&lt;div class=&quot;divider div-transparent div-arrow-down&quot;&gt;&lt;/div&gt;</tw-passagedata><tw-passagedata pid="4" name="StoryDisplayTitle" tags="" position="1950,150" size="100,100">The Mage&#39;s Tower</tw-passagedata><tw-passagedata pid="5" name="StoryMenu" tags="" position="2500,500" size="100,100">[[Archives]]
+[[Credits]]</tw-passagedata><tw-passagedata pid="6" name="Soft Awakening" tags="" position="900,625" size="100,100">&lt;&lt;set $warrior = true&gt;&gt;\
 It takes some effort, but the wolf opens his eyes. It takes a few seconds to regain their focus. At the same time, the stiffness of his body feels worse than ever. This nap was anything but comfortable.
 
 As his vision clears, $name realizes that he&#39;s not quite lying down. In fact, he&#39;s pretty much standing up. The feeling of the leather wrappings around his wrists, ankles, and mid-section becomes obvious upon his first attempts to move with a groan. \
@@ -513,7 +513,7 @@ He&#39;s a panther. And he&#39;s the mage whose face the wolf had seen in the bo
 
 He is also smirking triumphantly.
 
-[[Continue|Awakened]]</tw-passagedata><tw-passagedata pid="7" name="Rough Awakening" tags="" position="543,331" size="100,100">&lt;&lt;set $rough_awakening = true&gt;&gt;\
+[[Continue|Awakened]]</tw-passagedata><tw-passagedata pid="7" name="Rough Awakening" tags="" position="1025,625" size="100,100">&lt;&lt;set $rough_awakening = true&gt;&gt;\
 \
 Sleeping is easier. The wolf groans, but goes limp again. The sweet embrace of darkness feels good. Maybe just for a little while longer...
 
@@ -539,7 +539,7 @@ He&#39;s a panther. And he&#39;s the mage whose face the wolf had seen in the bo
 
 He is also smirking triumphantly.
 
-[[Continue|Awakened]]</tw-passagedata><tw-passagedata pid="8" name="Ivex Description" tags="" position="748,114" size="100,100">As advertised, Ivex is a black panther.
+[[Continue|Awakened]]</tw-passagedata><tw-passagedata pid="8" name="Ivex Description" tags="" position="750,825" size="100,100">As advertised, Ivex is a black panther.
 
 The wolf had never seen the mage outside of the drawings in his wanted poster, but on those he looked to be more on the slim side, as most magic users are. The mage that stands before the bound adventurer, however, is not slim at all. Though not extremely muscular, there are clear outlines of them on the visible parts of his arms and legs. His chest is broad, and the panther is remarkably tall for a feline.
 
@@ -547,7 +547,7 @@ With a sleek, typically feline muzzle that displays the whitest teeth and fangs 
 
 Unlike most mages as well, Ivex doesn&#39;t wear robes, but rather regular clothing that seems to be of very noble quality. A white shirt, complete with a brown vest accompanied by a set of black pants that go well with his dark fur. Just like most, the feline does not wear any footwear, instead letting his feline paws free and bare on the floor. The thing that draws the most attention, however, is the red cape the mage has draped over his shoulders. It is something he clearly wears for show rather than utility, although the clip holding the cloak close to his neck glows with an expensive-looking purple gemstone embedded into it.
 
-[[Return|Awakened]]</tw-passagedata><tw-passagedata pid="9" name="Office Description" tags="" position="626,112" size="100,100">The mage&#39;s office does not look special in itself, but it is rather curious.
+[[Return|Awakened]]</tw-passagedata><tw-passagedata pid="9" name="Office Description" tags="" position="750,700" size="100,100">The mage&#39;s office does not look special in itself, but it is rather curious.
 
 The office is sleek and fancy with luxurious furniture. Strange objects adorn the cabinets here or there, but most of all the wolf can see bookcases filled with books about magic. At its center and off to the wolf&#39;s side, a large desk with the basics can be seen: parchment, ink, quill and stacks of papers and letters spread over the table.
 
@@ -555,7 +555,7 @@ The place looks like a very regular office, so perhaps what stands out the most 
 
 Another curious aspect to the wolf is that, off to the side, he can see a window if he cranes his neck just enough. Outside, however, there is nothing but a blue sky, hinting that the office might be up high. Where did the mage bring him?
 
-[[Return|Awakened]]</tw-passagedata><tw-passagedata pid="10" name="Awakened" tags="" position="677,247" size="100,100">&quot;Finally awake,&quot; the panther continues, &quot;most people put up more of a fight when they are foolish enough to hunt me.&quot;
+[[Return|Awakened]]</tw-passagedata><tw-passagedata pid="10" name="Awakened" tags="" position="950,750" size="100,100">&quot;Finally awake,&quot; the panther continues, &quot;most people put up more of a fight when they are foolish enough to hunt me.&quot;
 
 The wolf&#39;s eyes follow the panther, still having trouble focusing properly, but slowly the $class regains his proper sight. For the first time, the wolf is able to see that the cross he&#39;s bound to looks out of place in some kind of [[office|Office Description]].
 
@@ -584,21 +584,10 @@ The panther stares at the wolf expecting an answer.
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-	&lt;li&gt;[[&#39;&quot;You won\&#39;t get anything out of me!&quot;&#39;|Refusal]]&lt;/li&gt;
-	&lt;li&gt;[[&#39;&quot;...If I tell you what you want to know, then what?&quot;&#39;|Consideration]]	  &lt;/li&gt;
+    &lt;li&gt;[[&#39;&quot;You won\&#39;t get anything out of me!&quot;&#39;|Refusal]]&lt;/li&gt;
+    &lt;li&gt;[[&#39;&quot;...If I tell you what you want to know, then what?&quot;&#39;|Consideration]]	  &lt;/li&gt;
   &lt;/ul&gt;\
-&lt;/div&gt;</tw-passagedata><tw-passagedata pid="11" name="Choose your character" tags="" position="110,351" size="100,100">CHARACTER SELECTION
-
-[[Wolf Warrior|Wolf Warrior Character Sheet]]
-[[Wolf Mage|Wolf Mage Character Sheet]]</tw-passagedata><tw-passagedata pid="12" name="Wolf Warrior Character Sheet" tags="incomplete" position="249,276" size="100,100">(wolf warrior character sheet display)
-
-
-[[Return to character selection|Choose your character]]
-[[Continue as Drekkar|Wolf Warrior Chosen]]</tw-passagedata><tw-passagedata pid="13" name="Wolf Mage Character Sheet" tags="incomplete" position="247,396" size="100,100">(wolf mage character sheet display)
-
-
-[[Return to character selection|Choose your character]]
-[[Continue as Nero|Wolf Mage Chosen]]</tw-passagedata><tw-passagedata pid="14" name="Wolf Warrior Chosen" tags="" position="398,178" size="100,100">&lt;&lt;set $name = &quot;Drekkar&quot;&gt;&gt;\
+&lt;/div&gt;</tw-passagedata><tw-passagedata pid="11" name="Wolf Warrior Chosen" tags="" position="950,500" size="100,100">&lt;&lt;set $name = &quot;Drekkar&quot;&gt;&gt;\
 &lt;&lt;set $class = &quot;warrior&quot;&gt;&gt;\
 &lt;&lt;set $warrior = true&gt;&gt;\
 &lt;&lt;set $mage = false&gt;&gt;\
@@ -611,31 +600,18 @@ Drekkar&#39;s muscles, usually his most powerful weapon, ache. They feel stiff. 
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-	&lt;li&gt;[[Make an effort to wake up.|Soft Awakening]]&lt;/li&gt;
-	&lt;li&gt;[[...Cling to the comfort of sleep.|Rough Awakening]]&lt;/li&gt;
+    &lt;li&gt;[[Make an effort to wake up.|Soft Awakening]]&lt;/li&gt;
+    &lt;li&gt;[[...Cling to the comfort of sleep.|Rough Awakening]]&lt;/li&gt;
   &lt;/ul&gt;\
-&lt;/div&gt;</tw-passagedata><tw-passagedata pid="15" name="Wolf Mage Chosen" tags="" position="398,300" size="100,100">&lt;&lt;set $name = &quot;Nero&quot;&gt;&gt;\
-&lt;&lt;set $class = &quot;mage&quot;&gt;&gt;\
-&lt;&lt;set $warrior = false&gt;&gt;\
-&lt;&lt;set $mage = true&gt;&gt;\
-&lt;&lt;set $rough_awakening = false&gt;&gt;\
-
-Nero&#39;s mind, usually his most powerful weapon, feels muddled. Thinking straight is a struggle, but little by little the wolf&#39;s thoughts start to reorganize themselves. Whatever he was under must have been either a very powerful anethesiac or a deep sleep spell of some kind. Although the symptoms of light vertigo also suggest some sort of teleportation...
-
-Thinking hurts. This is too much to try to reason in this state. Nero lets out another small groan...
-
-&quot;Last chance, buddy. Wake up, or else...&quot; the voice says again. The wolf can hear a mix of amusement and impatience in it...
-
-[[Make an effort to wake up|Soft Awakening]]
-[[Cling to the comfort of sleep|Rough Awakening]]</tw-passagedata><tw-passagedata pid="16" name="Refusal" tags="" position="816,223" size="100,100">Much to &lt;&lt;print $name&gt;&gt;&#39;s delight, the reaction at least seems to wipe that smirk out of the panther&#39;s face for a second. Only for a second, though, as a different kind of smile opens up. A smile that makes the wolf&#39;s ears lower themselves even if just a little.
+&lt;/div&gt;</tw-passagedata><tw-passagedata pid="12" name="Refusal" tags="" position="900,875" size="100,100">Much to &lt;&lt;print $name&gt;&gt;&#39;s delight, the reaction at least seems to wipe that smirk out of the panther&#39;s face for a second. Only for a second, though, as a different kind of smile opens up. A smile that makes the wolf&#39;s ears lower themselves even if just a little.
 
 &quot;I was kind of hoping you would say that. I enjoy the brave types very much.&quot; The panther approaches, closing in the last distance between him and the wolf.
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-	&lt;li&gt;[[Growl at Ivex.|Molesting]]&lt;/li&gt;
+    &lt;li&gt;[[Growl at Ivex.|Molesting]]&lt;/li&gt;
   &lt;/ul&gt;\
-&lt;/div&gt;</tw-passagedata><tw-passagedata pid="17" name="Consideration" tags="" position="816,327" size="100,100">&quot;Aahh... the good boy type,&quot; the panther muses. &quot;I am ever so glad. Or am I? Perhaps we won&#39;t have too much trouble here after all.&quot;
+&lt;/div&gt;</tw-passagedata><tw-passagedata pid="13" name="Consideration" tags="" position="1025,875" size="100,100">&quot;Aahh... the good boy type,&quot; the panther muses. &quot;I am ever so glad. Or am I? Perhaps we won&#39;t have too much trouble here after all.&quot;
 
 The panther took a step forward and opened a sinister smile. &quot;Unfortunately, I regret to say that regardless of your collaboration, you won&#39;t be getting out of here. I have plans for you.&quot;
 
@@ -647,9 +623,9 @@ With a spring to his step, the panther approaches, closing in the last distance 
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-	&lt;li&gt;[[Growl at Ivex.|Molesting]]&lt;/li&gt;
+    &lt;li&gt;[[Growl at Ivex.|Molesting]]&lt;/li&gt;
   &lt;/ul&gt;\
-&lt;/div&gt;</tw-passagedata><tw-passagedata pid="18" name="StoryInit" tags="" position="363,9" size="100,100">&lt;&lt;set $name = &quot;Drekkar&quot;&gt;&gt;\
+&lt;/div&gt;</tw-passagedata><tw-passagedata pid="14" name="StoryInit" tags="" position="2200,150" size="100,100">&lt;&lt;set $name = &quot;Drekkar&quot;&gt;&gt;\
 &lt;&lt;set $class = &quot;warrior&quot;&gt;&gt;\
 &lt;&lt;set $warrior = true&gt;&gt;\
 &lt;&lt;set $mage = false&gt;&gt;\
@@ -708,17 +684,17 @@ With a spring to his step, the panther approaches, closing in the last distance 
 &lt;&lt;append &quot;#ui-bar-body&quot;&gt;&gt;
   &lt;div id=&quot;ui-bar-footer&quot;&gt;
     &lt;span&gt;
-	  &lt;a class=&quot;footer-element&quot; target=&quot;_blank&quot; href=&quot;https://www.patreon.com/sleth&quot;&gt;&lt;img alt=&quot;Patreon&quot; src=&quot;images/pa_logo.png&quot; height=&quot;30&quot;&gt;&lt;/a&gt;
+      &lt;a class=&quot;footer-element&quot; target=&quot;_blank&quot; href=&quot;https://www.patreon.com/sleth&quot;&gt;&lt;img alt=&quot;Patreon&quot; src=&quot;images/pa_logo.png&quot; height=&quot;30&quot;&gt;&lt;/a&gt;
 
-	  &lt;a class=&quot;footer-element&quot; target=&quot;_blank&quot; href=&quot;https://twitter.com/slethwulf&quot;&gt;&lt;img alt=&quot;Twitter&quot; src=&quot;images/tw_logo.png&quot; height=&quot;30&quot;&gt;&lt;/a&gt;
+      &lt;a class=&quot;footer-element&quot; target=&quot;_blank&quot; href=&quot;https://twitter.com/slethwulf&quot;&gt;&lt;img alt=&quot;Twitter&quot; src=&quot;images/tw_logo.png&quot; height=&quot;30&quot;&gt;&lt;/a&gt;
 
-	  &lt;a class=&quot;footer-element&quot; target=&quot;_blank&quot; href=&quot;https://www.furaffinity.net/user/sleth/&quot;&gt;&lt;img alt=&quot;FurAffinity&quot; src=&quot;images/fa_logo.png&quot; height=&quot;30&quot;&gt;&lt;/a&gt;
+      &lt;a class=&quot;footer-element&quot; target=&quot;_blank&quot; href=&quot;https://www.furaffinity.net/user/sleth/&quot;&gt;&lt;img alt=&quot;FurAffinity&quot; src=&quot;images/fa_logo.png&quot; height=&quot;30&quot;&gt;&lt;/a&gt;
 
-	  &lt;a class=&quot;footer-element&quot; target=&quot;_blank&quot; href=&quot;https://sleth.sofurry.com/&quot;&gt;&lt;img alt=&quot;SoFurry&quot; src=&quot;images/sf_logo.png&quot; height=&quot;30&quot;&gt;&lt;/a&gt;
-	&lt;/span&gt;
+      &lt;a class=&quot;footer-element&quot; target=&quot;_blank&quot; href=&quot;https://sleth.sofurry.com/&quot;&gt;&lt;img alt=&quot;SoFurry&quot; src=&quot;images/sf_logo.png&quot; height=&quot;30&quot;&gt;&lt;/a&gt;
+    &lt;/span&gt;
   &lt;/div&gt;
 &lt;&lt;/append&gt;&gt;
-&lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="19" name="Molesting" tags="" position="960,271" size="100,100">&lt;&lt;print $name&gt;&gt; opens a warning growl, but even though the wolf tugs against the restraints of the cross he&#39;s bound to, there is nothing that can be done against the feeling of extreme vulnerability. The panther, the enemy, stands right there, well within the range of touch, and all the wolf can do is remain there with his limbs spread wide.
+&lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="15" name="Molesting" tags="" position="950,1000" size="100,100">&lt;&lt;print $name&gt;&gt; opens a warning growl, but even though the wolf tugs against the restraints of the cross he&#39;s bound to, there is nothing that can be done against the feeling of extreme vulnerability. The panther, the enemy, stands right there, well within the range of touch, and all the wolf can do is remain there with his limbs spread wide.
 
 &quot;Look at you, wolf. Such a powerful &lt;&lt;print $class&gt;&gt;...&quot; The panther licks his lips. His hand comes to the wolf&#39;s chest. His touch feels invasive as he places his hand upon &lt;&lt;print $name&gt;&gt;&#39;s broad pectorals and feels it up. All $name can do is snarl once more, but the wolf knows that his growling is nothing but a fake threat at that moment. There has to be a way to turn the tables on that damned mage, but how...?
 
@@ -748,7 +724,7 @@ Sounding arrogant and cocky as always, the mage takes a step back. $name feels s
 
 And simply snaps his fingers.
 
-[[Continue|Naked]]</tw-passagedata><tw-passagedata pid="20" name="Naked" tags="" position="1092,274" size="100,100">In an instant, all the wolf feels is... bare.
+[[Continue|Naked]]</tw-passagedata><tw-passagedata pid="16" name="Naked" tags="" position="1075,1000" size="100,100">In an instant, all the wolf feels is... bare.
 
 With an urgent look, $name looks down and realizes that, just like that, without moving an inch from his bound state, he now stands there not only bound, but also completely and entirely &lt;b&gt;naked&lt;/b&gt;.
 
@@ -770,7 +746,7 @@ Is he really that powerful of a mage?\
 
 The panther then turns away, thankfully, but to reach into one of the cabinets surrounding them to pull out...
 
-[[Continue|Candle]]</tw-passagedata><tw-passagedata pid="21" name="Candle" tags="" position="1074,421" size="100,100">&lt;&lt;set $FurtherDefiance = false&gt;&gt;\
+[[Continue|Candle]]</tw-passagedata><tw-passagedata pid="17" name="Candle" tags="" position="1200,1000" size="100,100">&lt;&lt;set $FurtherDefiance = false&gt;&gt;\
 ...a candle.
 
 It doesn&#39;t look like an ordinary candle, though. Instead of white, it is of a bright red color, and its high craftsmanship shows. The candle is adorned with ridges and ledges across its length. It also glistens, as if it was covered in a thin layer of something shiny all the way to its wick.
@@ -796,9 +772,9 @@ The panther approaches again.
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
 	&lt;li&gt;[[&quot;Whatever you&#39;re trying to do, it won&#39;t work!&quot; Keep holding your breath in defiance.|Hold Breath Defiantly]]&lt;/li&gt;
-	&lt;li&gt;[[He has a point. Breathe out and at least give him a warning growl.|Growl Defiantly]]&lt;/li&gt;
+    &lt;li&gt;[[He has a point. Breathe out and at least give him a warning growl.|Growl Defiantly]]&lt;/li&gt;
   &lt;/ul&gt;\
-&lt;/div&gt;</tw-passagedata><tw-passagedata pid="22" name="Hold Breath Defiantly" tags="" position="1067,555" size="100,100">$name keeps holding his breath, but it becomes harder to do so as Ivex steps towards him again. The feeling of vulnerability towards the panther grows tenfold when he is within the range of touch. Bound to the cross in a spread position, holding his breath and now completely naked, it feels even worse than before.
+&lt;/div&gt;</tw-passagedata><tw-passagedata pid="18" name="Hold Breath Defiantly" tags="" position="1325,1000" size="100,100">$name keeps holding his breath, but it becomes harder to do so as Ivex steps towards him again. The feeling of vulnerability towards the panther grows tenfold when he is within the range of touch. Bound to the cross in a spread position, holding his breath and now completely naked, it feels even worse than before.
 
 &quot;You really are something else,&quot; the panther chuckles, &quot;thinking you can defy me. Most of them are regretting their actions and begging me to let them go at this point...&quot;
 
@@ -828,12 +804,12 @@ Drekkar has years of training enduring pain, though. The thought of having his p
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-  	&lt;&lt;if $rough_awakening == false || ($rough_awakening == true &amp;&amp; $warrior == true)&gt;&gt;\
-	&lt;li&gt;[[Defy Ivex and keep holding his breath.|Further Defiance]]&lt;/li&gt;
+      &lt;&lt;if $rough_awakening == false || ($rough_awakening == true &amp;&amp; $warrior == true)&gt;&gt;\
+    &lt;li&gt;[[Defy Ivex and keep holding his breath.|Further Defiance]]&lt;/li&gt;
 &lt;&lt;/if&gt;&gt;\
-	&lt;li&gt;[[There is no choice. Breathe out and at least give him a warning growl.|Growl Defiantly]]&lt;/li&gt;
+    &lt;li&gt;[[There is no choice. Breathe out and at least give him a warning growl.|Growl Defiantly]]&lt;/li&gt;
   &lt;/ul&gt;\
-&lt;/div&gt;</tw-passagedata><tw-passagedata pid="23" name="Growl Defiantly" tags="" position="927,480" size="100,100">&quot;You look cute when you growl. The last defiant adventurer I had was a lion. He couldn&#39;t growl like you, but he sure as hell could roar. Oh, how he roared when he was in your place breathing in what you&#39;re breathing...&quot;
+&lt;/div&gt;</tw-passagedata><tw-passagedata pid="19" name="Growl Defiantly" tags="" position="1325,1125" size="100,100">&quot;You look cute when you growl. The last defiant adventurer I had was a lion. He couldn&#39;t growl like you, but he sure as hell could roar. Oh, how he roared when he was in your place breathing in what you&#39;re breathing...&quot;
 
 Ivex lets out a small laugh. The candle continues to burn off to the side and the spicy smell seems stronger than before. &lt;&lt;print $name&gt;&gt;&#39;s canine nose can detect even the subtleties of the smell and, indeed, it smells like nothing he has ever felt before.
 
@@ -855,7 +831,7 @@ The heat seems to grow worse by the second. As much as he tries to deny it, &lt;
 
 The panther&#39;s words cease suddenly when Ivex turns his head back in a sudden movement. He stares towards the office&#39;s door for a moment as if seeing something unexpected, but upon following his gaze, $name sees nothing.
 
-[[Continue|Alarm]]</tw-passagedata><tw-passagedata pid="24" name="Further Defiance" tags="" position="997,678" size="100,100">The seconds go by and $name makes every effort to keep holding his breath. Eyes locked, the panther seems to take notice of the active defiance. It is with much satisfaction that the wolf can see his smile fading, even if just a little, in annoyance. The thought of irritating the cocky mage is enough to bring the bound wolf some pleasure in this terrible situation.
+[[Continue|Alarm]]</tw-passagedata><tw-passagedata pid="20" name="Further Defiance" tags="" position="1450,1000" size="100,100">The seconds go by and $name makes every effort to keep holding his breath. Eyes locked, the panther seems to take notice of the active defiance. It is with much satisfaction that the wolf can see his smile fading, even if just a little, in annoyance. The thought of irritating the cocky mage is enough to bring the bound wolf some pleasure in this terrible situation.
 
 Unfortunately, that pleasure soon becomes radiating, blinding pain. In a swift move, the panther&#39;s hand holding the wolf&#39;s balls closes in a tight grip. The wolf&#39;s sensitive nuts get squeezed inside the panther&#39;s relentless paw.
 
@@ -875,9 +851,9 @@ Ivex&#39;s hand returns to the wolf&#39;s thigh. The invasive touch makes the wo
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-	&lt;li&gt;[[Give him a weak warning growl...|Growl Defiantly]]&lt;/li&gt;
+    &lt;li&gt;[[Give him a weak warning growl...|Growl Defiantly]]&lt;/li&gt;
   &lt;/ul&gt;\
-&lt;/div&gt;</tw-passagedata><tw-passagedata pid="25" name="Alarm" tags="" position="795,503" size="100,100">Thankfully, the panther then lets go of the wolf entirely. Before turning towards the door, $name can see that Ivex is frowning.
+&lt;/div&gt;</tw-passagedata><tw-passagedata pid="21" name="Alarm" tags="" position="1325,1250" size="100,100">Thankfully, the panther then lets go of the wolf entirely. Before turning towards the door, $name can see that Ivex is frowning.
 
 &quot;How unfortunate,&quot; the mage finally says. &quot;An interruption. Right when things were about to get interesting! What a busy day...&quot;
 
@@ -893,7 +869,7 @@ Ivex then raises it up in the air and whispers a word the wolf can&#39;t quite m
 
 Then, poof. In the blink of an eye, the mage disappears, leaving $name alone. Bound, naked, erect and alone.
 
-[[Continue|Alone]]</tw-passagedata><tw-passagedata pid="26" name="Alone" tags="" position="672,500" size="100,100">With the panther mage gone, all that remains is silence. The wolf finds himself alone in the office and bound at its center like some sort of depraved display. Looking down at himself, &lt;&lt;print $name&gt;&gt;&#39;s ears fold back a little.
+[[Continue|Alone]]</tw-passagedata><tw-passagedata pid="22" name="Alone" tags="" position="1200,1250" size="100,100">With the panther mage gone, all that remains is silence. The wolf finds himself alone in the office and bound at its center like some sort of depraved display. Looking down at himself, &lt;&lt;print $name&gt;&gt;&#39;s ears fold back a little.
 
 Jutting from his sheath, his erection stands at full mast now. It even throbs in the air every now and then. The canine-shaped, tapered member practically glows in its bright red, veiny shape. Even the wolf&#39;s sheath starts to bulge a little as his knot threatens to start growing as well.
 
@@ -909,7 +885,7 @@ The bound wolf realizes that he&#39;s able to suppress this for now, but if he s
 
 He had to find a way to escape. Ivex being gone gives him his best chance! But... how? And can it even be done before the candle&#39;s influence becomes too much?
 
-[[Continue|The Candle]]</tw-passagedata><tw-passagedata pid="27" name="The Candle" tags="" position="549,466" size="100,100">Bound and alone in the room without Ivex&#39;s cocky blabbering as a distraction, $name can feel the effects of the candle more sharply.
+[[Continue|The Candle]]</tw-passagedata><tw-passagedata pid="23" name="The Candle" tags="" position="1075,1250" size="100,100">Bound and alone in the room without Ivex&#39;s cocky blabbering as a distraction, $name can feel the effects of the candle more sharply.
 
 It burns there on the corner, innocently, yet the magically-enhanced scent that the candle produces, fills the air with, grows stronger by the minute. Every breath the wolf takes is filled with that strong scent. It heats up the canine&#39;s sensitive nose and, more than that, it heats up his very core.
 
@@ -927,7 +903,7 @@ The wolf turns his eyes towards the burning candle. So close yet so far.
 
 He needs to escape... before the crazed mage returns and before that thing&#39;s magic overcomes him.
 
-[[Continue|Escape Options]]</tw-passagedata><tw-passagedata pid="28" name="Escape Options" tags="" position="399,454" size="100,100">&lt;&lt;silently&gt;&gt;
+[[Continue|Escape Options]]</tw-passagedata><tw-passagedata pid="24" name="Escape Options" tags="restart" position="525,1625" size="100,100">&lt;&lt;silently&gt;&gt;
 &lt;&lt;set $CurArousal = 10&gt;&gt;
 &lt;&lt;set $observation1 = false&gt;&gt;
 &lt;&lt;set $struggle1 = false&gt;&gt;
@@ -969,11 +945,11 @@ A way out. There must be a way out! There isn&#39;t much choice left, but to...
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-	&lt;li&gt;[[Keep looking around the room for a solution.|Observation 1]]&lt;/li&gt;
-	&lt;li&gt;[[Try and pull at the leather bindings with vigor!|Struggle 1]]&lt;/li&gt;
+    &lt;li&gt;[[Keep looking around the room for a solution.|Observation 1]]&lt;/li&gt;
+    &lt;li&gt;[[Try and pull at the leather bindings with vigor!|Struggle 1]]&lt;/li&gt;
   &lt;/ul&gt;\
 &lt;/div&gt;
-&lt;&lt;/timed&gt;&gt;\</tw-passagedata><tw-passagedata pid="29" name="Observation 1" tags="" position="237,582" size="100,100">As his eyes scan the room for the tenth time, the wolf&#39;s ears drop low. His hope starts to wane, but as his vision sweeps over the left side with care, something catches his eye.
+&lt;&lt;/timed&gt;&gt;\</tw-passagedata><tw-passagedata pid="25" name="Observation 1" tags="" position="450,1775" size="100,100">As his eyes scan the room for the tenth time, the wolf&#39;s ears drop low. His hope starts to wane, but as his vision sweeps over the left side with care, something catches his eye.
 
 It&#39;s a mirror. A small, handheld mirror resting on its side casually against \
 &lt;&lt;if $mage&gt;&gt;\
@@ -993,12 +969,12 @@ The crystals are, of course, completely unreachable to the naked wolf bound to t
 &lt;&lt;if $escapeActions&gt;&gt;\
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-	&lt;li&gt;[[Reevaluate his options.|Escape Actions]]&lt;/li&gt;
+    &lt;li&gt;[[Reevaluate his options.|Escape Actions]]&lt;/li&gt;
   &lt;/ul&gt;\
 &lt;/div&gt;
 &lt;&lt;else&gt;&gt;\
 [[Continue|Escape Actions]]
-&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="30" name="Struggle 1" tags="" position="456,583" size="100,100">$name growls in frustration and tries, with more vehemence, to pull against the bindings with brute strength.
+&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="26" name="Struggle 1" tags="" position="600,1775" size="100,100">$name growls in frustration and tries, with more vehemence, to pull against the bindings with brute strength.
 
 Grunting with effort, the wolf puts all of his physical prowess behind the act. It takes quite a bunch of pulling and tugging, but while the leather bands wrapped around his wrists and ankles are as unyielding as the wood the cross is made of, the wolf does notice something.
 
@@ -1019,12 +995,12 @@ Unfortunately, all the physical effort also served to quicken the wolf&#39;s bre
 &lt;&lt;if $escapeActions&gt;&gt;\
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-	&lt;li&gt;[[Reevaluate his options.|Escape Actions]]&lt;/li&gt;
+    &lt;li&gt;[[Reevaluate his options.|Escape Actions]]&lt;/li&gt;
   &lt;/ul&gt;\
 &lt;/div&gt;
 &lt;&lt;else&gt;&gt;\
 [[Continue|Escape Actions]]
-&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="31" name="Escape Actions" tags="hub" position="250,716" size="200,200">&lt;&lt;nobr&gt;&gt;
+&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="27" name="Escape Actions" tags="" position="475,1925" size="200,200">&lt;&lt;nobr&gt;&gt;
   &lt;&lt;set $escapeActions = true&gt;&gt;
   &lt;&lt;if $CurArousal &gt; 90 &amp;&amp; $CurArousal &lt; 100&gt;&gt;
     &lt;&lt;set $CurArousal += 4&gt;&gt;
@@ -1032,7 +1008,7 @@ Unfortunately, all the physical effort also served to quicken the wolf&#39;s bre
     &lt;&lt;set $CurArousal += 9&gt;&gt;
   &lt;&lt;/if&gt;&gt;
   &lt;&lt;if $CurArousal &gt;= 100&gt;&gt;
-	&lt;&lt;goto &quot;Arousal Overwhelmed&quot;&gt;&gt;
+    &lt;&lt;goto &quot;Arousal Overwhelmed&quot;&gt;&gt;
   &lt;&lt;/if&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;
 Candle&#39;s Influence: &lt;&lt;arousalbar $CurArousal $MaxArousal&gt;&gt;
@@ -1047,7 +1023,7 @@ The candle still burns silently at the corner.
 &lt;&lt;if $CurArousal &lt;= 30&gt;&gt;\
 The wolf&#39;s forced arousal feels... &lt;span style=&quot;color:#46bb26&quot;&gt;distracting&lt;/span&gt;.
 &lt;br&gt;&lt;br&gt;
-&lt;&lt;include &quot;Arousal Level 1&quot;&gt;&gt;
+&lt;&lt;include &quot;Arousal Level 1&quot;&gt;&gt; &lt;!-- [[Arousal Level 1]] --&gt;
 
 &lt;&lt;elseif $CurArousal &gt; 30 &amp;&amp; $CurArousal &lt;= 50&gt;&gt;
 The wolf&#39;s forced arousal feels... &lt;span style=&quot;color:#e7d778&quot;&gt;gripping&lt;/span&gt;.
@@ -1081,36 +1057,36 @@ There must be a way to get out of his bonds, but how?
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
     &lt;&lt;if $observation1&gt;&gt;\
-	  &lt;li&gt;[[Look around the room for a solution once more...|Observation 2]]&lt;/li&gt;
-	&lt;&lt;else&gt;&gt;\
-	  &lt;li&gt;[[Look around the room for a solution.|Observation 1]]&lt;/li&gt;
-	&lt;&lt;/if&gt;&gt;\
-	&lt;&lt;if $struggle1&gt;&gt;\
-	  &lt;li&gt;[[Try harder to wear down the bindings with strength and effort!|Struggle 2]]&lt;/li&gt;
-	&lt;&lt;else&gt;&gt;\
-	  &lt;li&gt;[[Try and pull at the leather bindings with vigor!|Struggle 1]]&lt;/li&gt;
-	&lt;&lt;/if&gt;&gt;\
-	or...
-	&lt;li&gt;[[Take a moment to gather his thoughts about everything learned so far...|Gather Thoughts]]&lt;/li&gt;
+      &lt;li&gt;[[Look around the room for a solution once more...|Observation 2]]&lt;/li&gt;
+    &lt;&lt;else&gt;&gt;\
+      &lt;li&gt;[[Look around the room for a solution.|Observation 1]]&lt;/li&gt;
+    &lt;&lt;/if&gt;&gt;\
+    &lt;&lt;if $struggle1&gt;&gt;\
+      &lt;li&gt;[[Try harder to wear down the bindings with strength and effort!|Struggle 2]]&lt;/li&gt;
+    &lt;&lt;else&gt;&gt;\
+      &lt;li&gt;[[Try and pull at the leather bindings with vigor!|Struggle 1]]&lt;/li&gt;
+    &lt;&lt;/if&gt;&gt;\
+    or...
+    &lt;li&gt;[[Take a moment to gather his thoughts about everything learned so far...|Gather Thoughts]]&lt;/li&gt;
   &lt;/ul&gt;\
 &lt;/div&gt;
-&lt;&lt;/timed&gt;&gt;</tw-passagedata><tw-passagedata pid="32" name="Arousal Level 1" tags="" position="36,502" size="100,100">Avoiding taking deep breaths, $name just tries his best not to think about the constant distraction throbbing between his legs. He can seldom help glancing down towards it, though. It&#39;s always within his field of vision and trying to jump to the front of his mind.
+&lt;&lt;/timed&gt;&gt;</tw-passagedata><tw-passagedata pid="28" name="Arousal Level 1" tags="" position="725,1925" size="100,100">Avoiding taking deep breaths, $name just tries his best not to think about the constant distraction throbbing between his legs. He can seldom help glancing down towards it, though. It&#39;s always within his field of vision and trying to jump to the front of his mind.
 
 The wolf&#39;s cock. It stands there, fully aroused. His knot has inflated some, although not completely, and having it still trapped inside his sheath brings the wolf some discomfort, but he tries not to think about that either.
 
 Small jolts of pleasure keep coming from his cock, though. Every time he breathes in, the warmth spreads towards him, and his cock flexes with life by itself. Never before had $name felt so exposed, so at mercy of his own instincts, and yet...
 
-The bead of pre-cum lingering at the very tip of his firm arousal glistens as a constant threat of how those very instincts might betray him.</tw-passagedata><tw-passagedata pid="33" name="Arousal Level 2" tags="" position="35,614" size="100,100">It&#39;s getting harder and harder to resist. After breathing so much of the candle&#39;s foul air, the heat coursing inside the wolf now feels constant. His fur feels too warm and an urge to pant, to let his tongue loll out is always there, but he resists it to avoid breathing even more of the cursed affliction.
+The bead of pre-cum lingering at the very tip of his firm arousal glistens as a constant threat of how those very instincts might betray him.</tw-passagedata><tw-passagedata pid="29" name="Arousal Level 2" tags="" position="825,1925" size="100,100">It&#39;s getting harder and harder to resist. After breathing so much of the candle&#39;s foul air, the heat coursing inside the wolf now feels constant. His fur feels too warm and an urge to pant, to let his tongue loll out is always there, but he resists it to avoid breathing even more of the cursed affliction.
 
 The wolf&#39;s cock reflects his increased state of arousal. It stands rock hard, as erect as the wolf ever remembers feeling it, and the small veins on its bright red surface bulge ever so slightly as well from how incredibly aroused he feels. It throbs more often than before, pulsing alongside the wolf&#39;s quickened heartbeat while, at the same time, serving as a beacon that promises unending pleasure to the wolf&#39;s affected mind. The urge to touch it, to feel his fingers trailing over that sensitive surface, is crushing.
 
-The lupine&#39;s knot bulges his sheath in a very uncomfortable way being pretty much fully grown. From its very tip, a tendril of pre-cum lingers. Another droplet soon comes, then slowly falls down to the floor below his bound self. It&#39;s constant now. Every instinct the wolf has is slowly turning towards one thing and one thing alone: sex.</tw-passagedata><tw-passagedata pid="34" name="Arousal Level 3" tags="" position="35,723" size="100,100">Panting becomes inevitable. Every breath is like a new log thrown into a bonfire of arousal burning within the wolf. It&#39;s getting harder and harder to think, to keep his eyes away from his cock. It stands there, proud, pulsing. Pleasure without end promised, if he could just touch it...!
+The lupine&#39;s knot bulges his sheath in a very uncomfortable way being pretty much fully grown. From its very tip, a tendril of pre-cum lingers. Another droplet soon comes, then slowly falls down to the floor below his bound self. It&#39;s constant now. Every instinct the wolf has is slowly turning towards one thing and one thing alone: sex.</tw-passagedata><tw-passagedata pid="30" name="Arousal Level 3" tags="" position="925,1925" size="100,100">Panting becomes inevitable. Every breath is like a new log thrown into a bonfire of arousal burning within the wolf. It&#39;s getting harder and harder to think, to keep his eyes away from his cock. It stands there, proud, pulsing. Pleasure without end promised, if he could just touch it...!
 
 The wolf&#39;s cock throbs constantly now. Its surface glistens against the candlelight, the wolf&#39;s length covered in his own pre-cum that now keeps oozing from his tip without pause. Some of it runs down his length and brings involuntary groans from the wolf, some of it drips down to the ground below. His knot has grown as big as it can get outside of a tie and, much to both the wolf&#39;s relief and dismay, it has managed to push his sheath back. The bulb of sensitive flesh, thick and large, pulses alongside the whole of the wolf&#39;s length just begging to be touched. To be shoved into something. Something tight, something that would-
 
 With a shake of his head, $name tries his best to keep his focus away from his cock. It&#39;s incredibly hard to do so. Every odd thought in his head goes back to memories of him in his privacy with his paw around his member. Moving it up and down, stroking it, squeezing his knot, reaching the high of-
 
-It takes a growl to break himself off of it. With increased urgency, $name realizes he has to find a way out soon, or else he will for sure be doomed, just as Ivex said.</tw-passagedata><tw-passagedata pid="35" name="Arousal Level 4" tags="" position="33,832" size="100,100">Every breath is fire. $name can feel his eyes tearing up, but is it from the way his whole body burns up, or out of sheer frustration due to being unable to sate his lust?
+It takes a growl to break himself off of it. With increased urgency, $name realizes he has to find a way out soon, or else he will for sure be doomed, just as Ivex said.</tw-passagedata><tw-passagedata pid="31" name="Arousal Level 4" tags="" position="725,2025" size="100,100">Every breath is fire. $name can feel his eyes tearing up, but is it from the way his whole body burns up, or out of sheer frustration due to being unable to sate his lust?
 
 This is the cruelest of tortures. The wolf&#39;s breathing is quick and short and, even as he actively tries to slow it down, it&#39;s impossible now. His blood feels hot, his heart races and, most of all... his cock.
 
@@ -1118,7 +1094,7 @@ It radiates pleasure without ceasing. Looking at it brings small tears to the wo
 
 It feels impossible, but for the wolf, he swears he can feel it. It&#39;s not quite the feeling of touch, no, that still remains his sole need in life at the moment, but as his cock pulses there in the air, harder than it has ever been in his life, the wolf can swear he can feel &lt;i&gt;something&lt;/i&gt; brushing against it. It&#39;s soft, almost non-existent, but each time his cock flexes in sheer arousal, it&#39;s as if a feather-like brush passes through his length. Down to the very tip to the knot. It teases him, furthering his impossible arousal even further.
 
-It&#39;s maddening! With bated breath, $name shakes his head and grits his teeth together trying his hardest to keep his focus away from his cock.</tw-passagedata><tw-passagedata pid="36" name="Arousal Overwhelmed" tags="" position="147,1057" size="100,100">&lt;&lt;set $CurArousal = 110&gt;&gt;\
+It&#39;s maddening! With bated breath, $name shakes his head and grits his teeth together trying his hardest to keep his focus away from his cock.</tw-passagedata><tw-passagedata pid="32" name="Arousal Overwhelmed" tags="end" position="925,2025" size="100,100">&lt;&lt;set $CurArousal = 110&gt;&gt;\
 Candle&#39;s Influence: &lt;&lt;arousalbar $CurArousal $MaxArousal&gt;&gt;
 &lt;&lt;done&gt;&gt;
   &lt;&lt;addclass &quot;#horizontalhealthbar&quot; &quot;pulsingbar&quot;&gt;&gt;
@@ -1156,7 +1132,7 @@ With a laugh, Ivex withdraws his hand.
 &lt;span class=&quot;bad-ending&quot;&gt;Bad Ending: &lt;i&gt;Interrogation&lt;/i&gt;&lt;/span&gt;
 
 [[Continue|Ivex Torture 1]]
-&lt;&lt;/timed&gt;&gt;</tw-passagedata><tw-passagedata pid="37" name="Arousal Level 5" tags="" position="34,944" size="100,100">&quot;FUCK!&quot; $name yells in a growl. It&#39;s hard to even shift his eyes away from his cock. Small veins bulge from its side as the canine-shaped length almost glows as it throbs there in the air. Untouched. No stimulation, even though the wolf needs it. He NEEDS IT!
+&lt;&lt;/timed&gt;&gt;</tw-passagedata><tw-passagedata pid="33" name="Arousal Level 5" tags="" position="825,2025" size="100,100">&quot;FUCK!&quot; $name yells in a growl. It&#39;s hard to even shift his eyes away from his cock. Small veins bulge from its side as the canine-shaped length almost glows as it throbs there in the air. Untouched. No stimulation, even though the wolf needs it. He NEEDS IT!
 
 Drool runs down the sides of &lt;&lt;print $name&gt;&gt;&#39;s muzzle, but he does not care. It doesn&#39;t matter. Nothing matters, only the constant waves of arousal his burning body feels. It radiates from his loins, from his cock, from his fucking knot, and he needs to touch it! He needs it!
 
@@ -1166,7 +1142,7 @@ Those phantom feelings intensify. It feels as if an invisible force is stroking 
 
 He &lt;i&gt;needs&lt;/i&gt; to get out. It&#39;s almost impossible to think now. The candle&#39;s fire keeps penetrating his nose, adding to the volcano erupting inside of him and furthering his arousal to impossible levels. Tears of sheer need stream down from the wolf&#39;s eyes and he can feel his mind slipping.
 
-Fighting to stay conscious and absolutely desperate, $name fights to resist, but it&#39;s a battle he&#39;s about to lose.</tw-passagedata><tw-passagedata pid="38" name="Gather Thoughts" tags="" position="490,724" size="100,100">Exercising patience despite the urgency of his situation, $name takes a moment to reevaluate everything he knows so far, in an attempt to figure out the best way to escape. Before Ivex&#39;s cursed candle overwhelms him, that is.
+Fighting to stay conscious and absolutely desperate, $name fights to resist, but it&#39;s a battle he&#39;s about to lose.</tw-passagedata><tw-passagedata pid="34" name="Gather Thoughts" tags="" position="450,2200" size="100,100">Exercising patience despite the urgency of his situation, $name takes a moment to reevaluate everything he knows so far, in an attempt to figure out the best way to escape. Before Ivex&#39;s cursed candle overwhelms him, that is.
 &lt;&lt;if $CurArousal &lt; 60&gt;&gt;\
 
 Glancing down, the wolf can see his member there, proud and erect, but he quickly looks away. The temptation is strong, but he focuses on escaping.
@@ -1235,7 +1211,7 @@ That can work! Now to manage that before the candle&#39;s influence grows too st
 &lt;&lt;if $baseCrystal&gt;&gt;\
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-	&lt;li&gt;[[Attempt to dislodge the crystal at the cross&#39; base.|Dislodge Crystal]]&lt;/li&gt;
+    &lt;li&gt;[[Attempt to dislodge the crystal at the cross&#39; base.|Dislodge Crystal]]&lt;/li&gt;
   &lt;/ul&gt;\
 &lt;/div&gt;
 &lt;&lt;else&gt;&gt;\
@@ -1243,10 +1219,10 @@ The time gathering his thoughts was valuable, but the breathing never stops and,
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-	&lt;li&gt;[[Ponder on what action to take next...|Escape Actions]]&lt;/li&gt;
+    &lt;li&gt;[[Ponder on what action to take next...|Escape Actions]]&lt;/li&gt;
   &lt;/ul&gt;\
 &lt;/div&gt;
-&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="39" name="Observation 2" tags="" position="182,938" size="100,100">The wolf&#39;s eyes scan the room again. With increasing urgency, $name attempts to focus on each thing and think about how it could possibly help get out of that damned cross.
+&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="35" name="Observation 2" tags="" position="300,2000" size="100,100">The wolf&#39;s eyes scan the room again. With increasing urgency, $name attempts to focus on each thing and think about how it could possibly help get out of that damned cross.
 
 Most things are useless or, if they would have some use, it does not matter because he cannot reach them. The sharp leather opener at the desk taunts him with its usefulness, but it is completely out of reach with him stuck to that cross.
 
@@ -1265,9 +1241,9 @@ And the whole time, he still has to breathe. The fire inside him grows by the mi
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-	&lt;li&gt;[[Reevaluate his options.|Escape Actions]]&lt;/li&gt;
+    &lt;li&gt;[[Reevaluate his options.|Escape Actions]]&lt;/li&gt;
   &lt;/ul&gt;\
-&lt;/div&gt;</tw-passagedata><tw-passagedata pid="40" name="Struggle 2" tags="" position="393,936" size="100,100">&lt;&lt;if $warrior &amp;&amp; $CurArousal &gt; 90&gt;&gt;\
+&lt;/div&gt;</tw-passagedata><tw-passagedata pid="36" name="Struggle 2" tags="" position="600,2200" size="100,100">&lt;&lt;if $warrior &amp;&amp; $CurArousal &gt; 90&gt;&gt;\
 It&#39;s too much. Drekkar pants, huffs and drools like a wild beast. Rage swells within him as he stares down at his cock. The arousal, the impossible, infinite arousal he feels fuels his anger. Those bonds... they keep him from reaching what he needs, and he cannot take it anymore.
 
 &quot;Grrrrhhhrrhh...!&quot; 
@@ -1289,8 +1265,8 @@ As his paw envelops his cock, the wolf lets out a moan of relief. At that moment
 &lt;&lt;set $bound = false&gt;&gt;\
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-	&lt;li&gt;[[Fight the urges and snuff out the candle first.|Snuff Candle]]&lt;/li&gt;
-	&lt;li&gt;[[Choose pleasure. Sate the needs burning within.|Jerk off]]&lt;/li&gt;
+    &lt;li&gt;[[Fight the urges and snuff out the candle first.|Snuff Candle]]&lt;/li&gt;
+    &lt;li&gt;[[Choose pleasure. Sate the needs burning within.|Jerk off]]&lt;/li&gt;
   &lt;/ul&gt;\
 &lt;/div&gt;
 &lt;&lt;else&gt;&gt;\
@@ -1309,10 +1285,10 @@ The bound lupine takes a moment to catch his breath and recover his strength.
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-	&lt;li&gt;[[Reevaluate his options.|Escape Actions]]&lt;/li&gt;
+    &lt;li&gt;[[Reevaluate his options.|Escape Actions]]&lt;/li&gt;
   &lt;/ul&gt;\
 &lt;/div&gt;
-&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="41" name="Dislodge Crystal" tags="" position="583,875" size="100,100">&lt;&lt;set $finalArousal = $curArousal&gt;&gt;\
+&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="37" name="Dislodge Crystal" tags="" position="400,2325" size="100,100">&lt;&lt;set $finalArousal = $curArousal&gt;&gt;\
 With a grunt, the wolf starts his desperate attempt to get rid of the crystals holding the cross he&#39;s bound to. Drawing from what he has learned so far, $name pulls with his right arm against the bindings with all of his strength while, at the same time, he &lt;i&gt;pushes&lt;/i&gt; back against the cross with his left leg. With the directed tension, the cross shifts to the side.
 
 The wolf is hit with a small sense of dread as the cross turns. It takes a lot of pulling from his arm to even dislodge it a little, but with a determined growl, he keeps pushing. Again and again, until...
@@ -1338,10 +1314,10 @@ At the same time, the letter opener sitting on the desk is well within reach now
 &lt;&lt;set $bound = true&gt;&gt;\
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-	&lt;li&gt;[[Rush to the candle to put it out.|Snuff Candle]]&lt;/li&gt;
-	&lt;li&gt;[[Rush to the leather opener to cut out the bonds.|Free Himself]]&lt;/li&gt;
+    &lt;li&gt;[[Rush to the candle to put it out.|Snuff Candle]]&lt;/li&gt;
+    &lt;li&gt;[[Rush to the leather opener to cut out the bonds.|Free Himself]]&lt;/li&gt;
   &lt;/ul&gt;\
-&lt;/div&gt;</tw-passagedata><tw-passagedata pid="42" name="Snuff Candle" tags="" position="653,1012" size="100,100">&lt;&lt;set $candle = false&gt;&gt;\
+&lt;/div&gt;</tw-passagedata><tw-passagedata pid="38" name="Snuff Candle" tags="" position="400,2500" size="100,100">&lt;&lt;set $candle = false&gt;&gt;\
 &lt;&lt;if $bound&gt;&gt;\
 With urgency, the wolf awkwardly stumbles and hops towards the candle, even still stuck to the loose cross. Luckily, despite its insane magical properties, the candle itself works just like a normal candle. Leaning over it and blowing at it is enough to snuff out its fire.
 
@@ -1355,7 +1331,7 @@ His eyes shift to the table. The next step has to be freeing himself from these 
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-	&lt;li&gt;[[Finally cut the bonds away.|Free Himself]]&lt;/li&gt;
+    &lt;li&gt;[[Finally cut the bonds away.|Free Himself]]&lt;/li&gt;
   &lt;/ul&gt;\
 &lt;/div&gt;
 &lt;&lt;else&gt;&gt;\
@@ -1375,10 +1351,10 @@ Working hard to ignore his arousal, the wolf focuses on what really matters.
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-	&lt;li&gt;[[Start working on escaping this tower...|Escape Start]]&lt;/li&gt;
+    &lt;li&gt;[[Start working on escaping this tower...|Escape Start]]&lt;/li&gt;
   &lt;/ul&gt;\
 &lt;/div&gt;
-&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="43" name="Jerk off" tags="" position="440,1136" size="100,100">Fuck it! $name needs it. He needs the pleasure! After that is taken care of, then the wolf can deal with the candle and think about escaping. Only one thing matters now!
+&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="39" name="Jerk off" tags="end" position="800,2200" size="100,100">Fuck it! $name needs it. He needs the pleasure! After that is taken care of, then the wolf can deal with the candle and think about escaping. Only one thing matters now!
 
 With his paw blissfully wrapped around his cock, $name lets himself fall forward to his knees. An involuntary smile comes to his muzzle and he feels himself tearing up from the sheer happiness of being able to sate the lust burning within him. Every breath is fire, and now his paw can fan the fire.
 
@@ -1415,7 +1391,7 @@ Ivex approaches him and the mindless wolf can only look up at the panther.
 
 &lt;span class=&quot;bad-ending&quot;&gt;Bad Ending: &lt;i&gt;Interrogation&lt;/i&gt;&lt;/span&gt;
 
-[[Continue|Ivex Torture 1]]</tw-passagedata><tw-passagedata pid="44" name="Ivex Torture 1" tags="" position="208,1198" size="100,100">&lt;&lt;silently&gt;&gt;
+[[Continue|Ivex Torture 1]]</tw-passagedata><tw-passagedata pid="40" name="Ivex Torture 1" tags="" position="1100,2025" size="100,100">&lt;&lt;silently&gt;&gt;
 &lt;&lt;set $defiance = 0&gt;&gt;
 &lt;&lt;if $rough_awakening&gt;&gt;
   &lt;&lt;set $defiance += 1&gt;&gt;
@@ -1426,7 +1402,7 @@ Ivex approaches him and the mindless wolf can only look up at the panther.
 &lt;&lt;/silently&gt;&gt;
 &lt;&lt;include &quot;Ivex Torture 1 (Text)&quot;&gt;&gt;
 
-[[Continue|Ivex Torture 2]]</tw-passagedata><tw-passagedata pid="45" name="Free Himself" tags="" position="520,1010" size="100,100">Stumbling awkwardly with the cross&#39; weight upon his back and still stuck in a spread-eagle position, the wolf hops and steps towards the desk on the side. Turning to the side and leaning in, it still takes some effort for him to be able to take hold of the letter opener with his hand, but he succeeds.
+[[Continue|Ivex Torture 2]]</tw-passagedata><tw-passagedata pid="41" name="Free Himself" tags="" position="600,2375" size="100,100">Stumbling awkwardly with the cross&#39; weight upon his back and still stuck in a spread-eagle position, the wolf hops and steps towards the desk on the side. Turning to the side and leaning in, it still takes some effort for him to be able to take hold of the letter opener with his hand, but he succeeds.
 
 With it in hand, it&#39;s only a matter of awkwardly cutting the leather binding without harming himself in the process. It does not take too long and, with one hand free, cutting the others is a breeze.
 
@@ -1439,7 +1415,7 @@ A smile opens in the corner of the wolf&#39;s muzzle.
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-	&lt;li&gt;[[It&#39;s too late. It&#39;s impossible to resist. Start jerking off.|Jerk off]]&lt;/li&gt;
+    &lt;li&gt;[[It&#39;s too late. It&#39;s impossible to resist. Start jerking off.|Jerk off]]&lt;/li&gt;
   &lt;/ul&gt;\
 &lt;/div&gt;
 &lt;&lt;elseif $candle&gt;&gt;\
@@ -1451,8 +1427,8 @@ The wolf&#39;s mind is torn with indecision.
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-	&lt;li&gt;[[It&#39;s too hard to resist. Start jerking off.|Jerk off]]&lt;/li&gt;
-	&lt;li&gt;[[Don&#39;t yield! Go to the candle and snuff it out.|Snuff Candle]]&lt;/li&gt;
+    &lt;li&gt;[[It&#39;s too hard to resist. Start jerking off.|Jerk off]]&lt;/li&gt;
+    &lt;li&gt;[[Don&#39;t yield! Go to the candle and snuff it out.|Snuff Candle]]&lt;/li&gt;
   &lt;/ul&gt;\
 &lt;/div&gt;
 &lt;&lt;else&gt;&gt;\
@@ -1466,11 +1442,11 @@ Working hard to ignore his arousal, the wolf focuses on what really matters.
   &lt;ul class=&quot;actions&quot;&gt;\
     &lt;&lt;if ($CurArousal &gt; 80)&gt;&gt;\
       &lt;li&gt;[[It&#39;s really hard to resist. Start jerking off.|Jerk off]]&lt;/li&gt;
-	&lt;&lt;/if&gt;&gt;\
-	&lt;li&gt;[[Start working on escaping this tower...|Escape Start]]&lt;/li&gt;
+    &lt;&lt;/if&gt;&gt;\
+    &lt;li&gt;[[Start working on escaping this tower...|Escape Start]]&lt;/li&gt;
   &lt;/ul&gt;\
 &lt;/div&gt;
-&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="46" name="Escape Start" tags="start" position="616,1164" size="100,100">&lt;&lt;silently&gt;&gt;
+&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="42" name="Escape Start" tags="restart" position="500,2650" size="100,100">&lt;&lt;silently&gt;&gt;
 &lt;&lt;set $candleTimer = &quot;0s&quot;&gt;&gt;
 &lt;&lt;set $window = false&gt;&gt;
 &lt;&lt;set $office = false&gt;&gt;
@@ -1510,27 +1486,7 @@ His clothes and gear are nowhere near. The wolf lets out a soft growl. No weapon
 
 This is not the time to be worried about his modesty. This is the time to be worried about his freedom...
 
-[[Continue|The Upper Office]]</tw-passagedata><tw-passagedata pid="47" name="To Be Continued 1" tags="" position="548,1304" size="100,100">&lt;b&gt;Aaaand... that&#39;s it!&lt;/b&gt;
-
-You&#39;ve managed to escape the perverted mage Ivex&#39;s bondage and moved on to escape the tower! This marks the first half of the game completed and, unfortunately, it is where this first version ends.
-
-I have a few spicier plans for the second part leading to a (or a few) even spicier conclusions! I hope you enjoyed this first attempt at an interactive story so far!
-
-This game is a prototype, a test, a tryout before I move on to something bigger and more serious that I have in mind! I&#39;m trying things out here, both story-wise and coding-wise, and trying to learn as much as I can while entertaining everybody in the process as well!
-
-This prototype also comes as the results of the polls that all my patrons voted on, by the way! The setting that won the poll was &#39;High Magic&#39; and the kinks were, in order, &#39;Bondage&#39; first, &#39;CBT&#39; second and &#39;Milking&#39; third. I can promise that all of these will be included and, as you might have seen, some already were.
-
-Big thanks to my patrons for their support while I work on this!
-
-For now, you can still play around with different options. Was it easy to get here? Did it take you a few tries? There are a few different ways to successfully reach the way of escaping and some ways that don&#39;t lead you here at all!
-
-If you haven&#39;t, I do recommend trying different choices and seeing what changes! There&#39;s one particularly risky way to get here that I don&#39;t know how many people will find. There&#39;s also dire consequences of different kinds for failing to escape in time…
-
-My Patreon is also slightly ahead of the public build with some new content available for them first. If you&#39;d like, check it out over at &lt;a class=&quot;footer-element&quot; target=&quot;_blank&quot; href=&quot;https://www.patreon.com/sleth&quot;&gt;Patreon&lt;/a&gt; where &lt;a class=&quot;footer-element&quot; target=&quot;_blank&quot; href=&quot;https://www.patreon.com/posts/64812733&quot;&gt;version 0.7&lt;/a&gt; is already out, which the next one coming soon as well!
-
-If you&#39;d like,
-
-[[Return to the beginning|Bound]]</tw-passagedata><tw-passagedata pid="48" name="The Upper Office" tags="hub" position="811,1166" size="100,100">With the freedom to move around the office space, the wolf can now properly assess what is in this room. The many desks and cabinets seem to have nothing but documents on them with the occasional thick book lying here or there.
+[[Continue|The Upper Office]]</tw-passagedata><tw-passagedata pid="43" name="The Upper Office" tags="" position="500,2900" size="100,100">With the freedom to move around the office space, the wolf can now properly assess what is in this room. The many desks and cabinets seem to have nothing but documents on them with the occasional thick book lying here or there.
 
 The wolf&#39;s best bets, however, are of course the open window on one side of the wall and the simple wooden door on the opposite one.
 &lt;&lt;if $arousalLevel &gt; 0&gt;&gt;\
@@ -1541,38 +1497,38 @@ The wolf feels that, using his hand, he could bring himself to an immensely sati
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-  	&lt;&lt;if !$room&gt;&gt;\
-  	&lt;li&gt;[[Look around the room some more.|Room]]&lt;/li&gt;
-	&lt;&lt;/if&gt;&gt;
-	&lt;&lt;if !$window&gt;&gt;\
-	&lt;li&gt;[[Investigate the window.|Window]]&lt;/li&gt;
-	&lt;&lt;/if&gt;&gt;\
+      &lt;&lt;if !$room&gt;&gt;\
+      &lt;li&gt;[[Look around the room some more.|Room]]&lt;/li&gt;
+    &lt;&lt;/if&gt;&gt;
+    &lt;&lt;if !$window&gt;&gt;\
+    &lt;li&gt;[[Investigate the window.|Window]]&lt;/li&gt;
+    &lt;&lt;/if&gt;&gt;\
     &lt;&lt;if !$jerkoff&gt;&gt;\
-	&lt;li&gt;[[...Jerk off.|Arousal Relief]]&lt;/li&gt;
-	&lt;&lt;/if&gt;&gt;\
-	&lt;li&gt;[[Try the door.|Door]]&lt;/li&gt;
+    &lt;li&gt;[[...Jerk off.|Arousal Relief]]&lt;/li&gt;
+    &lt;&lt;/if&gt;&gt;\
+    &lt;li&gt;[[Try the door.|Door]]&lt;/li&gt;
   &lt;/ul&gt;\
 &lt;/div&gt;
 &lt;&lt;else&gt;&gt;\
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-  	&lt;&lt;if !$room&gt;&gt;\
-  	&lt;li&gt;[[Look around the room some more.|Room]]&lt;/li&gt;
-	&lt;&lt;/if&gt;&gt;
-	&lt;&lt;if !$window&gt;&gt;\
-	&lt;li&gt;[[Investigate the window.|Window]]&lt;/li&gt;
-	&lt;&lt;/if&gt;&gt;\
-	&lt;li&gt;[[Try the door.|Door]]&lt;/li&gt;
+      &lt;&lt;if !$room&gt;&gt;\
+      &lt;li&gt;[[Look around the room some more.|Room]]&lt;/li&gt;
+    &lt;&lt;/if&gt;&gt;
+    &lt;&lt;if !$window&gt;&gt;\
+    &lt;li&gt;[[Investigate the window.|Window]]&lt;/li&gt;
+    &lt;&lt;/if&gt;&gt;\
+    &lt;li&gt;[[Try the door.|Door]]&lt;/li&gt;
   &lt;/ul&gt;\
 &lt;/div&gt;
-&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="49" name="Room" tags="" position="862,1316" size="100,100">With his erection bobbing between his legs, the wolf searches the room with haste.
+&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="44" name="Room" tags="" position="300,2925" size="100,100">With his erection bobbing between his legs, the wolf searches the room with haste.
 
 Throwing the cabinets open, $name frowns. More papers, candles, ink and quills. Standard utilities and nothing else. The wolf doesn&#39;t waste too much time going through that stuff.
 
 Nothing of note is found.
 &lt;&lt;set $room = true&gt;&gt;\
 
-[[Continue|The Upper Office]]</tw-passagedata><tw-passagedata pid="50" name="Window" tags="" position="963,1200" size="100,100">$name approaches the window. Maybe it&#39;s climbable?
+[[Continue|The Upper Office]]</tw-passagedata><tw-passagedata pid="45" name="Window" tags="" position="300,3050" size="100,100">$name approaches the window. Maybe it&#39;s climbable?
 
 Upon putting his paws on the window&#39;s sill, the wolf&#39;s hopes of climbing out of there vanish. Not only that, though... something is wrong.
 
@@ -1585,7 +1541,7 @@ Frowning, $name grunts. He does not know too much about magic, but if this huge 
 Regardless... there is no way out through the window. Climbing down the smooth wall would be asking to slip and fall.
 &lt;&lt;set $window = true&gt;&gt;\
 
-[[Continue|The Upper Office]]</tw-passagedata><tw-passagedata pid="51" name="Door" tags="" position="851,1029" size="100,100">Narrowing his eyes, $name heads towards the door. The wolf lets out a low growl, measuring the door&#39;s apparent sturdiness as he approaches it fully expecting to have to tackle it down.
+[[Continue|The Upper Office]]</tw-passagedata><tw-passagedata pid="46" name="Door" tags="" position="650,2900" size="100,100">Narrowing his eyes, $name heads towards the door. The wolf lets out a low growl, measuring the door&#39;s apparent sturdiness as he approaches it fully expecting to have to tackle it down.
 
 When his paw tries the door&#39;s handle, however, it twists. The door is not locked and it just opens.
 
@@ -1594,7 +1550,7 @@ Outside of it, there&#39;s a small hallway with no other doors, but it leads to 
 &lt;&lt;if $room &amp;&amp; $window&gt;&gt;\
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-	&lt;li&gt;[[Leave the office and head down the stairs.|Head Downstairs]]&lt;/li&gt;
+    &lt;li&gt;[[Leave the office and head down the stairs.|Head Downstairs]]&lt;/li&gt;
   &lt;/ul&gt;\
 &lt;/div&gt;
 &lt;&lt;else&gt;&gt;\
@@ -1602,11 +1558,11 @@ There might still be useful things to see in the office before leaving, though.
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-  	&lt;li&gt;[[Close the door and keep looking.|The Upper Office]]&lt;/li&gt;
-	&lt;li&gt;[[Leave the office and head down the stairs.|Head Downstairs]]&lt;/li&gt;
+      &lt;li&gt;[[Close the door and keep looking.|The Upper Office]]&lt;/li&gt;
+    &lt;li&gt;[[Leave the office and head down the stairs.|Head Downstairs]]&lt;/li&gt;
   &lt;/ul&gt;\
 &lt;/div&gt;
-&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="52" name="Head Downstairs" tags="" position="987,966" size="100,100">&lt;&lt;silently&gt;&gt;\
+&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="47" name="Head Downstairs" tags="" position="775,2900" size="100,100">&lt;&lt;silently&gt;&gt;\
   &lt;&lt;set $stoneDoor = false&gt;&gt;
   &lt;&lt;set $lionDoor = false&gt;&gt;
   &lt;&lt;set $extractionDoor = false&gt;&gt;
@@ -1623,7 +1579,7 @@ Unfortunately, in that hallway, there is also nothing but a single door. No exit
 
 There is little choice but to proceed, though.
 
-[[Continue|Second Floor]]</tw-passagedata><tw-passagedata pid="53" name="Interrogation End" tags="" position="28,1345" size="100,100">$name fell into Ivex&#39;s hands.
+[[Continue|Second Floor]]</tw-passagedata><tw-passagedata pid="48" name="Interrogation End" tags="end" position="2300,1800" size="100,100">$name fell into Ivex&#39;s hands.
 
 &lt;&lt;if $interrogationEndingUnlock&gt;&gt;\
 &lt;&lt;set $interrogationEnding = true&gt;&gt;\
@@ -1655,32 +1611,32 @@ To change the adventurer&#39;s fate, you can...
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\  
-  	&lt;li&gt;[[Attempt to escape again.|Escape Options]]&lt;/li&gt;
-  	&lt;li&gt;[[Return to the beginning of the game.|Title Screen]]&lt;/li&gt;
+      &lt;li&gt;[[Attempt to escape again.|Escape Options]]&lt;/li&gt;
+      &lt;li&gt;[[Return to the beginning of the game.|Title Screen]]&lt;/li&gt;
   &lt;/ul&gt;\
-&lt;/div&gt;</tw-passagedata><tw-passagedata pid="54" name="Easy Way" tags="" position="64,1480" size="100,100">&lt;&lt;include &quot;Easy Way (Text)&quot;&gt;&gt;
+&lt;/div&gt;</tw-passagedata><tw-passagedata pid="49" name="Easy Way" tags="" position="1375,1975" size="100,100">&lt;&lt;include &quot;Easy Way (Text)&quot;&gt;&gt;
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-	&lt;li&gt;[[Stay silent and growl.|Resistance]]&lt;/li&gt;
-	&lt;li&gt;[[Spit towards Ivex to show his distaste.|Defiance]]&lt;/li&gt;	
+    &lt;li&gt;[[Stay silent and growl.|Resistance]]&lt;/li&gt;
+    &lt;li&gt;[[Spit towards Ivex to show his distaste.|Defiance]]&lt;/li&gt;	
   &lt;/ul&gt;\
-&lt;/div&gt;</tw-passagedata><tw-passagedata pid="55" name="Hard Way" tags="" position="342,1481" size="100,100">&lt;&lt;include &quot;Hard Way (Text)&quot;&gt;&gt;
+&lt;/div&gt;</tw-passagedata><tw-passagedata pid="50" name="Hard Way" tags="" position="1375,2100" size="100,100">&lt;&lt;include &quot;Hard Way (Text)&quot;&gt;&gt;
 &lt;&lt;set $defiance += 1&gt;&gt;\
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-	&lt;li&gt;[[Stay silent and growl.|Resistance]]&lt;/li&gt;
-	&lt;li&gt;[[Spit towards Ivex to show his distaste.|Defiance]]&lt;/li&gt;	
+    &lt;li&gt;[[Stay silent and growl.|Resistance]]&lt;/li&gt;
+    &lt;li&gt;[[Spit towards Ivex to show his distaste.|Defiance]]&lt;/li&gt;	
   &lt;/ul&gt;\
-&lt;/div&gt;</tw-passagedata><tw-passagedata pid="56" name="Ivex Torture 2" tags="" position="204,1342" size="100,100">&lt;&lt;include &quot;Ivex Torture 2 (Text)&quot;&gt;&gt;
+&lt;/div&gt;</tw-passagedata><tw-passagedata pid="51" name="Ivex Torture 2" tags="" position="1225,2025" size="100,100">&lt;&lt;include &quot;Ivex Torture 2 (Text)&quot;&gt;&gt;
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
     &lt;li&gt;[[Splay ears in submission.|Easy Way]]&lt;/li&gt;
-	&lt;li&gt;[[Growl in defiance.|Hard Way]]&lt;/li&gt;
+    &lt;li&gt;[[Growl in defiance.|Hard Way]]&lt;/li&gt;
   &lt;/ul&gt;\
-&lt;/div&gt;</tw-passagedata><tw-passagedata pid="57" name="Arousal Relief" tags="" position="727,1316" size="100,100">Fuck it. It will be quick and it will feel great! With a glance towards the door and a growl coming from his throat, $name wraps his paw around his cock and that alone brings a groan of relief.
+&lt;/div&gt;</tw-passagedata><tw-passagedata pid="52" name="Arousal Relief" tags="" position="300,2800" size="100,100">Fuck it. It will be quick and it will feel great! With a glance towards the door and a growl coming from his throat, $name wraps his paw around his cock and that alone brings a groan of relief.
 
 Closing his eyes, he starts pumping it. In fast, quick motions, the wolf lets his hand glide over the surface of his cock, stimulating it, pleasuring it. Nobody knows his own dick better than his own hand, so with dexterity, his paw strokes his cock up and down. It teases the tip, then when it reaches the base, the wolf opens his grip just lightly to give his knot a squeeze before it keeps going...
 
@@ -1698,19 +1654,19 @@ With a growl of frustration, all $name can do is try to ignore his erection agai
 &lt;&lt;set $arousalLevel = 1&gt;&gt;\
 &lt;&lt;set $jerkoff = true&gt;&gt;\
 
-[[Continue|The Upper Office]]</tw-passagedata><tw-passagedata pid="58" name="Resistance" tags="" position="118,1616" size="100,100">&lt;&lt;include &quot;Resistance (Text)&quot;&gt;&gt;
+[[Continue|The Upper Office]]</tw-passagedata><tw-passagedata pid="53" name="Resistance" tags="" position="1525,2100" size="100,100">&lt;&lt;include &quot;Resistance (Text)&quot;&gt;&gt;
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
     &lt;li&gt;[[&#39;&quot;Yes, I come from the far north, so what?&quot;&#39;|Ice]]&lt;/li&gt;
-	&lt;li&gt;[[&#39;&quot;No, I come from the south, so what?&quot;&#39;|Shock]]&lt;/li&gt;
-	&lt;li&gt;[[&quot;Stay silent.&quot;|Random Punishment]]&lt;/li&gt;
+    &lt;li&gt;[[&#39;&quot;No, I come from the south, so what?&quot;&#39;|Shock]]&lt;/li&gt;
+    &lt;li&gt;[[&quot;Stay silent.&quot;|Random Punishment]]&lt;/li&gt;
   &lt;/ul&gt;\
-&lt;/div&gt;</tw-passagedata><tw-passagedata pid="59" name="Ice" tags="" position="48,1789" size="100,100">&lt;&lt;include &quot;Ice (Text)&quot;&gt;&gt;
+&lt;/div&gt;</tw-passagedata><tw-passagedata pid="54" name="Ice" tags="" position="1675,2200" size="100,100">&lt;&lt;include &quot;Ice (Text)&quot;&gt;&gt;
 
-[[Continue|Ice 2]]</tw-passagedata><tw-passagedata pid="60" name="Shock" tags="" position="446,1789" size="100,100">&lt;&lt;include &quot;Shock (Text)&quot;&gt;&gt;
+[[Continue|Ice 2]]</tw-passagedata><tw-passagedata pid="55" name="Shock" tags="" position="1675,1900" size="100,100">&lt;&lt;include &quot;Shock (Text)&quot;&gt;&gt;
 
-[[Continue|Shock 2]]</tw-passagedata><tw-passagedata pid="61" name="Random Punishment" tags="" position="294,1790" size="100,100">&lt;&lt;silently&gt;&gt;
+[[Continue|Shock 2]]</tw-passagedata><tw-passagedata pid="56" name="Random Punishment" tags="" position="1675,2050" size="100,100">&lt;&lt;silently&gt;&gt;
 &lt;&lt;set $defiance += 2&gt;&gt;\
 &lt;&lt;set $punishment to random(1, 2)&gt;&gt;
 &lt;&lt;/silently&gt;&gt;
@@ -1730,18 +1686,18 @@ The mage grins.
 The mage grins.
 
 [[Continue|Shock]]
-&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="62" name="Ice 2" tags="" position="100,1936" size="100,100">&lt;&lt;include &quot;Ice 2 (Text)&quot;&gt;&gt;
+&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="57" name="Ice 2" tags="" position="1800,2200" size="100,100">&lt;&lt;include &quot;Ice 2 (Text)&quot;&gt;&gt;
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
     &lt;li&gt;[[&#39;&quot;I w-&quot;&#39;|Ice 3]]&lt;/li&gt;
   &lt;/ul&gt;\
-&lt;/div&gt;</tw-passagedata><tw-passagedata pid="63" name="Ice 3" tags="" position="139,2087" size="100,100">&lt;&lt;if !$interrogationEndingFreeze&gt;&gt;\
+&lt;/div&gt;</tw-passagedata><tw-passagedata pid="58" name="Ice 3" tags="" position="1925,2200" size="100,100">&lt;&lt;if !$interrogationEndingFreeze&gt;&gt;\
 &lt;&lt;set $interrogationEndingFreezeUnlock = true&gt;&gt;\
 &lt;&lt;/if&gt;&gt;\
 &lt;&lt;include &quot;Ice 3 (Text)&quot;&gt;&gt;
 
-[[Continue|Extra Torture]]</tw-passagedata><tw-passagedata pid="64" name="Extra Torture" tags="" position="257,2232" size="100,100">&lt;&lt;include &quot;Extra Torture (Text)&quot;&gt;&gt;
+[[Continue|Extra Torture]]</tw-passagedata><tw-passagedata pid="59" name="Extra Torture" tags="" position="2050,2025" size="100,100">&lt;&lt;include &quot;Extra Torture (Text)&quot;&gt;&gt;
 
 &lt;&lt;if $defiance &gt; 3&gt;&gt;\
 &quot;You thought you could fight me. You thought you had a chance of escaping. Of beating me. Hah! How wrong were you, hmm?&quot; the mage laughs. He grips the wolf&#39;s knot and gives it a painful squeeze. Enough to force a muffled whine. &quot;I did not forget your defiance, though. You will now see what your hopeless fighting and bravery brings upon you...&quot;
@@ -1751,7 +1707,7 @@ The mage grins.
 &quot;You&#39;ve been such a good boy, all things considered...&quot; the panther muses, caressing the wolf&#39;s knot. His hand grips the wolf&#39;s member more firmly, starting to stroke it in a pleasurable way. &quot;I&#39;ll be pleased to have someone like you by my side. I&#39;ve been needing more thralls, and I only accept handsome ones. Oh, the pleasures you will feel... too bad you won&#39;t be quite as aware of them...&quot;
 
 [[Continue|Compliant End]]
-&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="65" name="Defiant End" tags="" position="377,2375" size="100,100">&lt;&lt;if !$interrogationEnding&gt;&gt;\
+&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="60" name="Defiant End" tags="" position="2225,2025" size="100,100">&lt;&lt;if !$interrogationEnding&gt;&gt;\
 &lt;&lt;set $interrogationEndingUnlock = true&gt;&gt;\
 &lt;&lt;/if&gt;&gt;\
 &lt;&lt;if !$interrogationEndingRough&gt;&gt;\
@@ -1761,7 +1717,7 @@ The mage grins.
 
 &lt;span class=&quot;bad-ending&quot;&gt;Bad Ending: &lt;i&gt;Interrogation&lt;/i&gt;&lt;/span&gt;
 
-[[Continue|Interrogation End]]</tw-passagedata><tw-passagedata pid="66" name="Compliant End" tags="" position="132,2376" size="100,100">&lt;&lt;if !$interrogationEnding&gt;&gt;\
+[[Continue|Interrogation End]]</tw-passagedata><tw-passagedata pid="61" name="Compliant End" tags="" position="2125,1900" size="100,100">&lt;&lt;if !$interrogationEnding&gt;&gt;\
 &lt;&lt;set $interrogationEndingUnlock = true&gt;&gt;\
 &lt;&lt;/if&gt;&gt;\
 &lt;&lt;if !$interrogationEndingMild&gt;&gt;\
@@ -1771,27 +1727,27 @@ The mage grins.
 
 &lt;span class=&quot;bad-ending&quot;&gt;Bad Ending: &lt;i&gt;Interrogation&lt;/i&gt;&lt;/span&gt;
 
-[[Continue|Interrogation End]]</tw-passagedata><tw-passagedata pid="67" name="Defiance" tags="" position="386,1618" size="100,100">&lt;&lt;include &quot;Defiance (Text)&quot;&gt;&gt;
+[[Continue|Interrogation End]]</tw-passagedata><tw-passagedata pid="62" name="Defiance" tags="" position="1525,1975" size="100,100">&lt;&lt;include &quot;Defiance (Text)&quot;&gt;&gt;
 &lt;&lt;set $defiance += 1&gt;&gt;\
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
     &lt;li&gt;[[&#39;&quot;Yes, I come from the far north, so what?&quot;&#39;|Ice]]&lt;/li&gt;
-	&lt;li&gt;[[&#39;&quot;No, I come from the south, so what?&quot;&#39;|Shock]]&lt;/li&gt;
-	&lt;li&gt;[[&quot;Stay silent.&quot;|Random Punishment]]&lt;/li&gt;
+    &lt;li&gt;[[&#39;&quot;No, I come from the south, so what?&quot;&#39;|Shock]]&lt;/li&gt;
+    &lt;li&gt;[[&quot;Stay silent.&quot;|Random Punishment]]&lt;/li&gt;
   &lt;/ul&gt;\
-&lt;/div&gt;</tw-passagedata><tw-passagedata pid="68" name="Shock 2" tags="" position="394,1934" size="100,100">&lt;&lt;include &quot;Shock 2 (Text)&quot;&gt;&gt;
+&lt;/div&gt;</tw-passagedata><tw-passagedata pid="63" name="Shock 2" tags="" position="1800,1900" size="100,100">&lt;&lt;include &quot;Shock 2 (Text)&quot;&gt;&gt;
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
     &lt;li&gt;[[&#39;&quot;I w-&quot;&#39;|Shock 3]]&lt;/li&gt;
   &lt;/ul&gt;\
-&lt;/div&gt;</tw-passagedata><tw-passagedata pid="69" name="Shock 3" tags="" position="367,2087" size="100,100">&lt;&lt;if !$interrogationEndingShock&gt;&gt;\
+&lt;/div&gt;</tw-passagedata><tw-passagedata pid="64" name="Shock 3" tags="" position="1925,1900" size="100,100">&lt;&lt;if !$interrogationEndingShock&gt;&gt;\
 &lt;&lt;set $interrogationEndingShockUnlock = true&gt;&gt;\
 &lt;&lt;/if&gt;&gt;\
 &lt;&lt;include &quot;Shock 3 (Text)&quot;&gt;&gt;
 
-[[Continue|Extra Torture]]</tw-passagedata><tw-passagedata pid="70" name="Second Floor" tags="hub" position="1186,928" size="200,200">&lt;&lt;if $end07&gt;&gt;\
+[[Continue|Extra Torture]]</tw-passagedata><tw-passagedata pid="65" name="Second Floor" tags="" position="675,3100" size="200,200">&lt;&lt;if $end07&gt;&gt;\
   &lt;&lt;goto &quot;To Be Continued 2&quot;&gt;&gt;
 &lt;&lt;/if&gt;&gt;\
 &lt;&lt;if $secondFloor&gt;&gt;\
@@ -1822,19 +1778,19 @@ Now the question is... where to go?
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
     &lt;&lt;if !$extractionRoom&gt;&gt;\
-  	  &lt;li&gt;[[Try the closed door.|Extraction Room Intro]]&lt;/li&gt;
-	&lt;&lt;else&gt;&gt;\
-	  &lt;li&gt;[[Try the large hall.|Extraction Room]]&lt;/li&gt;
-	&lt;&lt;/if&gt;&gt;\
-	&lt;&lt;if !$lionGemstoneKnowledge&gt;&gt;\
-	  &lt;&lt;if $lionWatch&gt;&gt;\
-	    &lt;li&gt;[[Try the door with the lion inside.|Lion Watch]]&lt;/li&gt;
-	  &lt;&lt;else&gt;&gt;\
-	    &lt;li&gt;[[Pry open the door with someone inside.|Lion Room Intro]]&lt;/li&gt;	
-	  &lt;&lt;/if&gt;&gt;\
-	&lt;&lt;/if&gt;&gt;\
+        &lt;li&gt;[[Try the closed door.|Extraction Room Intro]]&lt;/li&gt;
+    &lt;&lt;else&gt;&gt;\
+      &lt;li&gt;[[Try the large hall.|Extraction Room]]&lt;/li&gt;
+    &lt;&lt;/if&gt;&gt;\
+    &lt;&lt;if !$lionGemstoneKnowledge&gt;&gt;\
+      &lt;&lt;if $lionWatch&gt;&gt;\
+        &lt;li&gt;[[Try the door with the lion inside.|Lion Watch]]&lt;/li&gt;
+      &lt;&lt;else&gt;&gt;\
+        &lt;li&gt;[[Pry open the door with someone inside.|Lion Room Intro]]&lt;/li&gt;	
+      &lt;&lt;/if&gt;&gt;\
+    &lt;&lt;/if&gt;&gt;\
   &lt;/ul&gt;\
-&lt;/div&gt;</tw-passagedata><tw-passagedata pid="71" name="Extraction Room Intro" tags="" position="1254,792" size="100,100">&lt;&lt;if !$extractionDoor&gt;&gt;\
+&lt;/div&gt;</tw-passagedata><tw-passagedata pid="66" name="Extraction Room Intro" tags="" position="725,3775" size="100,100">&lt;&lt;if !$extractionDoor&gt;&gt;\
 With care, the wolf approaches the closed door. Taking a couple of reflexive sniffs towards it, the smells coming from it seem... varied, but also stale. With his ears perked up, $name tries to listen in to see if there&#39;s movement inside, but not a sound comes from it.
 
 An attempt to turn the door handle shows that it is indeed not locked. With care, the wolf pries it open just enough to peer inside...
@@ -1850,8 +1806,8 @@ Maybe it would be good to go in and take a closer look... or maybe trying someth
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-  	&lt;li&gt;[[Pry further and investigate the room.|Extraction Room]]&lt;/li&gt;
-	&lt;li&gt;[[Return to the hallway.|Second Floor]]&lt;/li&gt;
+      &lt;li&gt;[[Pry further and investigate the room.|Extraction Room]]&lt;/li&gt;
+    &lt;li&gt;[[Return to the hallway.|Second Floor]]&lt;/li&gt;
   &lt;/ul&gt;\
 &lt;/div&gt;\
 &lt;&lt;else&gt;&gt;\
@@ -1861,11 +1817,11 @@ Maybe it would be good to go in and take a closer look... or maybe trying someth
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-  	&lt;li&gt;[[Pry further and investigate the room.|Extraction Room]]&lt;/li&gt;
-	&lt;li&gt;[[Return to the hallway.|Second Floor]]&lt;/li&gt;
+      &lt;li&gt;[[Pry further and investigate the room.|Extraction Room]]&lt;/li&gt;
+    &lt;li&gt;[[Return to the hallway.|Second Floor]]&lt;/li&gt;
   &lt;/ul&gt;\
 &lt;/div&gt;\
-&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="72" name="Lion Room Intro" tags="" position="1235,1181" size="100,100">&lt;&lt;if !$lionDoor&gt;&gt;\
+&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="67" name="Lion Room Intro" tags="" position="950,3100" size="100,100">&lt;&lt;if !$lionDoor&gt;&gt;\
 Silently approaching the half-open door, the wolf carefully places his paw upon it and slides it open just a tad bit more so that he can peer inside.
 
 It&#39;s a strange room. A large counter with a plenitude of vials adorns its left side, the only side of the room the wolf can see from that viewpoint, with shelves of instruments, materials, and more empty vials above it. That&#39;s not what surprises the wolf, however. Near the center of the room, turned towards the counter and with several jars of strange herbs surrounding him stands... a [[lion|Lion Description]].
@@ -1879,8 +1835,8 @@ Perhaps observing him for a little while longer could be useful. Getting discove
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-  	&lt;li&gt;[[Pry further and watch the lion.|Lion Watch]]&lt;/li&gt;
-	&lt;li&gt;[[Return to the hallway.|Second Floor]]&lt;/li&gt;
+      &lt;li&gt;[[Pry further and watch the lion.|Lion Watch]]&lt;/li&gt;
+    &lt;li&gt;[[Return to the hallway.|Second Floor]]&lt;/li&gt;
   &lt;/ul&gt;\
 &lt;/div&gt;\
 &lt;&lt;else&gt;&gt;\
@@ -1894,22 +1850,11 @@ Approaching him for more information could be useful, even if risky...
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-  	&lt;li&gt;[[Pry further and watch the lion.|Lion Watch]]&lt;/li&gt;
-	&lt;li&gt;[[Return to the hallway.|Second Floor]]&lt;/li&gt;
+      &lt;li&gt;[[Pry further and watch the lion.|Lion Watch]]&lt;/li&gt;
+    &lt;li&gt;[[Return to the hallway.|Second Floor]]&lt;/li&gt;
   &lt;/ul&gt;\
 &lt;/div&gt;\
-&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="73" name="Blocked Exit" tags="" position="1447,965" size="100,100">Silently making his way past the other doors, the wolf quickly reaches the end of the hallway, where he is greeted by the black door he had seen before.
-
-From up close it looks even thicker. If it wasn&#39;t made of a different material, it might as well be part of a solid wall. Placing his hand on it, the wolf can feel that the black stone is smooth, but there doesn&#39;t seem to be any way to open it. Judging by the hallways&#39; layout and the indications on the floor, it seems like it would be fair to guess that there are more stairs leading down to the next floor behind this sealed door.
-
-$name frowns. Tackling it would certainly not help and it would draw attention. Even a powerful wolf such as him cannot force this door open. Still, it can&#39;t be there for nothing. There has to be a way to open it and the wolf hopes that the answer is not just magic.
-
-After spending a few more moments feeling up the door in different places, the wolf is forced to sigh and give up. There is no moving further down the tower without finding a way to open this door.
-
-All $name can do is turn back and look into his other options.
-&lt;&lt;set $stoneDoor = true&gt;&gt;\
-
-[[Continue|Second Floor]]</tw-passagedata><tw-passagedata pid="74" name="Lion Watch" tags="" position="1342,1292" size="100,100">&lt;&lt;set $lionWatch = true&gt;&gt;\
+&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="68" name="Lion Watch" tags="" position="950,3225" size="100,100">&lt;&lt;set $lionWatch = true&gt;&gt;\
 &lt;&lt;set $lionwatchFinal = ($lionwatch1 + $lionwatch2 + $lionwatch3 + $lionwatch4+ $lionwatch5 + $lionwatch6 + $lionwatch7)&gt;&gt;
 With care, the wolf pries the door open just a little more so that he can slide his head inside to watch. &lt;&lt;print $name&gt;&gt;&#39;s erection grinds uncomfortably against the wooden door, reminding him of its presence, but he does his best to ignore it.
 
@@ -2018,16 +1963,16 @@ It doesn&#39;t seem like he&#39;s going to be going anywhere or doing anything d
 \
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-  	&lt;li&gt;[[Stop watching him and return to the hallway.|Second Floor]]&lt;/li&gt;
-	&lt;&lt;if $lionCutscene&gt;&gt;\
-	  &lt;li&gt;[[Approach the lion.|Lion Start]]&lt;/li&gt;
-	&lt;&lt;else&gt;&gt;\
-	  &lt;&lt;timed `$lionwatchFinal + &quot;s&quot;` t8n&gt;&gt;\
-	    &lt;li&gt;[[Approach the lion.|Lion Start]]&lt;/li&gt;
-	  &lt;&lt;/timed&gt;&gt;\
-	&lt;&lt;/if&gt;&gt;\
+      &lt;li&gt;[[Stop watching him and return to the hallway.|Second Floor]]&lt;/li&gt;
+    &lt;&lt;if $lionCutscene&gt;&gt;\
+      &lt;li&gt;[[Approach the lion.|Lion Start]]&lt;/li&gt;
+    &lt;&lt;else&gt;&gt;\
+      &lt;&lt;timed `$lionwatchFinal + &quot;s&quot;` t8n&gt;&gt;\
+        &lt;li&gt;[[Approach the lion.|Lion Start]]&lt;/li&gt;
+      &lt;&lt;/timed&gt;&gt;\
+    &lt;&lt;/if&gt;&gt;\
   &lt;/ul&gt;\
-&lt;/div&gt;\</tw-passagedata><tw-passagedata pid="75" name="Extraction Room" tags="" position="1410,788" size="100,100">&lt;&lt;if $extractionRoom&gt;&gt;\
+&lt;/div&gt;\</tw-passagedata><tw-passagedata pid="69" name="Extraction Room" tags="" position="525,3900" size="200,200">&lt;&lt;if $extractionRoom&gt;&gt;\
 There isn&#39;t much to see despite the room&#39;s size. The mysterious, numbered alcoves line up along the tall walls around the wolf, with most of them being closed.
 
 At the center, the altar with the gooey thing resting on it draws the most attention, with the desk full of books and writing supplies splayed all over it being the second most interesting thing.
@@ -2046,11 +1991,11 @@ A careful, more thorough investigation of the strange room could be helpful.
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-  	&lt;li&gt;[[Examine the desk.|The Desk]]&lt;/li&gt;
-	&lt;li&gt;[[Examine the altar.|The Altar]]&lt;/li&gt;
+      &lt;li&gt;[[Examine the desk.|The Desk]]&lt;/li&gt;
+    &lt;li&gt;[[Examine the altar.|The Altar]]&lt;/li&gt;
     &lt;li&gt;[[Go back to the hallway.|Second Floor]]&lt;/li&gt;
   &lt;/ul&gt;\
-&lt;/div&gt;</tw-passagedata><tw-passagedata pid="76" name="Lion Start" tags="" position="1266,1450" size="100,100">Frowning and taking a deep breath, the wolf has had enough observing and decides to approach the lion. One of his paws goes down to cover his hard cock as best as it can, but the wolf&#39;s ears remain up and his stance a wary one. The lion has the appearance of a warrior himself, and he&#39;s definitely not normal, so he doesn&#39;t know what to expect.
+&lt;/div&gt;</tw-passagedata><tw-passagedata pid="70" name="Lion Start" tags="" position="1075,3225" size="100,100">Frowning and taking a deep breath, the wolf has had enough observing and decides to approach the lion. One of his paws goes down to cover his hard cock as best as it can, but the wolf&#39;s ears remain up and his stance a wary one. The lion has the appearance of a warrior himself, and he&#39;s definitely not normal, so he doesn&#39;t know what to expect.
 
 Abandoning subtlety, the wolf opens the door and steps in. The sounds do cause the lion to turn his head towards the lupine, although his hands continue to grind herbs and his expression does not change, even as he sets his eyes on $name.
 
@@ -2062,10 +2007,10 @@ The question makes the wolf blink. At least the lion isn&#39;t showing any signs
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-  	&lt;li&gt;[[&#39;&quot;Uhh... Yes?&quot;&#39;|Lion Conversation]]&lt;/li&gt;
-	&lt;li&gt;[[&#39;&quot;I&#39;m looking for a way out...&quot;&#39;|Lion Conversation]]&lt;/li&gt;
+      &lt;li&gt;[[&#39;&quot;Uhh... Yes?&quot;&#39;|Lion Conversation]]&lt;/li&gt;
+    &lt;li&gt;[[&#39;&quot;I&#39;m looking for a way out...&quot;&#39;|Lion Conversation]]&lt;/li&gt;
   &lt;/ul&gt;\
-&lt;/div&gt;\</tw-passagedata><tw-passagedata pid="77" name="Lion Conversation" tags="" position="1219,1599" size="100,100">Before the wolf can even properly finish speaking, however, the lion interrupts him.
+&lt;/div&gt;\</tw-passagedata><tw-passagedata pid="71" name="Lion Conversation" tags="" position="1200,3225" size="100,100">Before the wolf can even properly finish speaking, however, the lion interrupts him.
 
 &quot;I am directed to provide the means for one to take their place. Wait here.&quot;
 
@@ -2109,14 +2054,14 @@ Apparently tired of waiting, the lion starts stepping forward, raising the penda
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-  	&lt;li&gt;[[Let the lion put the pendant on.|Mind Capture]]&lt;/li&gt;
-	&lt;li&gt;[[Refuse the pendant.|Lion Refusal]]&lt;/li&gt;
+      &lt;li&gt;[[Let the lion put the pendant on.|Mind Capture]]&lt;/li&gt;
+    &lt;li&gt;[[Refuse the pendant.|Lion Refusal]]&lt;/li&gt;
   &lt;/ul&gt;\
-&lt;/div&gt;\</tw-passagedata><tw-passagedata pid="78" name="Mind Capture" tags="" position="883,1849" size="100,100">&lt;&lt;include &quot;Mind Capture (Text)&quot;&gt;&gt;
+&lt;/div&gt;\</tw-passagedata><tw-passagedata pid="72" name="Mind Capture" tags="end" position="1325,3225" size="100,100">&lt;&lt;include &quot;Mind Capture (Text)&quot;&gt;&gt;
 
 &lt;span class=&quot;bad-ending&quot;&gt;Bad Ending: &lt;i&gt;Enthrallment&lt;/i&gt;&lt;/span&gt;
 
-[[Continue|Mind Capture 2]]</tw-passagedata><tw-passagedata pid="79" name="Lion Refusal" tags="" position="1294,1749" size="100,100">There&#39;s no way $name is letting this lion put some magic gadget on him without him knowing what it is, especially coming from someone like that panther.
+[[Continue|Mind Capture 2]]</tw-passagedata><tw-passagedata pid="73" name="Lion Refusal" tags="" position="1200,3350" size="100,100">There&#39;s no way $name is letting this lion put some magic gadget on him without him knowing what it is, especially coming from someone like that panther.
 
 With a growl, $name takes a step back and slaps the lion&#39;s hands to the side.
 
@@ -2138,9 +2083,9 @@ The wolf&#39;s eyes scan the room around him for weapons or ways to subdue the l
 
 After all, Ivex could still return at any minute or hear something if things get too loud...
 
-[[Continue|Lion Fight]]</tw-passagedata><tw-passagedata pid="80" name="Lion Fight" tags="" position="1320,1905" size="100,100">&lt;&lt;include &quot;Lion Fight (Text)&quot;&gt;&gt;
+[[Continue|Lion Fight]]</tw-passagedata><tw-passagedata pid="74" name="Lion Fight" tags="" position="1200,3475" size="100,100">&lt;&lt;include &quot;Lion Fight (Text)&quot;&gt;&gt;
 
-[[Continue|Lion Pindown]]</tw-passagedata><tw-passagedata pid="81" name="Lion Pindown" tags="" position="1352,2057" size="100,100">&lt;&lt;include &quot;Lion Pindown (Text)&quot;&gt;&gt;
+[[Continue|Lion Pindown]]</tw-passagedata><tw-passagedata pid="75" name="Lion Pindown" tags="" position="1200,3600" size="100,100">&lt;&lt;include &quot;Lion Pindown (Text)&quot;&gt;&gt;
 &lt;&lt;if $arousalLevel == 1&gt;&gt;\
 
 The candle&#39;s lingering influence... it must be that, but... It&#39;s so hard to resist. This damned lion, one of Ivex&#39;s thralls, gave him so much trouble. He&#39;s asking for it. Looking down at the feline&#39;s tender hole, the wolf&#39;s cock throbs. As he keeps squirming, the lion&#39;s backside gets matted with the lupine&#39;s pre-cum. $name huffs, his eyes growing wide with lust and desire. Maybe... Maybe he could...
@@ -2151,10 +2096,10 @@ The candle&#39;s lingering influence... it drives the wolf crazy, It&#39;s so ha
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-  	&lt;li&gt;[[Fight the urge. Tie the lion up and be done with it.|Lion Bondage]]&lt;/li&gt;
-	&lt;li&gt;[[The lion is a defeated thrall. Just a quick fuck to help relieve the urges...|Lion Fucking]]&lt;/li&gt;
+      &lt;li&gt;[[Fight the urge. Tie the lion up and be done with it.|Lion Bondage]]&lt;/li&gt;
+    &lt;li&gt;[[The lion is a defeated thrall. Just a quick fuck to help relieve the urges...|Lion Fucking]]&lt;/li&gt;
   &lt;/ul&gt;\
-&lt;/div&gt;\</tw-passagedata><tw-passagedata pid="82" name="Lion Bondage" tags="key" position="1602,1810" size="100,100">&lt;&lt;set $end07 = false&gt;&gt;\
+&lt;/div&gt;\</tw-passagedata><tw-passagedata pid="76" name="Lion Bondage" tags="key" position="1000,3800" size="100,100">&lt;&lt;set $end07 = false&gt;&gt;\
 Reaching for the rope, it is only a matter of holding the lion down while forcing his arms back to tie them behind his back. Once that is done, the wolf plays it safe by doing the same to his legs and finishing with the lion in a tight hogtie.
 
 Very satisfied with his work, the wolf smirks, looking down at the feline. He keeps struggling, not too intensely, but rather with a mild yet continuous amount of effort the whole time.
@@ -2192,7 +2137,7 @@ He is ready to try and craft the key to his escape.
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-  	[[Try and craft the red gemstone.|Gemstone Crafting]]
+      [[Try and craft the red gemstone.|Gemstone Crafting]]
   &lt;/ul&gt;\
 &lt;/div&gt;
 &lt;&lt;else&gt;&gt;\
@@ -2206,7 +2151,7 @@ All the wolf can do for now is return to the hallway and explore the rest of thi
 &lt;&lt;set $lionGemstoneKnowledge = true&gt;&gt;\
 
 [[Continue|Second Floor]]
-&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="83" name="Lion Fucking" tags="" position="1346,2260" size="100,100">&lt;&lt;include &quot;Lion Fucking (Text)&quot;&gt;&gt;
+&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="77" name="Lion Fucking" tags="" position="1350,3600" size="100,100">&lt;&lt;include &quot;Lion Fucking (Text)&quot;&gt;&gt;
 &lt;&lt;if $arousalLevel &gt;= 2&gt;&gt;\
 
 But there&#39;s no decision to be made. After being exposed to that candle for so long, the wolf&#39;s body is mad with arousal. He needs to knot, he &lt;b&gt;needs&lt;/b&gt; to, and with a huff of mad lust, he starts working towards it...
@@ -2215,12 +2160,12 @@ But there&#39;s no decision to be made. After being exposed to that candle for s
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
     &lt;&lt;if $arousalLevel &lt; 2&gt;&gt;\
-  	&lt;li&gt;[[Resist knotting him.|Lion Finish]]&lt;/li&gt;
-	&lt;&lt;else&gt;&gt;\
-	&lt;li&gt;[[Knot him!|Lion Knotting]]&lt;/li&gt;
-	&lt;&lt;/if&gt;&gt;\
+      &lt;li&gt;[[Resist knotting him.|Lion Finish]]&lt;/li&gt;
+    &lt;&lt;else&gt;&gt;\
+    &lt;li&gt;[[Knot him!|Lion Knotting]]&lt;/li&gt;
+    &lt;&lt;/if&gt;&gt;\
   &lt;/ul&gt;\
-&lt;/div&gt;\</tw-passagedata><tw-passagedata pid="84" name="Lion Finish" tags="" position="1630,2180" size="100,100">Gritting his teeth, it takes every ounce of effort from the wolf to, instead of shoving his knot into that damned lion hard as he wants to, reach down to his knot with his own paw and give it a hard squeeze.
+&lt;/div&gt;\</tw-passagedata><tw-passagedata pid="78" name="Lion Finish" tags="" position="1250,3750" size="100,100">Gritting his teeth, it takes every ounce of effort from the wolf to, instead of shoving his knot into that damned lion hard as he wants to, reach down to his knot with his own paw and give it a hard squeeze.
 
 $name moans out loud. That&#39;s what he needs, that&#39;s what any wolf needs, to drive him crazy and past the point of no return. With pleasure overcoming him, the wolf&#39;s cock throbs, shoved deep inside the lion save for the knot, to start depositing the wolf&#39;s mark deep into the other male.
 
@@ -2234,29 +2179,29 @@ But, no! He&#39;s wasted enough time as it is! Ivex could return at any time. Lo
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-  	&lt;li&gt;[[Tie the lion up and be done with it.|Lion Bondage]]&lt;/li&gt;
+      &lt;li&gt;[[Tie the lion up and be done with it.|Lion Bondage]]&lt;/li&gt;
   &lt;/ul&gt;\
-&lt;/div&gt;\</tw-passagedata><tw-passagedata pid="85" name="Lion Knotting" tags="" position="1116,2199" size="100,100">&lt;&lt;if !$enthrallmentLion&gt;&gt;\
+&lt;/div&gt;\</tw-passagedata><tw-passagedata pid="79" name="Lion Knotting" tags="" position="1475,3600" size="100,100">&lt;&lt;if !$enthrallmentLion&gt;&gt;\
 &lt;&lt;set $enthrallmentLionUnlock = true&gt;&gt;\
 &lt;&lt;/if&gt;&gt;\
 &lt;&lt;include &quot;Lion Knotting (Text)&quot;&gt;&gt;
 
-[[Continue|Mind Capture (Knot)]]</tw-passagedata><tw-passagedata pid="86" name="Mind Capture (Knot)" tags="" position="1109,1912" size="100,100">&lt;&lt;include &quot;Mind Capture (Knot) (Text)&quot;&gt;&gt;
+[[Continue|Mind Capture (Knot)]]</tw-passagedata><tw-passagedata pid="80" name="Mind Capture (Knot)" tags="" position="1600,3600" size="100,100">&lt;&lt;include &quot;Mind Capture (Knot) (Text)&quot;&gt;&gt;
 
 &lt;span class=&quot;bad-ending&quot;&gt;Bad Ending: &lt;i&gt;Enthrallment&lt;/i&gt;&lt;/span&gt;
 
-[[Continue|Mind Capture 2]]</tw-passagedata><tw-passagedata pid="87" name="Mind Capture 2" tags="" position="986,2045" size="100,100">&lt;&lt;include &quot;Mind Capture 2 (Text)&quot;&gt;&gt;
+[[Continue|Mind Capture 2]]</tw-passagedata><tw-passagedata pid="81" name="Mind Capture 2" tags="" position="1450,3225" size="100,100">&lt;&lt;include &quot;Mind Capture 2 (Text)&quot;&gt;&gt;
 
-[[Continue|Enthrallment 1]]</tw-passagedata><tw-passagedata pid="88" name="Enthrallment 1" tags="" position="886,2199" size="100,100">&lt;&lt;include &quot;Enthrallment 1 (Text)&quot;&gt;&gt;
+[[Continue|Enthrallment 1]]</tw-passagedata><tw-passagedata pid="82" name="Enthrallment 1" tags="" position="1575,3225" size="100,100">&lt;&lt;include &quot;Enthrallment 1 (Text)&quot;&gt;&gt;
 
-[[Continue|Enthrallment 2]]</tw-passagedata><tw-passagedata pid="89" name="Enthrallment 2" tags="" position="749,2028" size="100,100">&lt;&lt;if !$enthrallmentEnding&gt;&gt;\
+[[Continue|Enthrallment 2]]</tw-passagedata><tw-passagedata pid="83" name="Enthrallment 2" tags="" position="1700,3225" size="100,100">&lt;&lt;if !$enthrallmentEnding&gt;&gt;\
 &lt;&lt;set $enthrallmentEndingUnlock = true&gt;&gt;\
 &lt;&lt;/if&gt;&gt;\
 &lt;&lt;include &quot;Enthrallment 2 (Text)&quot;&gt;&gt;
 
 &lt;span class=&quot;bad-ending&quot;&gt;Bad Ending: &lt;i&gt;Enthrallment&lt;/i&gt;&lt;/span&gt;
 
-[[Continue|Enthrallment End]]</tw-passagedata><tw-passagedata pid="90" name="Enthrallment End" tags="" position="697,1731" size="100,100">$name became Ivex&#39;s thrall.
+[[Continue|Enthrallment End]]</tw-passagedata><tw-passagedata pid="84" name="Enthrallment End" tags="end" position="1800,2875" size="100,100">$name became Ivex&#39;s thrall.
 
 &lt;&lt;if $enthrallmentEndingUnlock&gt;&gt;\
 &lt;&lt;set $enthrallmentEnding = true&gt;&gt;\
@@ -2273,30 +2218,10 @@ To change the adventurer&#39;s fate, you can...
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\  
-  	&lt;li&gt;[[Return to the point of escaping the first floor.|Escape Start]]&lt;/li&gt;
-  	&lt;li&gt;[[Return to the beginning of the game.|Title Screen]]&lt;/li&gt;
+      &lt;li&gt;[[Return to the point of escaping the first floor.|Escape Start]]&lt;/li&gt;
+      &lt;li&gt;[[Return to the beginning of the game.|Title Screen]]&lt;/li&gt;
   &lt;/ul&gt;\
-&lt;/div&gt;</tw-passagedata><tw-passagedata pid="91" name="To Be Continued 2" tags="" position="1104,1252" size="100,100">&lt;b&gt;Aaaand... that&#39;s it, again!&lt;/b&gt;
-
-You&#39;ve reached the end of this version! Unfortunately, in order to see what lies beyond the other door and finally escape this tower once and for all, you&#39;ll need to wait a bit longer. The next version will get you closer to the end!
-
-For now, however, just as before, I encourage you to try some new things if you haven&#39;t yet. Choose different options, see what happens...
-
-Starting from this enhanced build, you can check out the [[Archives]] (also always available in the sidebar menu) and see what you have unlocked and what&#39;s still left to be unlocked! Not only that, but in there, you&#39;ll have the ability to easily read through any endings you have already unlocked as many times as you want without having to go through the entire game to reach them. I hope you enjoy it!
-
-Overall, though, thank you so much for playing this prototype interactive story. If you wanna see more ASAP, my &lt;a target=&quot;_blank&quot; href=&quot;https://www.patreon.com/sleth&quot;&gt;patreon&lt;/a&gt; is one build ahead of the public release with more content! They&#39;ll also get a poll that will influence one of the endings... ;)
-
-It&#39;s thanks to their awesome support that I can keep working on my passion for writing!
-
-Regardless of supporting me with $$ or not, thank you so much for playing! If you&#39;d like, leave a comment about the game or something and I&#39;ll gladly read it and take it to heart as well.
-
-From here, you can...
-
-[[Return to the start of the second floor|Escape Start]]
-
-OR!
-
-[[Return all the way to the beginning|Bound]]</tw-passagedata><tw-passagedata pid="92" name="Archives" tags="noreturn" position="331,2607" size="100,100">[[Return to the game|$return]]
+&lt;/div&gt;</tw-passagedata><tw-passagedata pid="85" name="Archives" tags="noreturn" position="2400,700" size="100,100">&lt;&lt;link &quot;Return to the game&quot; $return&gt;&gt;&lt;&lt;/link&gt;&gt;\
 
 &lt;h1&gt;Archives&lt;/h1&gt;
 Welcome to the Mage&#39;s Tower Archives.
@@ -2308,17 +2233,17 @@ Grayed out endings are paths that have not yet been found, although there are hi
 
 &lt;hr&gt;
 &lt;h2&gt;Endings unlocked:&lt;/h2&gt;
-&lt;&lt;include &quot;Interrogation Archive Display&quot;&gt;&gt;
+&lt;&lt;include [[Interrogation Archive Display]]&gt;&gt;
 
-&lt;&lt;include &quot;Enthrallment Archive Display&quot;&gt;&gt;
+&lt;&lt;include [[Enthrallment Archive Display]]&gt;&gt;
 
-&lt;&lt;include &quot;Extraction Archive Display&quot;&gt;&gt;
+&lt;&lt;include [[Extraction Archive Display]]&gt;&gt;
 
-&lt;&lt;include &quot;Ivex Punishment Archive Display&quot;&gt;&gt;
+&lt;&lt;include [[Ivex Punishment Archive Display]]&gt;&gt;
 
-&lt;&lt;include &quot;Ivex Enthrallment Archive Display&quot;&gt;&gt;
+&lt;&lt;include [[Ivex Enthrallment Archive Display]]&gt;&gt;
 
-&lt;&lt;include &quot;Ivex Extraction Archive Display&quot;&gt;&gt;</tw-passagedata><tw-passagedata pid="93" name="The Desk" tags="" position="1535,637" size="100,100">&lt;&lt;if $theDesk&gt;&gt;\
+&lt;&lt;include [[Ivex Extraction Archive Display]]&gt;&gt;</tw-passagedata><tw-passagedata pid="86" name="The Desk" tags="" position="900,4350" size="100,100">&lt;&lt;if $theDesk&gt;&gt;\
 The only interesting things the wolf can see on the desk are the &lt;span class=&quot;imp-info&quot;&gt;thick book&lt;/span&gt; and the &lt;span class=&quot;imp-info&quot;&gt;journal&lt;/span&gt;.
 &lt;&lt;else&gt;&gt;\
 &lt;&lt;set $theDesk = true&gt;&gt;\
@@ -2337,17 +2262,17 @@ If they belong to Ivex, they might be worth checking out.
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-	&lt;&lt;if !$theJournal&gt;&gt;\
-	&lt;li&gt;[[Examine the journal.|The Journal]]&lt;/li&gt;
-	&lt;&lt;else&gt;&gt;\
-	&lt;li&gt;[[Examine the journal again.|Journal Notes]]&lt;/li&gt;
-	&lt;&lt;/if&gt;&gt;\
+    &lt;&lt;if !$theJournal&gt;&gt;\
+    &lt;li&gt;[[Examine the journal.|The Journal]]&lt;/li&gt;
+    &lt;&lt;else&gt;&gt;\
+    &lt;li&gt;[[Examine the journal again.|Journal Notes]]&lt;/li&gt;
+    &lt;&lt;/if&gt;&gt;\
     &lt;&lt;if !$spellbookKnowledge&gt;&gt;\
-  	&lt;li&gt;[[Examine the large book.|The Spellbook]]&lt;/li&gt;
-	&lt;&lt;/if&gt;&gt;\	
-	&lt;li&gt;[[Go try something else.|Extraction Room]]&lt;/li&gt;
+      &lt;li&gt;[[Examine the large book.|The Spellbook]]&lt;/li&gt;
+    &lt;&lt;/if&gt;&gt;\	
+    &lt;li&gt;[[Go try something else.|Extraction Room]]&lt;/li&gt;
   &lt;/ul&gt;\
-&lt;/div&gt;</tw-passagedata><tw-passagedata pid="94" name="The Altar" tags="" position="1307,618" size="100,100">&lt;&lt;if $thePlatform&gt;&gt;\
+&lt;/div&gt;</tw-passagedata><tw-passagedata pid="87" name="The Altar" tags="" position="800,4000" size="100,100">&lt;&lt;if $thePlatform&gt;&gt;\
 $name approaches the altar at the center of the room to take a closer look once more.
 
 The strange blob rests over the altar as before, unmoving. Inside it, the red glowing gemstone still floats harmlessly near the altar&#39;s surface.
@@ -2379,58 +2304,58 @@ Still, it looks absolutely harmless.
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-  	&lt;li&gt;[[Touch the substance.|Pulled In]]&lt;/li&gt;
-	&lt;li&gt;[[Go back to try something else.|Extraction Room]]&lt;/li&gt;
+      &lt;li&gt;[[Touch the substance.|Pulled In]]&lt;/li&gt;
+    &lt;li&gt;[[Go back to try something else.|Extraction Room]]&lt;/li&gt;
   &lt;/ul&gt;\
-&lt;/div&gt;</tw-passagedata><tw-passagedata pid="95" name="Pulled In" tags="" position="1208,491" size="100,100">&lt;&lt;include &quot;Pulled In (Text)&quot;&gt;&gt;
+&lt;/div&gt;</tw-passagedata><tw-passagedata pid="88" name="Pulled In" tags="" position="925,4000" size="100,100">&lt;&lt;include &quot;Pulled In (Text)&quot;&gt;&gt;
 
-[[Continue|Pulled Further]]</tw-passagedata><tw-passagedata pid="96" name="Pulled Further" tags="" position="1455,465" size="100,100">&lt;&lt;include &quot;Pulled Further (Text)&quot;&gt;&gt;
+[[Continue|Pulled Further]]</tw-passagedata><tw-passagedata pid="89" name="Pulled Further" tags="end" position="1050,4000" size="100,100">&lt;&lt;include &quot;Pulled Further (Text)&quot;&gt;&gt;
 
 &lt;span class=&quot;bad-ending&quot;&gt;Bad Ending: &lt;i&gt;Extraction&lt;/i&gt;&lt;/span&gt;
 
-[[Continue|Extraction 1]]</tw-passagedata><tw-passagedata pid="97" name="Extraction 1" tags="" position="1321,235" size="100,100">&lt;&lt;include &quot;Extraction 1 (Text)&quot;&gt;&gt;
+[[Continue|Extraction 1]]</tw-passagedata><tw-passagedata pid="90" name="Extraction 1" tags="" position="1175,4000" size="100,100">&lt;&lt;include &quot;Extraction 1 (Text)&quot;&gt;&gt;
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-  	&lt;li&gt;[[&quot;Hmmfgh!!&quot;|Extraction 2]]&lt;/li&gt;
-	&lt;li&gt;[[&quot;Hmmfffhhg?!&quot;|Extraction 2]]&lt;/li&gt;
+      &lt;li&gt;[[&quot;Hmmfgh!!&quot;|Extraction 2]]&lt;/li&gt;
+    &lt;li&gt;[[&quot;Hmmfffhhg?!&quot;|Extraction 2]]&lt;/li&gt;
   &lt;/ul&gt;\
-&lt;/div&gt;</tw-passagedata><tw-passagedata pid="98" name="Extraction 2" tags="" position="1187,146" size="100,100">&lt;&lt;include &quot;Extraction 2 (Text)&quot;&gt;&gt;
+&lt;/div&gt;</tw-passagedata><tw-passagedata pid="91" name="Extraction 2" tags="" position="1300,4000" size="100,100">&lt;&lt;include &quot;Extraction 2 (Text)&quot;&gt;&gt;
 
-[[Continue|Extraction 3]]</tw-passagedata><tw-passagedata pid="99" name="Extraction 3" tags="" position="1361,32" size="100,100">&lt;&lt;include &quot;Extraction 3 (Text)&quot;&gt;&gt;
+[[Continue|Extraction 3]]</tw-passagedata><tw-passagedata pid="92" name="Extraction 3" tags="" position="1425,4000" size="100,100">&lt;&lt;include &quot;Extraction 3 (Text)&quot;&gt;&gt;
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-  	&lt;li&gt;[[&quot;Hmmrrrrhfgh!!!&quot;|Forceful Extraction 1]]&lt;/li&gt;
-	&lt;li&gt;[[&quot;Hmmmffh...&quot;|Gentle Extraction 1]]&lt;/li&gt;
+      &lt;li&gt;[[&quot;Hmmrrrrhfgh!!!&quot;|Forceful Extraction 1]]&lt;/li&gt;
+    &lt;li&gt;[[&quot;Hmmmffh...&quot;|Gentle Extraction 1]]&lt;/li&gt;
   &lt;/ul&gt;\
-&lt;/div&gt;</tw-passagedata><tw-passagedata pid="100" name="Forceful Extraction 1" tags="" position="1535,219" size="100,100">&lt;&lt;set $forcefulExtraction = true&gt;&gt;\
+&lt;/div&gt;</tw-passagedata><tw-passagedata pid="93" name="Forceful Extraction 1" tags="" position="1550,4050" size="100,100">&lt;&lt;set $forcefulExtraction = true&gt;&gt;\
 &lt;&lt;include &quot;Forceful Extraction 1 (Text)&quot;&gt;&gt;
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-  	&lt;li&gt;[[&quot;HMMRFGH!!!&quot;|Forceful Extraction 2]]&lt;/li&gt;
+      &lt;li&gt;[[&quot;HMMRFGH!!!&quot;|Forceful Extraction 2]]&lt;/li&gt;
   &lt;/ul&gt;\
-&lt;/div&gt;</tw-passagedata><tw-passagedata pid="101" name="Gentle Extraction 1" tags="" position="1534,0" size="100,100">&lt;&lt;set $forcefulExtraction = false&gt;&gt;\
+&lt;/div&gt;</tw-passagedata><tw-passagedata pid="94" name="Gentle Extraction 1" tags="" position="1550,3925" size="100,100">&lt;&lt;set $forcefulExtraction = false&gt;&gt;\
 &lt;&lt;include &quot;Gentle Extraction 1 (Text)&quot;&gt;&gt;
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-  	&lt;li&gt;[[&quot;Hmmmmfffgghh...!&quot;|Gentle Extraction 2]]&lt;/li&gt;
+      &lt;li&gt;[[&quot;Hmmmmfffgghh...!&quot;|Gentle Extraction 2]]&lt;/li&gt;
   &lt;/ul&gt;\
-&lt;/div&gt;</tw-passagedata><tw-passagedata pid="102" name="Forceful Extraction 2" tags="" position="1672,220" size="100,100">&lt;&lt;include &quot;Forceful Extraction 2 (Text)&quot;&gt;&gt;
+&lt;/div&gt;</tw-passagedata><tw-passagedata pid="95" name="Forceful Extraction 2" tags="" position="1675,4050" size="100,100">&lt;&lt;include &quot;Forceful Extraction 2 (Text)&quot;&gt;&gt;
 
-[[Continue|Forceful Extraction 3]]</tw-passagedata><tw-passagedata pid="103" name="Forceful Extraction 3" tags="" position="1797,222" size="100,100">&lt;&lt;include &quot;Forceful Extraction 3 (Text)&quot;&gt;&gt;
+[[Continue|Forceful Extraction 3]]</tw-passagedata><tw-passagedata pid="96" name="Forceful Extraction 3" tags="" position="1800,4050" size="100,100">&lt;&lt;include &quot;Forceful Extraction 3 (Text)&quot;&gt;&gt;
 
-[[Continue|Forceful Extraction End]]</tw-passagedata><tw-passagedata pid="104" name="Forceful Extraction End" tags="" position="1922,222" size="100,100">&lt;&lt;include &quot;Forceful Extraction End (Text)&quot;&gt;&gt;
+[[Continue|Forceful Extraction End]]</tw-passagedata><tw-passagedata pid="97" name="Forceful Extraction End" tags="" position="1925,4050" size="100,100">&lt;&lt;include &quot;Forceful Extraction End (Text)&quot;&gt;&gt;
 
-[[Continue|Extraction End 1]]</tw-passagedata><tw-passagedata pid="105" name="Extraction End 1" tags="" position="2058,76" size="100,100">&lt;&lt;include &quot;Extraction End 1 (Text)&quot;&gt;&gt;
+[[Continue|Extraction End 1]]</tw-passagedata><tw-passagedata pid="98" name="Extraction End 1" tags="" position="2050,3975" size="100,100">&lt;&lt;include &quot;Extraction End 1 (Text)&quot;&gt;&gt;
 
 &lt;&lt;if $forcefulExtraction&gt;&gt;\
 [[Continue|Forceful Extraction End 2]]
 &lt;&lt;else&gt;&gt;\
 [[Continue|Gentle Extraction End 2]]
-&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="106" name="Forceful Extraction End 2" tags="" position="2195,239" size="100,100">&lt;&lt;if !$extractionEnding&gt;&gt;\
+&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="99" name="Forceful Extraction End 2" tags="" position="2175,4050" size="100,100">&lt;&lt;if !$extractionEnding&gt;&gt;\
 &lt;&lt;set $extractionEndingUnlock = true&gt;&gt;\
 &lt;&lt;/if&gt;&gt;\
 &lt;&lt;if !$extractionForcefulEnd&gt;&gt;\
@@ -2439,7 +2364,7 @@ Still, it looks absolutely harmless.
 
 &lt;&lt;include &quot;Forceful Extraction End 2 (Text)&quot;&gt;&gt;
 
-[[Continue|Extraction End 2]]</tw-passagedata><tw-passagedata pid="107" name="Extraction End 2" tags="" position="2342,85" size="100,100">$name remained trapped serving as fuel for Ivex&#39;s magic.
+[[Continue|Extraction End 2]]</tw-passagedata><tw-passagedata pid="100" name="Extraction End 2" tags="end" position="2525,3575" size="100,100">$name remained trapped serving as fuel for Ivex&#39;s magic.
 
 &lt;&lt;if $extractionEndingUnlock&gt;&gt;\
 &lt;&lt;set $extractionEnding = true&gt;&gt;\
@@ -2461,10 +2386,10 @@ To change the adventurer&#39;s fate, you can...
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\  
-  	&lt;li&gt;[[Return to the point of escaping the first floor.|Escape Start]]&lt;/li&gt;
-  	&lt;li&gt;[[Return to the beginning of the game.|Title Screen]]&lt;/li&gt;
+      &lt;li&gt;[[Return to the point of escaping the first floor.|Escape Start]]&lt;/li&gt;
+      &lt;li&gt;[[Return to the beginning of the game.|Title Screen]]&lt;/li&gt;
   &lt;/ul&gt;\
-&lt;/div&gt;</tw-passagedata><tw-passagedata pid="108" name="Gentle Extraction End 2" tags="" position="2197,1" size="100,100">&lt;&lt;if !$extractionEnding&gt;&gt;\
+&lt;/div&gt;</tw-passagedata><tw-passagedata pid="101" name="Gentle Extraction End 2" tags="" position="2175,3925" size="100,100">&lt;&lt;if !$extractionEnding&gt;&gt;\
 &lt;&lt;set $extractionEndingUnlock = true&gt;&gt;\
 &lt;&lt;/if&gt;&gt;\
 &lt;&lt;if !$extractionGentleEnd&gt;&gt;\
@@ -2473,13 +2398,13 @@ To change the adventurer&#39;s fate, you can...
 
 &lt;&lt;include &quot;Gentle Extraction End 2 (Text)&quot;&gt;&gt;
 
-[[Continue|Extraction End 2]]</tw-passagedata><tw-passagedata pid="109" name="Gentle Extraction 2" tags="" position="1674,0" size="100,100">&lt;&lt;include &quot;Gentle Extraction 2 (Text)&quot;&gt;&gt;
+[[Continue|Extraction End 2]]</tw-passagedata><tw-passagedata pid="102" name="Gentle Extraction 2" tags="" position="1675,3925" size="100,100">&lt;&lt;include &quot;Gentle Extraction 2 (Text)&quot;&gt;&gt;
 
-[[Continue|Gentle Extraction 3]]</tw-passagedata><tw-passagedata pid="110" name="Gentle Extraction 3" tags="" position="1801,0" size="100,100">&lt;&lt;include &quot;Gentle Extraction 3 (Text)&quot;&gt;&gt;
+[[Continue|Gentle Extraction 3]]</tw-passagedata><tw-passagedata pid="103" name="Gentle Extraction 3" tags="" position="1800,3925" size="100,100">&lt;&lt;include &quot;Gentle Extraction 3 (Text)&quot;&gt;&gt;
 
-[[Continue|Gentle Extraction End]]</tw-passagedata><tw-passagedata pid="111" name="Gentle Extraction End" tags="" position="1926,1" size="100,100">&lt;&lt;include &quot;Gentle Extraction End (Text)&quot;&gt;&gt;
+[[Continue|Gentle Extraction End]]</tw-passagedata><tw-passagedata pid="104" name="Gentle Extraction End" tags="" position="1925,3925" size="100,100">&lt;&lt;include &quot;Gentle Extraction End (Text)&quot;&gt;&gt;
 
-[[Continue|Extraction End 1]]</tw-passagedata><tw-passagedata pid="112" name="Interrogation Archive" tags="noreturn" position="471,2696" size="100,100">&lt;&lt;include &quot;Ivex Torture 1 (Text)&quot;&gt;&gt;
+[[Continue|Extraction End 1]]</tw-passagedata><tw-passagedata pid="105" name="Interrogation Archive" tags="noreturn" position="1700,1100" size="100,100">&lt;&lt;include &quot;Ivex Torture 1 (Text)&quot;&gt;&gt;
 
 &lt;&lt;include &quot;Ivex Torture 2 (Text)&quot;&gt;&gt;
 
@@ -2533,7 +2458,7 @@ The wolf chooses to remain silent with nothing but a low growl towards the mage.
 
 &lt;span class=&quot;bad-ending&quot;&gt;Bad Ending: &lt;i&gt;Interrogation&lt;/i&gt;&lt;/span&gt;
 
-[[Return to the Archives|Archives]]</tw-passagedata><tw-passagedata pid="113" name="Ivex Torture 1 (Text)" tags="text" position="311,1198" size="100,100">The mage hums to himself as he takes the time to casually walk around the wolf, observing him from all sides. $name can&#39;t help but keep desperately pulling against the restraints. The wolf&#39;s cock flexes, dripping pre-cum almost constantly now from the overwhelming arousal he&#39;s subjected to.
+[[Return to the Archives|Archives]]</tw-passagedata><tw-passagedata pid="106" name="Ivex Torture 1 (Text)" tags="text" position="1100,1925" size="100,100">The mage hums to himself as he takes the time to casually walk around the wolf, observing him from all sides. $name can&#39;t help but keep desperately pulling against the restraints. The wolf&#39;s cock flexes, dripping pre-cum almost constantly now from the overwhelming arousal he&#39;s subjected to.
 
 &quot;Look at you... barely more than a feral beast now, slave to your baser instincts...&quot; the mage mocked. &quot;What would your fellow adventurers say if they could see you now? Bound, drooling, wanting to get out just so that you can pleasure yourself relentlessly...&quot;
 
@@ -2551,7 +2476,7 @@ At least the wolf has enough awareness back to know he won&#39;t be able, to whi
 
 Ivex pulls the cloth covering his nose down as well to reveal his large grin.
 
-&quot;Now that you&#39;re back with me... shall we begin?&quot;</tw-passagedata><tw-passagedata pid="114" name="Ivex Torture 2 (Text)" tags="text" position="310,1342" size="100,100">The mage brings both his hands up. A few precise movements are made and $name can see the panther&#39;s eyes glow for a moment. Ivex mutters some words under his breath and then the creaking sound of a chest opening comes from behind the bound wolf. From there, a small crystal comes floating to Ivex with remarkable speed, which he promptly catches with ease and holds up.
+&quot;Now that you&#39;re back with me... shall we begin?&quot;</tw-passagedata><tw-passagedata pid="107" name="Ivex Torture 2 (Text)" tags="text" position="1225,1925" size="100,100">The mage brings both his hands up. A few precise movements are made and $name can see the panther&#39;s eyes glow for a moment. Ivex mutters some words under his breath and then the creaking sound of a chest opening comes from behind the bound wolf. From there, a small crystal comes floating to Ivex with remarkable speed, which he promptly catches with ease and holds up.
 
 &quot;This is a gravity crystal. Handy things, those are. You can bind their energy and attach them to anything. They have many practical uses, but I&#39;m going to show you one of my favorites.&quot; Ivex took a step forward.
 
@@ -2575,7 +2500,7 @@ As soon as he does, the crystal starts falling, but instead of falling all the w
 
 Ivex chuckles in a way of mocking. &quot;See how utterly helpless you are before me? And this is just the beginning. You will tell me everything I want to know and more.&quot; The panther went back to grinning. &quot;Now, little wolf, are we doing this the easy way or the hard way?&quot;
 
-The weight on the wolf&#39;s balls feels heavy. It tugs at them uncomfortably and, even though it has only been a few seconds, it already starts to feel a little painful to hold the crystal with his nuts alone. Ivex stares at the wolf with a cocky smile of superiority waiting for his answer.</tw-passagedata><tw-passagedata pid="115" name="Easy Way (Text)" tags="text" position="168,1482" size="100,100">&quot;Learning your place I see...&quot; the mage smiles. Even though the wolf says nothing, Ivex seems smart enough to pick up the hesitation in body language.
+The weight on the wolf&#39;s balls feels heavy. It tugs at them uncomfortably and, even though it has only been a few seconds, it already starts to feel a little painful to hold the crystal with his nuts alone. Ivex stares at the wolf with a cocky smile of superiority waiting for his answer.</tw-passagedata><tw-passagedata pid="108" name="Easy Way (Text)" tags="text" position="1375,1875" size="100,100">&quot;Learning your place I see...&quot; the mage smiles. Even though the wolf says nothing, Ivex seems smart enough to pick up the hesitation in body language.
 
 The panther leans in close, his hand coming to the wolf&#39;s leg to caress it. $name can&#39;t help but draw in a sharp breath as just the caressing near his needy cock is enough to make the wolf&#39;s heartbeat accelerate.
 
@@ -2589,7 +2514,7 @@ It gets even worse when Ivex starts massaging it ever so lightly with his finger
 
 &quot;I know the adventurer&#39;s guild sent you. What do they have on me?&quot;
 
-A vague question. The wolf&#39;s knowledge is limited, but any details he tells Ivex could put the Adventurer&#39;s guild or whoever else they send after Ivex in the same danger he is facing. Betraying his comrades is something the wolf would never do, and just the fact that Ivex believes he would is an offense in itself.</tw-passagedata><tw-passagedata pid="116" name="Hard Way (Text)" tags="text" position="446,1481" size="100,100">&quot;Aahh... still so full of fire, aren&#39;t you? Even knowing how small you are next to me?&quot; Ivex says with his usual lingering smile of amusement. &quot;I suppose it&#39;s only fair. I haven&#39;t even begun to show you what I can do to you.&quot;
+A vague question. The wolf&#39;s knowledge is limited, but any details he tells Ivex could put the Adventurer&#39;s guild or whoever else they send after Ivex in the same danger he is facing. Betraying his comrades is something the wolf would never do, and just the fact that Ivex believes he would is an offense in itself.</tw-passagedata><tw-passagedata pid="109" name="Hard Way (Text)" tags="text" position="1375,2200" size="100,100">&quot;Aahh... still so full of fire, aren&#39;t you? Even knowing how small you are next to me?&quot; Ivex says with his usual lingering smile of amusement. &quot;I suppose it&#39;s only fair. I haven&#39;t even begun to show you what I can do to you.&quot;
 
 &lt;&lt;print $name&gt;&gt;&#39;s growling continues. &quot;You wouldn&#39;t stand a fucking chance against a warrior like me if it weren&#39;t for your magic tricks!&quot;
 
@@ -2611,7 +2536,7 @@ It gets even worse when Ivex starts massaging it ever so lightly with his finger
 
 &quot;I know the adventurer&#39;s guild sent you. What do they have on me?&quot;
 
-A vague question. The wolf&#39;s knowledge is limited, but any details he tells Ivex could put the Adventurer&#39;s guild or whoever else they send after Ivex in the same danger he is facing. Betraying his comrades is something the wolf would never do.</tw-passagedata><tw-passagedata pid="117" name="Resistance (Text)" tags="text" position="222,1615" size="100,100">&quot;Not willing to tell me, hmm? A shame... such a shame...&quot; Ivex speaks with obviously fake disappointment. In fact, he smiles, the panther&#39;s tail swishing back and forth lazily as a sign of worrying satisfaction and amusement.
+A vague question. The wolf&#39;s knowledge is limited, but any details he tells Ivex could put the Adventurer&#39;s guild or whoever else they send after Ivex in the same danger he is facing. Betraying his comrades is something the wolf would never do.</tw-passagedata><tw-passagedata pid="110" name="Resistance (Text)" tags="text" position="1525,2200" size="100,100">&quot;Not willing to tell me, hmm? A shame... such a shame...&quot; Ivex speaks with obviously fake disappointment. In fact, he smiles, the panther&#39;s tail swishing back and forth lazily as a sign of worrying satisfaction and amusement.
 
 $name decides to remain quiet. It is hard enough to endure the weight on his balls on one side and the urge to let out sounds of pleasure as Ivex&#39;s fingers still continue to tease his oversensitive cock. If only that cursed arousal would go away! Looking down at his member, hard as a rock and leaking, a small wave of shame comes over the wolf, but this is all the sick mage&#39;s doing, $name tells himself. Only his doing...
 
@@ -2629,7 +2554,7 @@ It bothers him. Another male is touching his cock just like that and there is no
 
 The light touch is not enough to satisfy the wolf&#39;s urges, not nearly enough, but it does quickly build up his need. More pre-cum comes. $name does his best not to let Ivex have the pleasure of seeing how much it affects him, but he suspects the mage knows. He knows and is stroking his cock slowly on purpose. The fucker...
 
-&quot;So? Do you like the cold or not? Answer me or I&#39;ll make my own assumptions...&quot; he grins once more.</tw-passagedata><tw-passagedata pid="118" name="Defiance (Text)" tags="text" position="490,1617" size="100,100">$name spits at the mage to give his response. The panther is fast enough to take a quick step back so that the spit, at best, splashes at his footpaws.
+&quot;So? Do you like the cold or not? Answer me or I&#39;ll make my own assumptions...&quot; he grins once more.</tw-passagedata><tw-passagedata pid="111" name="Defiance (Text)" tags="text" position="1525,1875" size="100,100">$name spits at the mage to give his response. The panther is fast enough to take a quick step back so that the spit, at best, splashes at his footpaws.
 
 The mage&#39;s smile fades immediately.
 
@@ -2663,7 +2588,7 @@ It bothers him. Another male is touching his cock just like that and there is no
 
 The light touch is not enough to satisfy the wolf, not nearly enough, but it does quickly build up his need. More pre-cum comes. $name does his best not to let Ivex have the pleasure of seeing how much it affects him, but he suspects the mage knows. He knows and is stroking his cock slowly on purpose. The fucker...
 
-&quot;So? Do you like the cold or not? Answer me or I&#39;ll make my own assumptions...&quot; he grins once more.</tw-passagedata><tw-passagedata pid="119" name="Shock (Text)" tags="text" position="549,1788" size="100,100">With a chuckle, the panther comes even closer. $name grows stiff and growls seeing the panther leaning against him. With the wolf bound and spread as he is, Ivex has full freedom to press his side against the wolf&#39;s, going as far as leaning his head to rest it against &lt;&lt;print $name&gt;&gt;&#39;s broad chest. The panther&#39;s hand never leaves the wolf&#39;s cock, continuing to stroke and tease it in its way too slow manner, but the mage&#39;s other hand comes to caress the exposed fur of the wolf&#39;s chest.
+&quot;So? Do you like the cold or not? Answer me or I&#39;ll make my own assumptions...&quot; he grins once more.</tw-passagedata><tw-passagedata pid="112" name="Shock (Text)" tags="text" position="1675,1800" size="100,100">With a chuckle, the panther comes even closer. $name grows stiff and growls seeing the panther leaning against him. With the wolf bound and spread as he is, Ivex has full freedom to press his side against the wolf&#39;s, going as far as leaning his head to rest it against &lt;&lt;print $name&gt;&gt;&#39;s broad chest. The panther&#39;s hand never leaves the wolf&#39;s cock, continuing to stroke and tease it in its way too slow manner, but the mage&#39;s other hand comes to caress the exposed fur of the wolf&#39;s chest.
 
 &quot;Such a big specimen... the big ones are my favorite. Wolves, even more. I wonder what sounds you&#39;ll make...&quot;
 
@@ -2687,7 +2612,7 @@ The shock feels much, much worse when applied to the wolf&#39;s sensitive nipple
 
 $name breathes a small sigh of relief.
 
-Yet Ivex grins again. &quot;Time to have fun with you.&quot;</tw-passagedata><tw-passagedata pid="120" name="Shock 2 (Text)" tags="text" position="499,1933" size="100,100">The panther&#39;s eyes move back to the wolf&#39;s cock. That hand never stopped teasing it, much to the wolf&#39;s dismay, and the weight on his balls never went away either. Yet, still, as Ivex chuckles again, his hand speeds up. The stroking gets faster. The panther&#39;s hand skillfully strokes and teases the whole of the wolf&#39;s exposed length, going all the way down to the knot, toying with it to make him gasp, then moving back to the dripping tip. He does it a few times, furthering the wolf&#39;s pleasure, and soon $name is panting. The candle did too much. His balls churn and the weight feels more uncomfortable than ever. $name feels like he could cum ten times in a row and one of them is already coming with just that bit of stimulation... until Ivex grins.
+Yet Ivex grins again. &quot;Time to have fun with you.&quot;</tw-passagedata><tw-passagedata pid="113" name="Shock 2 (Text)" tags="text" position="1800,1800" size="100,100">The panther&#39;s eyes move back to the wolf&#39;s cock. That hand never stopped teasing it, much to the wolf&#39;s dismay, and the weight on his balls never went away either. Yet, still, as Ivex chuckles again, his hand speeds up. The stroking gets faster. The panther&#39;s hand skillfully strokes and teases the whole of the wolf&#39;s exposed length, going all the way down to the knot, toying with it to make him gasp, then moving back to the dripping tip. He does it a few times, furthering the wolf&#39;s pleasure, and soon $name is panting. The candle did too much. His balls churn and the weight feels more uncomfortable than ever. $name feels like he could cum ten times in a row and one of them is already coming with just that bit of stimulation... until Ivex grins.
 
 &lt;&lt;print $name&gt;&gt;&#39;s eyes start going wide.
 
@@ -2713,7 +2638,7 @@ $name can&#39;t help it. The wolf lets out what is almost a howl as Ivex pinches
 
 It feels like far, far too long before he lets go, and the tingling sensation remains around the wolf&#39;s knot and entire groin. 
 
-&quot;Now, are you willing to tell me &lt;b&gt;everything&lt;/b&gt; I want to know?&quot; the mage asks with three fingers playing around the wolf&#39;s knot, threatening to touch it. It takes effort to even form words to muster a response, but when $name finally manages to...</tw-passagedata><tw-passagedata pid="121" name="Shock 3 (Text)" tags="text" position="473,2087" size="100,100">Before the wolf can finish saying anything at all, a movement from Ivex&#39;s finger has some kind of belt come flying from behind to wrap itself around the wolf&#39;s muzzle with lightning speed. It buckles itself and tightens &lt;b&gt;hard&lt;/b&gt;, making the wolf flinch and causing him to be unable to open his muzzle at all.
+&quot;Now, are you willing to tell me &lt;b&gt;everything&lt;/b&gt; I want to know?&quot; the mage asks with three fingers playing around the wolf&#39;s knot, threatening to touch it. It takes effort to even form words to muster a response, but when $name finally manages to...</tw-passagedata><tw-passagedata pid="114" name="Shock 3 (Text)" tags="text" position="1925,1800" size="100,100">Before the wolf can finish saying anything at all, a movement from Ivex&#39;s finger has some kind of belt come flying from behind to wrap itself around the wolf&#39;s muzzle with lightning speed. It buckles itself and tightens &lt;b&gt;hard&lt;/b&gt;, making the wolf flinch and causing him to be unable to open his muzzle at all.
 
 &quot;Hmmmhgghm!&quot; the wolf complains. It&#39;s impossible to form proper words with his muzzle shut tight.
 
@@ -2729,7 +2654,7 @@ It feels like a long time goes by before Ivex&#39;s hand finally reaches the tip
 
 Ivex spends a little time pleasuring the wolf, but unfortunately, it is all too brief. Before long, the panther lets go and makes sure the wolf is watching as he grins and brings his lightning-covered hand close to his cock again.
 
-$name shakes his hand, letting out muffled pleas and complaints against it, but it is to no avail. The wolf howls through his shut muzzle as Ivex envelops his cock in lightning once more and starts stroking it with that hand instead...</tw-passagedata><tw-passagedata pid="122" name="Extra Torture (Text)" tags="text" position="361,2232" size="100,100">It&#39;s hard to tell for how long the mage plays with the wolf. Unable to even say anything, all $name can do is stay there, bound and exposed, as he endures the whims of the sadistic mage. With his magic-engulfed hand, he alternates between torturing and pleasuring the wolf&#39;s exposed cock a few more times before he moves on to different methods.
+$name shakes his hand, letting out muffled pleas and complaints against it, but it is to no avail. The wolf howls through his shut muzzle as Ivex envelops his cock in lightning once more and starts stroking it with that hand instead...</tw-passagedata><tw-passagedata pid="115" name="Extra Torture (Text)" tags="text" position="2050,2125" size="100,100">It&#39;s hard to tell for how long the mage plays with the wolf. Unable to even say anything, all $name can do is stay there, bound and exposed, as he endures the whims of the sadistic mage. With his magic-engulfed hand, he alternates between torturing and pleasuring the wolf&#39;s exposed cock a few more times before he moves on to different methods.
 
 Ivex seems to take immense pleasure in shifting the weight of the crystal hanging from the wolf&#39;s balls back and forth. Sometimes it grows light to give his nuts some relief, and sometimes the mage makes it so heavy that $name feels like his balls are supporting the weight of a person by themselves.
 
@@ -2743,7 +2668,7 @@ To the wolf, it feels like hours pass by. His cock feels sore, his balls even mo
 
 &quot;Well then... isn&#39;t this fun? Unfortunately, I have things to do, so we must be moving on...&quot;
 
-Ivex approaches the wolf again, leaning against his chest, his hand caressing the wolf&#39;s tortured knot and bringing a whine of need from the bound adventurer.</tw-passagedata><tw-passagedata pid="123" name="Defiant End (Text)" tags="text" position="482,2374" size="100,100">Ivex&#39;s painful squeezing thankfully does not last long. The panther soon lets go of it, stepping back, but as he does, he motions with his hands again and...
+Ivex approaches the wolf again, leaning against his chest, his hand caressing the wolf&#39;s tortured knot and bringing a whine of need from the bound adventurer.</tw-passagedata><tw-passagedata pid="116" name="Defiant End (Text)" tags="text" position="2325,2025" size="100,100">Ivex&#39;s painful squeezing thankfully does not last long. The panther soon lets go of it, stepping back, but as he does, he motions with his hands again and...
 
 Four small metal rings come to him, all flying between the mage and the wolf. With a smile, the panther motions more delicately, and much to the wolf&#39;s dismay, all four rings fly in order towards his cock and carefully slide around it. One rests right above his knot, the other three a little spaced out around the wolf&#39;s throbbing length.
 
@@ -2793,7 +2718,7 @@ The mage turns and starts walking away. $name grunts and yells through his shut 
 
 &quot;Don&#39;t worry,&quot; Ivex says, stopping by the door. &quot;I did enjoy our time together. The best part is that, since you will be here anyway, we can bring you back up, strap you up and have another one of these fun play sessions whenever I feel like it. Isn&#39;t that great?&quot;
 
-$name shakes his head. Ivex, however, just laughs and walks away. The large wolf is left alone in the room, bound, with the candle burning and clouded in unending pleasure for who knows how long. Overwhelmed by everything inflicted upon him, $name can&#39;t even wonder what Ivex has in store for him in the future now that he&#39;s in the mage&#39;s hands.</tw-passagedata><tw-passagedata pid="124" name="Compliant End (Text)" tags="text" position="236,2375" size="100,100">Ivex&#39;s pleasurable stroking does not last long. The panther soon lets go of it, stepping back, but as he does, he motions with his hands again and...
+$name shakes his head. Ivex, however, just laughs and walks away. The large wolf is left alone in the room, bound, with the candle burning and clouded in unending pleasure for who knows how long. Overwhelmed by everything inflicted upon him, $name can&#39;t even wonder what Ivex has in store for him in the future now that he&#39;s in the mage&#39;s hands.</tw-passagedata><tw-passagedata pid="117" name="Compliant End (Text)" tags="text" position="2125,1800" size="100,100">Ivex&#39;s pleasurable stroking does not last long. The panther soon lets go of it, stepping back, but as he does, he motions with his hands again and...
 
 Four small metal rings come to him, all flying between the mage and the wolf. With a smile, the panther motions more delicately, and much to the wolf&#39;s dismay, all four rings fly in order towards his cock and carefully slide around it. One rests right above his knot, the other three a little spaced out around the wolf&#39;s throbbing length.
 
@@ -2825,7 +2750,7 @@ Ivex lets go of all he is holding and, as usual, everything floats up instead of
 
 &quot;I will love having you as my loving thrall... and the best part? Since you will be here anyway, we can come back here, strap you up and have another one of these fun play sessions whenever I feel like it. Isn&#39;t that great?&quot;
 
-$name shakes his head. Ivex, however, just laughs and motions with his hand again. The gear approaches the bound wolf... and there is nothing he can do to stop it.</tw-passagedata><tw-passagedata pid="125" name="Ice (Text)" tags="text" position="150,1788" size="100,100">With a chuckle, the panther comes even closer. $name grows stiff and growls seeing the panther leaning against him. With the wolf bound and spread as he is, Ivex has full freedom to press his side against the wolf&#39;s, going as far as leaning his head to rest it against &lt;&lt;print $name&gt;&gt;&#39;s broad chest. The panther&#39;s hand never leaves the wolf&#39;s cock, continuing to stroke and tease it in its way too slow manner, but the mage&#39;s other hand comes to caress the exposed fur of the wolf&#39;s chest.
+$name shakes his head. Ivex, however, just laughs and motions with his hand again. The gear approaches the bound wolf... and there is nothing he can do to stop it.</tw-passagedata><tw-passagedata pid="118" name="Ice (Text)" tags="text" position="1675,2300" size="100,100">With a chuckle, the panther comes even closer. $name grows stiff and growls seeing the panther leaning against him. With the wolf bound and spread as he is, Ivex has full freedom to press his side against the wolf&#39;s, going as far as leaning his head to rest it against &lt;&lt;print $name&gt;&gt;&#39;s broad chest. The panther&#39;s hand never leaves the wolf&#39;s cock, continuing to stroke and tease it in its way too slow manner, but the mage&#39;s other hand comes to caress the exposed fur of the wolf&#39;s chest.
 
 &quot;Such a big specimen... the big ones are my favorite. Wolves, even more. I wonder what sounds you&#39;ll make...&quot;
 
@@ -2849,7 +2774,7 @@ The ice feels terrible on the wolf&#39;s soft, exposed nipple. $name is forced t
 
 He breathes a sigh of relief.
 
-Yet Ivex grins again. &quot;Time to have fun with you.&quot;</tw-passagedata><tw-passagedata pid="126" name="Ice 2 (Text)" tags="text" position="203,1935" size="100,100">The panther&#39;s eyes move back to the wolf&#39;s cock. That hand never stopped teasing it, much to the wolf&#39;s dismay, and the weight on his balls never went away either. Yet, still, as Ivex chuckles again, his hand speeds up. The stroking gets faster. The panther&#39;s hand skillfully strokes and teases the whole of the wolf&#39;s exposed length, going all the way down to the knot, toying with it to make him gasp, then moving back to the dripping tip. He does it a few times, furthering the wolf&#39;s pleasure, and soon $name is panting. The candle did too much. His balls churn and the weight feels more uncomfortable than ever. $name feels like he could cum ten times in a row and one of them is already coming with just that bit of stimulation... until Ivex grins.
+Yet Ivex grins again. &quot;Time to have fun with you.&quot;</tw-passagedata><tw-passagedata pid="119" name="Ice 2 (Text)" tags="text" position="1800,2300" size="100,100">The panther&#39;s eyes move back to the wolf&#39;s cock. That hand never stopped teasing it, much to the wolf&#39;s dismay, and the weight on his balls never went away either. Yet, still, as Ivex chuckles again, his hand speeds up. The stroking gets faster. The panther&#39;s hand skillfully strokes and teases the whole of the wolf&#39;s exposed length, going all the way down to the knot, toying with it to make him gasp, then moving back to the dripping tip. He does it a few times, furthering the wolf&#39;s pleasure, and soon $name is panting. The candle did too much. His balls churn and the weight feels more uncomfortable than ever. $name feels like he could cum ten times in a row and one of them is already coming with just that bit of stimulation... until Ivex grins.
 
 &lt;&lt;print $name&gt;&gt;&#39;s eyes start going wide.
 
@@ -2871,7 +2796,7 @@ It occurred to $name that Ivex had been focusing on his length since the ice app
 
 $name can&#39;t help it. The wolf lets out what is almost a howl as the ice envelops his knot. Ivex makes a point to grip it in his hand, keeping the sensitive bulb of flesh trapped and encased in the punishing ice. The wolf gasps, trying to form words to ask him to let go, but they don&#39;t even come. Only a whine does, and a shameful one, but there is no time to feel shame. Only the pleasure mixed with pain coming from Ivex&#39;s cruel torture.
 
-&quot;Now, are you willing to tell me &lt;b&gt;everything&lt;/b&gt; I want to know?&quot; the mage asks without letting go of the wolf&#39;s knot. It takes effort to even form words to muster a response, but when $name finally manages to...</tw-passagedata><tw-passagedata pid="127" name="Ice 3 (Text)" tags="text" position="241,2086" size="100,100">Before the wolf can finish saying anything at all, a movement from Ivex&#39;s finger has some kind of belt come flying from behind to wrap itself around the wolf&#39;s muzzle with lightning speed. It buckles itself and tightens &lt;b&gt;hard&lt;/b&gt;, making the wolf flinch and causing him to be unable to open his muzzle at all.
+&quot;Now, are you willing to tell me &lt;b&gt;everything&lt;/b&gt; I want to know?&quot; the mage asks without letting go of the wolf&#39;s knot. It takes effort to even form words to muster a response, but when $name finally manages to...</tw-passagedata><tw-passagedata pid="120" name="Ice 3 (Text)" tags="text" position="1925,2300" size="100,100">Before the wolf can finish saying anything at all, a movement from Ivex&#39;s finger has some kind of belt come flying from behind to wrap itself around the wolf&#39;s muzzle with lightning speed. It buckles itself and tightens &lt;b&gt;hard&lt;/b&gt;, making the wolf flinch and causing him to be unable to open his muzzle at all.
 
 &quot;Hmmmhgghm!&quot; the wolf complains. It&#39;s impossible to form proper words with his muzzle shut tight.
 
@@ -2883,7 +2808,7 @@ The panther laughs. A genuine laugh. All the while the bound wolf feels small te
 
 It feels like a long time goes by before Ivex&#39;s hand finally retreats. The wolf&#39;s cock feels icy cold, wet with a sheen layer of cold melted water... and yet it still throbs, radiating the heat of his forced arousal. Ivex takes a step back so that he can grab it with his other hand and, to the wolf, the wave of pleasure and relief is unmatched. The warmth of Ivex&#39;s hand on his cold cock as he teases it feels heavenly and brings the conflicting pleasure back up. Unfortunately, it only lasts a few seconds. Before long, the panther lets go and makes sure the wolf is watching as he grins and brings his ice-covered hand close to his cock again.
 
-$name shakes his hand, letting out muffled pleas and complaints against it, but it is to no avail. The wolf howls through his shut muzzle as Ivex envelops his cock in ice once more and starts stroking all over again.</tw-passagedata><tw-passagedata pid="128" name="Mind Capture (Knot) (Text)" tags="text" position="1212,1912" size="100,100">For a moment, $name feels his adrenaline shoot up. His first reflex is to bring his paw up to remove the pendant from his neck, but as he tries to do so he realizes... it doesn&#39;t work. His arm won&#39;t move, no matter how much he wills it to. Neither will the other one, or his legs, or... anything!
+$name shakes his hand, letting out muffled pleas and complaints against it, but it is to no avail. The wolf howls through his shut muzzle as Ivex envelops his cock in ice once more and starts stroking all over again.</tw-passagedata><tw-passagedata pid="121" name="Mind Capture (Knot) (Text)" tags="text" position="1700,3600" size="100,100">For a moment, $name feels his adrenaline shoot up. His first reflex is to bring his paw up to remove the pendant from his neck, but as he tries to do so he realizes... it doesn&#39;t work. His arm won&#39;t move, no matter how much he wills it to. Neither will the other one, or his legs, or... anything!
 
 The wolf finds himself stuck there, on all fours above the lion with his knot stuck to the feline. His mind races for a moment, his heart speeding up, but then...
 
@@ -2907,7 +2832,7 @@ All the lupine can do is watch his body bring the mortar and pestle to the count
 
 His body starts grinding herbs next to the lion and there&#39;s nothing he can do about it. The gemstone on the pendant... it must be the gemstone! But removing it is out of question. His body won&#39;t obey. 
 
-$name is trapped.</tw-passagedata><tw-passagedata pid="129" name="Mind Capture (Text)" tags="text" position="989,1848" size="100,100">The lion stands chest to chest with the wolf and brings the pendant up. $name reluctantly allows the feline to put it over his head and around his neck.
+$name is trapped.</tw-passagedata><tw-passagedata pid="122" name="Mind Capture (Text)" tags="text" position="1325,3125" size="100,100">The lion stands chest to chest with the wolf and brings the pendant up. $name reluctantly allows the feline to put it over his head and around his neck.
 
 Looking down at it, the wolf can see the blue gemstone glowing brighter. It is as if there is a mist inside it that glows and whirls. At first, nothing happens.
 
@@ -2925,7 +2850,7 @@ All the lupine can do is watch his body bring the mortar and pestle to the count
 
 His body starts grinding herbs next to the lion and there&#39;s nothing he can do about it. The gemstone on the pendant... it must be the gemstone! But removing it is out of the question. His body won&#39;t obey. 
 
-$name is trapped.</tw-passagedata><tw-passagedata pid="130" name="Mind Capture 2 (Text)" tags="text" position="1090,2045" size="100,100">It doesn&#39;t matter how much the wolf shouts and yells inside his thoughts or how much willpower he puts into defying his body&#39;s movements. It won&#39;t obey. Whatever that pendant is, it&#39;s strong enough to overcome him entirely.
+$name is trapped.</tw-passagedata><tw-passagedata pid="123" name="Mind Capture 2 (Text)" tags="text" position="1450,3125" size="100,100">It doesn&#39;t matter how much the wolf shouts and yells inside his thoughts or how much willpower he puts into defying his body&#39;s movements. It won&#39;t obey. Whatever that pendant is, it&#39;s strong enough to overcome him entirely.
 
 $name is forced to remain there next to the lion in the exact same state the leonine warrior is in. Blank expression and mindlessly grinding herbs for Ivex&#39;s nefarious purposes. Like... like some sort of slave. Like a mindless fucking thrall! The thought alone is enough to drive the wolf mad with anger, but his heart does not even speed up. It feels so unnatural to feel these things without really feeling them!
 
@@ -2933,7 +2858,7 @@ Everything about it is unnatural. Invasive! And the worst part? $name can tell t
 
 For some reason, that smell feels incredibly &lt;b&gt;arousing&lt;/b&gt;. If he could look at the lion by his side, he would. The wolf starts to understand why the lion was hard and dripping the whole time while working. He himself cannot help it. His cock throbs between his legs, unattended, but the arousal is there, coming from the herbs he&#39;s forced to grind. With how boring the work is, the lust surrounding his body is the only thing his mind can focus on. It feels like torture to feel it and be completely unable to even get close to tend to it. 
 
-No matter how much he tries, $name cannot find a way out. He&#39;s trapped there grinding herbs and getting aroused by it until who knows how long after that, Ivex himself opens the door.</tw-passagedata><tw-passagedata pid="131" name="Interrogation Archive Display" tags="" position="182,2696" size="100,100">&lt;&lt;silently&gt;&gt;\
+No matter how much he tries, $name cannot find a way out. He&#39;s trapped there grinding herbs and getting aroused by it until who knows how long after that, Ivex himself opens the door.</tw-passagedata><tw-passagedata pid="124" name="Interrogation Archive Display" tags="noreturn" position="1700,1000" size="100,100">&lt;&lt;silently&gt;&gt;\
   &lt;&lt;if $interrogationEndingFreeze &amp;&amp; $interrogationEndingShock&gt;&gt;
     &lt;&lt;set $interrogationSpell = &#39;freeze&#39;&gt;&gt;
   &lt;&lt;elseif $interrogationEndingFreeze &amp;&amp; !$interrogationEndingShock&gt;&gt;
@@ -2951,70 +2876,70 @@ No matter how much he tries, $name cannot find a way out. He&#39;s trapped there
     &lt;&lt;set $interrogationEnd = &#39;rough&#39;&gt;&gt;
   &lt;&lt;else&gt;&gt;
     &lt;&lt;set $interrogationEnd = &#39;&#39;&gt;&gt;
-  &lt;&lt;/if&gt;&gt;  
+  &lt;&lt;/if&gt;&gt;
 &lt;&lt;/silently&gt;&gt;\
 \
 &lt;&lt;if $interrogationEnding&gt;&gt;\
   &lt;b&gt;[[Bad Ending: Interrogation|Interrogation Archive]]&lt;/b&gt;
   Variation 1: &lt;&lt;nobr&gt;&gt;
   &lt;&lt;if $interrogationEndingFreeze&gt;&gt;
-	&lt;label&gt;&lt;&lt;radiobutton &quot;$interrogationSpell&quot; &quot;freeze&quot; autocheck&gt;&gt; Freeze&lt;/label&gt;
+    &lt;label&gt;&lt;&lt;radiobutton &quot;$interrogationSpell&quot; &quot;freeze&quot; autocheck&gt;&gt; Freeze&lt;/label&gt;
   &lt;&lt;else&gt;&gt;
     &lt;span class=&quot;helper-container&quot;&gt;
-	  &lt;span&gt;&lt;label&gt;&lt;&lt;radiobutton &quot;$interrogationSpell&quot; &quot;&quot;&gt;&gt; &lt;span class=&quot;disabled&quot;&gt;Freeze&lt;/span&gt;&lt;/label&gt;&lt;/span&gt;
-	  &lt;small class=&quot;helper-text&quot;&gt;Ivex has a special treatment for northern wolves that like the cold...&lt;/small&gt;
-	&lt;/span&gt;
-	&lt;&lt;done&gt;&gt;&lt;&lt;script&gt;&gt;
-	document.getElementById(&quot;radiobutton-interrogationspell-0&quot;).disabled = true;
-	&lt;&lt;/script&gt;&gt;&lt;&lt;/done&gt;&gt;
+      &lt;span&gt;&lt;label&gt;&lt;&lt;radiobutton &quot;$interrogationSpell&quot; &quot;&quot;&gt;&gt; &lt;span class=&quot;disabled&quot;&gt;Freeze&lt;/span&gt;&lt;/label&gt;&lt;/span&gt;
+      &lt;small class=&quot;helper-text&quot;&gt;Ivex has a special treatment for northern wolves that like the cold...&lt;/small&gt;
+    &lt;/span&gt;
+    &lt;&lt;done&gt;&gt;&lt;&lt;script&gt;&gt;
+    document.getElementById(&quot;radiobutton-interrogationspell-0&quot;).disabled = true;
+    &lt;&lt;/script&gt;&gt;&lt;&lt;/done&gt;&gt;
   &lt;&lt;/if&gt;&gt;
   &lt;&lt;/nobr&gt;&gt;\
    | &lt;&lt;nobr&gt;&gt;
-	&lt;&lt;if $interrogationEndingShock&gt;&gt;
-		&lt;label&gt;&lt;&lt;radiobutton &quot;$interrogationSpell&quot; &quot;shock&quot; autocheck&gt;&gt; Shock&lt;/label&gt;
-	  &lt;&lt;else&gt;&gt;
-		&lt;span class=&quot;helper-container&quot;&gt;
-		  &lt;span&gt;&lt;label&gt;&lt;&lt;radiobutton &quot;$interrogationSpell&quot; &quot;&quot;&gt;&gt; &lt;span class=&quot;disabled&quot;&gt;Shock&lt;/span&gt;&lt;/label&gt;&lt;/span&gt;
-		  &lt;small class=&quot;helper-text&quot;&gt;Ivex has a special treatment for southern wolves that hate the cold...&lt;/small&gt;
-		&lt;/span&gt;
-		&lt;&lt;done&gt;&gt;&lt;&lt;script&gt;&gt;
-			document.getElementById(&quot;radiobutton-interrogationspell-1&quot;).disabled = true;
-		&lt;&lt;/script&gt;&gt;&lt;&lt;/done&gt;&gt;
+    &lt;&lt;if $interrogationEndingShock&gt;&gt;
+        &lt;label&gt;&lt;&lt;radiobutton &quot;$interrogationSpell&quot; &quot;shock&quot; autocheck&gt;&gt; Shock&lt;/label&gt;
+      &lt;&lt;else&gt;&gt;
+        &lt;span class=&quot;helper-container&quot;&gt;
+          &lt;span&gt;&lt;label&gt;&lt;&lt;radiobutton &quot;$interrogationSpell&quot; &quot;&quot;&gt;&gt; &lt;span class=&quot;disabled&quot;&gt;Shock&lt;/span&gt;&lt;/label&gt;&lt;/span&gt;
+          &lt;small class=&quot;helper-text&quot;&gt;Ivex has a special treatment for southern wolves that hate the cold...&lt;/small&gt;
+        &lt;/span&gt;
+        &lt;&lt;done&gt;&gt;&lt;&lt;script&gt;&gt;
+            document.getElementById(&quot;radiobutton-interrogationspell-1&quot;).disabled = true;
+        &lt;&lt;/script&gt;&gt;&lt;&lt;/done&gt;&gt;
     &lt;&lt;/if&gt;&gt;
   &lt;&lt;/nobr&gt;&gt;
 
   Variation 2: &lt;&lt;nobr&gt;&gt;
   &lt;&lt;if $interrogationEndingMild&gt;&gt;
-	&lt;label&gt;&lt;label&gt;&lt;&lt;radiobutton &quot;$interrogationEnd&quot; &quot;mild&quot; autocheck&gt;&gt; Mild&lt;/label&gt;
+    &lt;label&gt;&lt;label&gt;&lt;&lt;radiobutton &quot;$interrogationEnd&quot; &quot;mild&quot; autocheck&gt;&gt; Mild&lt;/label&gt;
   &lt;&lt;else&gt;&gt;
     &lt;span class=&quot;helper-container&quot;&gt;
-	  &lt;span&gt;&lt;label&gt;&lt;&lt;radiobutton &quot;$interrogationEnd&quot; &quot;&quot;&gt;&gt; &lt;span class=&quot;disabled&quot;&gt;Mild&lt;/span&gt;&lt;/label&gt;&lt;/span&gt;
-	  &lt;small class=&quot;helper-text&quot;&gt;Ivex treats those that choose collaboration over defiance with &quot;kindness&quot;...&lt;/small&gt;
-	&lt;/span&gt;
-	&lt;&lt;done&gt;&gt;&lt;&lt;script&gt;&gt;
-	document.getElementById(&quot;radiobutton-interrogationend-0&quot;).disabled = true;
-	&lt;&lt;/script&gt;&gt;&lt;&lt;/done&gt;&gt;
+      &lt;span&gt;&lt;label&gt;&lt;&lt;radiobutton &quot;$interrogationEnd&quot; &quot;&quot;&gt;&gt; &lt;span class=&quot;disabled&quot;&gt;Mild&lt;/span&gt;&lt;/label&gt;&lt;/span&gt;
+      &lt;small class=&quot;helper-text&quot;&gt;Ivex treats those that choose collaboration over defiance with &quot;kindness&quot;...&lt;/small&gt;
+    &lt;/span&gt;
+    &lt;&lt;done&gt;&gt;&lt;&lt;script&gt;&gt;
+    document.getElementById(&quot;radiobutton-interrogationend-0&quot;).disabled = true;
+    &lt;&lt;/script&gt;&gt;&lt;&lt;/done&gt;&gt;
   &lt;&lt;/if&gt;&gt;
   &lt;&lt;/nobr&gt;&gt;\
    | &lt;&lt;nobr&gt;&gt;
-	&lt;&lt;if $interrogationEndingRough&gt;&gt;
-	  &lt;label&gt;&lt;&lt;radiobutton &quot;$interrogationEnd&quot; &quot;rough&quot; autocheck&gt;&gt; Harsh&lt;/label&gt;
-	&lt;&lt;else&gt;&gt;
-	  &lt;span class=&quot;helper-container&quot;&gt;
-	  &lt;span&gt;&lt;label&gt;&lt;&lt;radiobutton &quot;$interrogationEnd&quot; &quot;&quot;&gt;&gt; &lt;span class=&quot;disabled&quot;&gt;Rough&lt;/span&gt;&lt;/label&gt;&lt;/span&gt;
-	  &lt;small class=&quot;helper-text&quot;&gt;Ivex has a special disdain for those that dare defy his wishes...&lt;/small&gt;
-	  &lt;/span&gt;
-	  &lt;&lt;done&gt;&gt;&lt;&lt;script&gt;&gt;
-	  document.getElementById(&quot;radiobutton-interrogationend-1&quot;).disabled = true;
-	  &lt;&lt;/script&gt;&gt;&lt;&lt;/done&gt;&gt;
+    &lt;&lt;if $interrogationEndingRough&gt;&gt;
+      &lt;label&gt;&lt;&lt;radiobutton &quot;$interrogationEnd&quot; &quot;rough&quot; autocheck&gt;&gt; Harsh&lt;/label&gt;
+    &lt;&lt;else&gt;&gt;
+      &lt;span class=&quot;helper-container&quot;&gt;
+      &lt;span&gt;&lt;label&gt;&lt;&lt;radiobutton &quot;$interrogationEnd&quot; &quot;&quot;&gt;&gt; &lt;span class=&quot;disabled&quot;&gt;Rough&lt;/span&gt;&lt;/label&gt;&lt;/span&gt;
+      &lt;small class=&quot;helper-text&quot;&gt;Ivex has a special disdain for those that dare defy his wishes...&lt;/small&gt;
+      &lt;/span&gt;
+      &lt;&lt;done&gt;&gt;&lt;&lt;script&gt;&gt;
+      document.getElementById(&quot;radiobutton-interrogationend-1&quot;).disabled = true;
+      &lt;&lt;/script&gt;&gt;&lt;&lt;/done&gt;&gt;
     &lt;&lt;/if&gt;&gt;
   &lt;&lt;/nobr&gt;&gt;
 &lt;&lt;else&gt;&gt;\
   &lt;span class=&quot;helper-container&quot;&gt;
-  	&lt;b&gt;&lt;span class=&quot;disabled&quot;&gt;Bad Ending: Interrogation&lt;/span&gt;&lt;/b&gt;
-	&lt;small class=&quot;helper-text&quot;&gt;Interrogation by the hands of the wizard is the first step that awaits those that cannot escape his contraptions...&lt;/small&gt;
+      &lt;b&gt;&lt;span class=&quot;disabled&quot;&gt;Bad Ending: Interrogation&lt;/span&gt;&lt;/b&gt;
+    &lt;small class=&quot;helper-text&quot;&gt;Interrogation by the hands of the wizard is the first step that awaits those that cannot escape his contraptions...&lt;/small&gt;
   &lt;/span&gt;
-&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="132" name="Enthrallment 1 (Text)" tags="text" position="990,2199" size="100,100">The wolf can&#39;t even turn his head to look at the damned mage, but the panther is incredibly happy and amused to find him there with a gemstone around his neck and working next to the lion.
+&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="125" name="Enthrallment 1 (Text)" tags="text" position="1575,3125" size="100,100">The wolf can&#39;t even turn his head to look at the damned mage, but the panther is incredibly happy and amused to find him there with a gemstone around his neck and working next to the lion.
 
 There is nothing $name can do. Ivex compliments the lion for capturing him with a slap to the feline&#39;s bare ass. The wolf is forced to remain there, grinding herbs while Ivex&#39;s hands explore his helpless body, stroke and play with his forcefully aroused cock and even go as far as shoving a finger up his ass.
 
@@ -3024,7 +2949,7 @@ Ivex decides there and then to keep him as a thrall, saying the lion had been ne
 
 Much to &lt;&lt;print $name&gt;&gt;&#39;s dismay, whatever order Ivex issues, the parasitic mind created by the necklace makes his body obey right away. The wolf has never tried so hard to will his body to punch someone as he does when Ivex makes him lift his arms, turn this way and that, and even lift his tail while he puts the leather gear upon his body. Just like the lion, his &#39;uniform&#39; consists of little more than a leather harness. Unlike the lion, however, the wolf gets nothing more than a metal ring around the base of his balls that keeps them uncomfortably pulled forward, making them more exposed. The discomfort is still felt by the wolf, but Ivex? He merely pats the wolf&#39;s exposed nuts and laughs, saying he&#39;ll enjoy looking and playing with them in the future.
 
-After that, there is nothing else the wolf can do. Removing the pendant is impossible by himself and Ivex surely won&#39;t do it. $name finds himself doomed to serve as the perverted mage&#39;s thrall against his will.</tw-passagedata><tw-passagedata pid="133" name="Enthrallment 2 (Text)" tags="text" position="851,2028" size="100,100">Time loses all meaning to the wolf. Inside Ivex&#39;s tower, it&#39;s impossible to tell day from night. His body sleeps sometimes, but the intervals at which he does seem random and, sometimes, get interrupted by Ivex&#39;s orders if they are particularly lengthy.
+After that, there is nothing else the wolf can do. Removing the pendant is impossible by himself and Ivex surely won&#39;t do it. $name finds himself doomed to serve as the perverted mage&#39;s thrall against his will.</tw-passagedata><tw-passagedata pid="126" name="Enthrallment 2 (Text)" tags="text" position="1700,3125" size="100,100">Time loses all meaning to the wolf. Inside Ivex&#39;s tower, it&#39;s impossible to tell day from night. His body sleeps sometimes, but the intervals at which he does seem random and, sometimes, get interrupted by Ivex&#39;s orders if they are particularly lengthy.
 
 Little by little, the unwilling wolf learns more about the mage, but every new thing he learns just makes him hate him more. $name gets by telling himself that, as soon as he&#39;s free, he&#39;s gonna get his revenge on the mage, except that the days keep going by and freedom never comes.
 
@@ -3038,9 +2963,9 @@ There&#39;s the lion as well. Overhearing Ivex&#39;s comments to him, $name find
 
 Activities with the lion end up being quite common as well. The mage takes pleasure sitting back and jerking off while watching the two of them fuck each other under his orders in any position he can imagine. Neither warrior has any choice in the matter but to watch their bodies obey and feel everything as the mage uses them for his own pleasure.
 
-Time keeps passing, each day a new set of orders with some being worse and some being better. Still, &lt;&lt;print $name&gt;&gt;&#39;s own mind waits. His current system is counting the number of punches he&#39;s gonna give Ivex when he gets free, but as of right now he&#39;s beaten a thousand and is still going. Still, someday... someday freedom will come and he&#39;ll be able to settle the score. Someday, somehow.</tw-passagedata><tw-passagedata pid="134" name="Lion Description" tags="" position="1420,1161" size="100,100">The lion is large with shiny golden fur and an impressive mane. He is also quite muscular, with thick arms and a broad chest, as made plain by the fact that he does not wear much in terms of clothing. What seems to be some kind of harness made of leather has some straps going across his chest and back, and below? Nothing. The lion does not wear anything to cover his rear that is plain for the wolf to see from where he stands.
+Time keeps passing, each day a new set of orders with some being worse and some being better. Still, &lt;&lt;print $name&gt;&gt;&#39;s own mind waits. His current system is counting the number of punches he&#39;s gonna give Ivex when he gets free, but as of right now he&#39;s beaten a thousand and is still going. Still, someday... someday freedom will come and he&#39;ll be able to settle the score. Someday, somehow.</tw-passagedata><tw-passagedata pid="127" name="Lion Description" tags="" position="1025,2950" size="100,100">The lion is large with shiny golden fur and an impressive mane. He is also quite muscular, with thick arms and a broad chest, as made plain by the fact that he does not wear much in terms of clothing. What seems to be some kind of harness made of leather has some straps going across his chest and back, and below? Nothing. The lion does not wear anything to cover his rear that is plain for the wolf to see from where he stands.
 
-[[Return|Lion Room Intro]]</tw-passagedata><tw-passagedata pid="135" name="Lion Fucking (Text)" tags="text" position="1448,2259" size="100,100">It&#39;s too hard to resist. Besides, the lion is clearly a thrall fighting for Ivex. The wolf has beaten him fair and square, and now...
+[[Return|Lion Room Intro]]</tw-passagedata><tw-passagedata pid="128" name="Lion Fucking (Text)" tags="text" position="1350,3500" size="100,100">It&#39;s too hard to resist. Besides, the lion is clearly a thrall fighting for Ivex. The wolf has beaten him fair and square, and now...
 
 With a lustful growl, $name pulls his hips back so that he can line himself up with the struggling lion&#39;s hole. His cock is already coated in his own pre-cum from all the fighting, the damned lingering arousal from that blasted candle. The thought of it, the memories, the humiliation he went through because of Ivex&#39;s pervertedness makes the wolf angry. All he went through... Yeah, it&#39;s time to let it out on something.
 
@@ -3056,7 +2981,7 @@ Before long, $name is panting like a dog as he fucks with reckless abandon. His 
 
 His knot is the only thing that still remains outside of the lion. It begs to feel that same tightness around it, to be gripped, squeezed, and to make the wolf&#39;s act of filling that damned lion up the best it can be.
 
-Despite his eagerness and need, however, the wolf glances at the rope. Knotting the lion would mean being stuck to him for a long time, which is a luxury he definitely does not have. His rational mind tells him that, but as $name keeps fucking, his body begs him to knot the damned bastard. As he fucks faster, his pleasure reaching its peak...</tw-passagedata><tw-passagedata pid="136" name="Lion Knotting (Text)" tags="text" position="1219,2198" size="100,100">Gritting his teeth, the wolf puts even more force behind his fucking. It feels good, great even, to give in to the overwhelming lust. Drool runs down the wolf&#39;s muzzle to fall down on the lion&#39;s exposed back at the mere thought of how that tight ass is going to feel around his knot.
+Despite his eagerness and need, however, the wolf glances at the rope. Knotting the lion would mean being stuck to him for a long time, which is a luxury he definitely does not have. His rational mind tells him that, but as $name keeps fucking, his body begs him to knot the damned bastard. As he fucks faster, his pleasure reaching its peak...</tw-passagedata><tw-passagedata pid="129" name="Lion Knotting (Text)" tags="text" position="1475,3500" size="100,100">Gritting his teeth, the wolf puts even more force behind his fucking. It feels good, great even, to give in to the overwhelming lust. Drool runs down the wolf&#39;s muzzle to fall down on the lion&#39;s exposed back at the mere thought of how that tight ass is going to feel around his knot.
 
 It takes effort. A lot of effort. With a lot of grunting from both parties and a lot of insistence from the wolf, his knot finally spreads the lion&#39;s ass, the large bulb forcing its way in until finally...
 
@@ -3076,7 +3001,7 @@ The wolf&#39;s orgasm is hard and long and, even after it starts ebbing, his coc
 
 With one sudden move, the lion&#39;s hand reaches over his head. The wolf feels something around his neck. Looking down, he can see it is... the pendant.
 
-$name blinks. Through his fucking, he didn&#39;t realize the lion had freed his other hand, reached out for the pendant and now managed to place it over his neck.</tw-passagedata><tw-passagedata pid="137" name="Enthrallment Archive" tags="noreturn" position="475,2806" size="100,100">&lt;&lt;if $lionFuck&gt;&gt;\
+$name blinks. Through his fucking, he didn&#39;t realize the lion had freed his other hand, reached out for the pendant and now managed to place it over his neck.</tw-passagedata><tw-passagedata pid="130" name="Enthrallment Archive" tags="noreturn" position="1825,1100" size="100,100">&lt;&lt;if $lionFuck&gt;&gt;\
 &lt;&lt;include &quot;Lion Fight (Text)&quot;&gt;&gt;
 
 &lt;&lt;include &quot;Lion Pindown (Text)&quot;&gt;&gt;
@@ -3104,34 +3029,34 @@ But there&#39;s no decision to be made. After being exposed to that candle for s
 
 &lt;span class=&quot;bad-ending&quot;&gt;Bad Ending: &lt;i&gt;Enthrallment&lt;/i&gt;&lt;/span&gt;
 
-[[Return to the Archives|Archives]]</tw-passagedata><tw-passagedata pid="138" name="Enthrallment Archive Display" tags="" position="180,2804" size="100,100">&lt;&lt;silently&gt;&gt;\
+[[Return to the Archives|Archives]]</tw-passagedata><tw-passagedata pid="131" name="Enthrallment Archive Display" tags="noreturn" position="1825,1000" size="100,100">&lt;&lt;silently&gt;&gt;\
   &lt;&lt;set $lionFuck = false&gt;&gt;
 &lt;&lt;/silently&gt;&gt;\
 \
 &lt;&lt;if $enthrallmentEnding&gt;&gt;\
   &lt;b&gt;[[Bad Ending: Enthrallment|Enthrallment Archive]]&lt;/b&gt;
   Variation: &lt;&lt;nobr&gt;&gt;
-	&lt;label&gt;&lt;&lt;radiobutton &quot;$lionFuck&quot; false checked&gt;&gt; None&lt;/label&gt;
+    &lt;label&gt;&lt;&lt;radiobutton &quot;$lionFuck&quot; false checked&gt;&gt; None&lt;/label&gt;
   &lt;&lt;/nobr&gt;&gt;\
    | &lt;&lt;nobr&gt;&gt;
-	&lt;&lt;if $enthrallmentLion&gt;&gt;
-		&lt;label&gt;&lt;&lt;radiobutton &quot;$lionFuck&quot; true&gt;&gt; Lion&lt;/label&gt;
-	  &lt;&lt;else&gt;&gt;
-		&lt;span class=&quot;helper-container&quot;&gt;
-		  &lt;span&gt;&lt;label&gt;&lt;&lt;radiobutton &quot;$lionFuck&quot; &quot;&quot;&gt;&gt; &lt;span class=&quot;disabled&quot;&gt;Lion&lt;/span&gt;&lt;/label&gt;&lt;/span&gt;
-		  &lt;small class=&quot;helper-text&quot;&gt;Engaging in arousing activities while overtaken by previous magical lust makes some things impossible to resist...&lt;/small&gt;
-		&lt;/span&gt;
-		&lt;&lt;done&gt;&gt;&lt;&lt;script&gt;&gt;
-			document.getElementById(&quot;radiobutton-lionfuck-1&quot;).disabled = true;
-		&lt;&lt;/script&gt;&gt;&lt;&lt;/done&gt;&gt;
+    &lt;&lt;if $enthrallmentLion&gt;&gt;
+        &lt;label&gt;&lt;&lt;radiobutton &quot;$lionFuck&quot; true&gt;&gt; Lion&lt;/label&gt;
+      &lt;&lt;else&gt;&gt;
+        &lt;span class=&quot;helper-container&quot;&gt;
+          &lt;span&gt;&lt;label&gt;&lt;&lt;radiobutton &quot;$lionFuck&quot; &quot;&quot;&gt;&gt; &lt;span class=&quot;disabled&quot;&gt;Lion&lt;/span&gt;&lt;/label&gt;&lt;/span&gt;
+          &lt;small class=&quot;helper-text&quot;&gt;Engaging in arousing activities while overtaken by previous magical lust makes some things impossible to resist...&lt;/small&gt;
+        &lt;/span&gt;
+        &lt;&lt;done&gt;&gt;&lt;&lt;script&gt;&gt;
+            document.getElementById(&quot;radiobutton-lionfuck-1&quot;).disabled = true;
+        &lt;&lt;/script&gt;&gt;&lt;&lt;/done&gt;&gt;
     &lt;&lt;/if&gt;&gt;
   &lt;&lt;/nobr&gt;&gt;
 &lt;&lt;else&gt;&gt;\
   &lt;span class=&quot;helper-container&quot;&gt;
-  	&lt;b&gt;&lt;span class=&quot;disabled&quot;&gt;Bad Ending: Enthrallment&lt;/span&gt;&lt;/b&gt;
-	&lt;small class=&quot;helper-text&quot;&gt;Sometimes a magical accessory is for more than just the looks...&lt;/small&gt;
+      &lt;b&gt;&lt;span class=&quot;disabled&quot;&gt;Bad Ending: Enthrallment&lt;/span&gt;&lt;/b&gt;
+    &lt;small class=&quot;helper-text&quot;&gt;Sometimes a magical accessory is for more than just the looks...&lt;/small&gt;
   &lt;/span&gt;
-&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="139" name="Lion Pindown (Text)" tags="text" position="1455,2057" size="100,100">The feline is good. Very good. How can someone this strong end up grinding herbs in some psycho mage&#39;s tower?! The wolf&#39;s wondering has to wait, however, because as the lion uses his legs to trap his own, things start getting ugly. Much to the wolf&#39;s dismay, the lion grips him closer than ever and, in that position, the wolf&#39;s cock finds itself hard-pressed against the lion&#39;s own member. It feels warm against the wolf&#39;s sensitive length, tingles of pleasure distracting $name from the urgency of the situation. The lion forces him back, climbing on top of him, dangerously close to pinning him down...
+&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="132" name="Lion Pindown (Text)" tags="text" position="1100,3600" size="100,100">The feline is good. Very good. How can someone this strong end up grinding herbs in some psycho mage&#39;s tower?! The wolf&#39;s wondering has to wait, however, because as the lion uses his legs to trap his own, things start getting ugly. Much to the wolf&#39;s dismay, the lion grips him closer than ever and, in that position, the wolf&#39;s cock finds itself hard-pressed against the lion&#39;s own member. It feels warm against the wolf&#39;s sensitive length, tingles of pleasure distracting $name from the urgency of the situation. The lion forces him back, climbing on top of him, dangerously close to pinning him down...
 
 &quot;NO!&quot; the wolf yells at the lion&#39;s face. With a surge of anger, the wolf lets out a loud snarl and bends his knee, hitting the exposed lion straight on the nuts.
 
@@ -3149,7 +3074,7 @@ However...
 
 As he does so, the lion keeps squirming. When he does, the wolf looks down to see...
 
-The lion&#39;s rear is toned and round. The feline&#39;s tail swishes back and forth in distress, but with his squirming, his cheeks move and up and down, back and forth... right against the wolf&#39;s cock. His erection sits right there, between the beautiful molds of the lion&#39;s ass, and his squirming just makes it grind against it. Tingles of pleasure shoot up at the wolf and, as he looks down with more attention, he can see everything. The lion&#39;s exposed ass. Bare. Vulnerable. It looks really tight...</tw-passagedata><tw-passagedata pid="140" name="Lion Fight (Text)" tags="text" position="1422,1905" size="100,100">The lion rushes forward. The wolf growls, bracing to meet the large warrior chest to chest. $name has fought many strong men before and, while many couldn&#39;t match the large wolf&#39;s strength and size, giving him an advantage, that is not the case with this lion. When the feline tackles him and pushes forward, the wolf finds himself losing his footing.
+The lion&#39;s rear is toned and round. The feline&#39;s tail swishes back and forth in distress, but with his squirming, his cheeks move and up and down, back and forth... right against the wolf&#39;s cock. His erection sits right there, between the beautiful molds of the lion&#39;s ass, and his squirming just makes it grind against it. Tingles of pleasure shoot up at the wolf and, as he looks down with more attention, he can see everything. The lion&#39;s exposed ass. Bare. Vulnerable. It looks really tight...</tw-passagedata><tw-passagedata pid="133" name="Lion Fight (Text)" tags="text" position="1100,3475" size="100,100">The lion rushes forward. The wolf growls, bracing to meet the large warrior chest to chest. $name has fought many strong men before and, while many couldn&#39;t match the large wolf&#39;s strength and size, giving him an advantage, that is not the case with this lion. When the feline tackles him and pushes forward, the wolf finds himself losing his footing.
 
 Before he can fall, however, $name spins, paws pushing back against the lion trying to grip and hold him so that they both fall side by side rather than letting the lion be on top. The wolf then props his knee up to try and get the upper hand and force the lion to roll with him to pin the feline down, but despite the lion&#39;s apparent mindless status, $name can tell that his fighting reflexes are still sharp.
 
@@ -3161,7 +3086,7 @@ The lion grabs hold of &lt;&lt;print $name&gt;&gt;&#39;s wrist and tries to twis
 
 &quot;The master&#39;s pendant must be worn by his thralls at all... times...&quot; the lion says, grunting with effort as he keeps fighting. His voice still remains toneless save from the effect his effort has on it.
 
-The two roll on the ground, muscle against muscle, each trying to end up on top.</tw-passagedata><tw-passagedata pid="141" name="The Spellbook" tags="key" position="1759,674" size="100,100">Opening the large tome, it&#39;s plain to see that it is something of importance.
+The two roll on the ground, muscle against muscle, each trying to end up on top.</tw-passagedata><tw-passagedata pid="134" name="The Spellbook" tags="key" position="1575,4725" size="100,100">Opening the large tome, it&#39;s plain to see that it is something of importance.
 
 On one of its pages, a very intricate circle that even $name can identify as some sort of arcane incantation symbol takes all the space. On the page beside it, there is what seems to be the name and instructions on words to say for the incantation itself. The random page the wolf opens the book on only says &#39;Levitate&#39;. It&#39;s definitely some sort of &lt;span class=&quot;imp-info&quot;&gt;spellbook&lt;/span&gt;.
 
@@ -3183,7 +3108,7 @@ He is ready to try and craft the key to his escape.
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-  	&lt;li&gt;[[Try and craft the red gemstone.|Gemstone Crafting]]&lt;/li&gt;
+      &lt;li&gt;[[Try and craft the red gemstone.|Gemstone Crafting]]&lt;/li&gt;
   &lt;/ul&gt;\
 &lt;/div&gt;
 &lt;&lt;else&gt;&gt;\
@@ -3192,7 +3117,7 @@ Now, to craft a gemstone, all he would need is to find an empty gemstone somewhe
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-  	&lt;li&gt;[[Leave the spellbook as it is for now.|The Desk]]&lt;/li&gt;
+      &lt;li&gt;[[Leave the spellbook as it is for now.|The Desk]]&lt;/li&gt;
   &lt;/ul&gt;\
 &lt;/div&gt;
 &lt;&lt;/if&gt;&gt;\
@@ -3202,17 +3127,17 @@ After leafing through a bunch of them, the wolf just grunts. It doesn&#39;t seem
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-  	&lt;li&gt;[[Leave the spellbook as it is.|The Desk]]&lt;/li&gt;
+      &lt;li&gt;[[Leave the spellbook as it is.|The Desk]]&lt;/li&gt;
   &lt;/ul&gt;\
 &lt;/div&gt;
-&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="142" name="The Journal" tags="" position="1677,476" size="100,100">&lt;&lt;set $theJournal = true&gt;&gt;\
+&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="135" name="The Journal" tags="" position="1000,4475" size="100,100">&lt;&lt;set $theJournal = true&gt;&gt;\
 Pulling the journal close to himself, the wolf sits down to take a look. His bare rear against the chair reminds him of his forced nudity, but he forces himself to ignore it and focus on the contents of the journal instead.
 
 It does seem to indeed be Ivex&#39;s personal journal of some sort. There are pages upon pages filled with writing. Some look like scribbled notes, some look like detailed writing, and as the wolf skims through it, its contents seem to vary wildly as well.
 
 As $name goes through it, there are a few parts that catch his attention...
 
-[[Continue|Journal Notes]]</tw-passagedata><tw-passagedata pid="143" name="Journal Notes" tags="" position="1795,524" size="100,100">Among the many, many pages of passages, some stand out...
+[[Continue|Journal Notes]]</tw-passagedata><tw-passagedata pid="136" name="Journal Notes" tags="" position="900,4600" size="100,100">Among the many, many pages of passages, some stand out...
 
 Near the beginning of the journal...
 
@@ -3244,9 +3169,9 @@ The rest of the journal is still blank and unwritten.
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-  	&lt;li&gt;[[Leave the journal as it is.|The Desk]]&lt;/li&gt;
+      &lt;li&gt;[[Leave the journal as it is.|The Desk]]&lt;/li&gt;
   &lt;/ul&gt;\
-&lt;/div&gt;</tw-passagedata><tw-passagedata pid="144" name="Memory Book Notes" tags="" position="1933,439" size="100,100">This is the first entry in the journal. The calligraphy is neat and done with care, but the ink is already starting to fade, signaling that it might have been written a long time ago. It reads:
+&lt;/div&gt;</tw-passagedata><tw-passagedata pid="137" name="Memory Book Notes" tags="" position="1050,4600" size="100,100">This is the first entry in the journal. The calligraphy is neat and done with care, but the ink is already starting to fade, signaling that it might have been written a long time ago. It reads:
 
 &lt;span class=&quot;handwriting&quot;&gt;
 &lt;h3&gt;Memory Notes&lt;/h3&gt;
@@ -3262,9 +3187,9 @@ This part continues on to some far too detailed notes of what seems to be Ivex&#
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-  	&lt;li&gt;[[Read something else.|Journal Notes]]&lt;/li&gt;
+      &lt;li&gt;[[Read something else.|Journal Notes]]&lt;/li&gt;
   &lt;/ul&gt;\
-&lt;/div&gt;</tw-passagedata><tw-passagedata pid="145" name="School Notes" tags="" position="2046,440" size="100,100">These notes are smeared and poorly written, unlike most that surround them. They read:
+&lt;/div&gt;</tw-passagedata><tw-passagedata pid="138" name="School Notes" tags="" position="1150,4600" size="100,100">These notes are smeared and poorly written, unlike most that surround them. They read:
 
 &lt;span class=&quot;handwriting&quot;&gt;
 &lt;h3&gt;10th of the Waning Moon, 5th&lt;/h3&gt;
@@ -3295,9 +3220,9 @@ After that, the next routine writing seems to take place several days later and 
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-  	&lt;li&gt;[[Read something else.|Journal Notes]]&lt;/li&gt;
+      &lt;li&gt;[[Read something else.|Journal Notes]]&lt;/li&gt;
   &lt;/ul&gt;\
-&lt;/div&gt;</tw-passagedata><tw-passagedata pid="146" name="Tower Notes" tags="" position="1933,552" size="100,100">This note stands out amidst a bunch of unorganized notes. The writing at this point is more sporadic and rough. It speaks of concerning matters. It reads:
+&lt;/div&gt;</tw-passagedata><tw-passagedata pid="139" name="Tower Notes" tags="" position="1050,4700" size="100,100">This note stands out amidst a bunch of unorganized notes. The writing at this point is more sporadic and rough. It speaks of concerning matters. It reads:
 
 &lt;span class=&quot;mild-handwriting&quot;&gt;
 &lt;h3&gt;Completion!&lt;/h3&gt;
@@ -3317,9 +3242,9 @@ The rest of the notes on this page are crude drawings of both things that look a
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-  	&lt;li&gt;[[Read something else.|Journal Notes]]&lt;/li&gt;
+      &lt;li&gt;[[Read something else.|Journal Notes]]&lt;/li&gt;
   &lt;/ul&gt;\
-&lt;/div&gt;</tw-passagedata><tw-passagedata pid="147" name="Gem Notes" tags="" position="2046,552" size="100,100">These notes stand out amidst a bunch of unorganized notes. The writing at this point is sporadic and rough. They seem to talk about &lt;span class=&quot;imp-info&quot;&gt;gemstones&lt;/span&gt; though. It reads:
+&lt;/div&gt;</tw-passagedata><tw-passagedata pid="140" name="Gem Notes" tags="" position="1150,4700" size="100,100">These notes stand out amidst a bunch of unorganized notes. The writing at this point is sporadic and rough. They seem to talk about &lt;span class=&quot;imp-info&quot;&gt;gemstones&lt;/span&gt; though. It reads:
 
 &lt;span class=&quot;mild-handwriting&quot;&gt;
 &lt;h3&gt;Gemstones&lt;/h3&gt;
@@ -3339,9 +3264,9 @@ The notes that follow this get far too into magical terms for the wolf to proper
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-  	&lt;li&gt;[[Read something else.|Journal Notes]]&lt;/li&gt;
+      &lt;li&gt;[[Read something else.|Journal Notes]]&lt;/li&gt;
   &lt;/ul&gt;\
-&lt;/div&gt;</tw-passagedata><tw-passagedata pid="148" name="Extraction Notes" tags="" position="2155,553" size="100,100">These notes stand out amidst a bunch of unorganized notes. The writing at this point is sporadic and rough. Ivex seems to write about his plans but in a confusing manner. It reads:
+&lt;/div&gt;</tw-passagedata><tw-passagedata pid="141" name="Extraction Notes" tags="" position="1250,4700" size="100,100">These notes stand out amidst a bunch of unorganized notes. The writing at this point is sporadic and rough. Ivex seems to write about his plans but in a confusing manner. It reads:
 
 &lt;span class=&quot;mild-handwriting&quot;&gt;
 &lt;h3&gt;Extraction methodologies&lt;/h3&gt;
@@ -3365,9 +3290,9 @@ There are drawings and sketches beneath more strange notes. The drawings are lit
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-  	&lt;li&gt;[[Read something else.|Journal Notes]]&lt;/li&gt;
+      &lt;li&gt;[[Read something else.|Journal Notes]]&lt;/li&gt;
   &lt;/ul&gt;\
-&lt;/div&gt;</tw-passagedata><tw-passagedata pid="149" name="Lion Notes" tags="" position="1932,672" size="100,100">These notes are written in a brasher way with much less care for the handwriting. They seem to mention a lion, which reminds the wolf of the one he&#39;s seen in the tower, making them possibly worth reading. It reads:
+&lt;/div&gt;</tw-passagedata><tw-passagedata pid="142" name="Lion Notes" tags="" position="1050,4800" size="100,100">These notes are written in a brasher way with much less care for the handwriting. They seem to mention a lion, which reminds the wolf of the one he&#39;s seen in the tower, making them possibly worth reading. It reads:
 
 &lt;span class=&quot;crude-handwriting&quot;&gt;
 Today when I was shopping for ingredients at the Kargaro markets, two tall men grabbed me by the shoulders and led me to an alley. Taking off their hoods, I found that they were fellow felines: a tiger and a lion.
@@ -3401,9 +3326,9 @@ This seems to be where the notes about the lion end. The topic of the notes chan
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-  	&lt;li&gt;[[Read something else.|Journal Notes]]&lt;/li&gt;
+      &lt;li&gt;[[Read something else.|Journal Notes]]&lt;/li&gt;
   &lt;/ul&gt;\
-&lt;/div&gt;</tw-passagedata><tw-passagedata pid="150" name="Kink Notes" tags="" position="2045,672" size="100,100">These notes are written in a brasher way with much less care for the handwriting. Around the page, there are marks left by some kind of dry liquid and, when the wolf touches them, they feel a tad sticky. It reads:
+&lt;/div&gt;</tw-passagedata><tw-passagedata pid="143" name="Kink Notes" tags="" position="1150,4800" size="100,100">These notes are written in a brasher way with much less care for the handwriting. Around the page, there are marks left by some kind of dry liquid and, when the wolf touches them, they feel a tad sticky. It reads:
 
 &lt;span class=&quot;crude-handwriting&quot;&gt;
 Ideas to try
@@ -3444,9 +3369,9 @@ There are dozens of other ideas written here, but the anger inside the wolf make
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-  	&lt;li&gt;[[Read something else.|Journal Notes]]&lt;/li&gt;
+      &lt;li&gt;[[Read something else.|Journal Notes]]&lt;/li&gt;
   &lt;/ul&gt;\
-&lt;/div&gt;</tw-passagedata><tw-passagedata pid="151" name="Thief Notes" tags="" position="2156,671" size="100,100">These notes are written in a brasher way with much less care for the handwriting. The ink in these notes is dry but still strong, signaling that they might be recent. It reads:
+&lt;/div&gt;</tw-passagedata><tw-passagedata pid="144" name="Thief Notes" tags="" position="600,4775" size="100,100">These notes are written in a brasher way with much less care for the handwriting. The ink in these notes is dry but still strong, signaling that they might be recent. It reads:
 
 &lt;span class=&quot;crude-handwriting&quot;&gt;
 There was a pathetic attempt to escape my tower last night. The sly little fox adventurer I captured last week was left bound to my wooden cross in the extraction hall. I planned on going back to play with him in the morning, but what I found was that the cross was empty. The fucker had managed to cut the magic ropes I used to keep the cross in place and got away.
@@ -3474,7 +3399,7 @@ This is the last entry in the journal so far. The wolf&#39;s eyes go wide. This 
 This is the last entry on the journal so far and, thankfully, it has already proven to be very useful.
 &lt;&lt;/if&gt;&gt;\
 
-[[Continue|Notes Knowledge]]</tw-passagedata><tw-passagedata pid="152" name="Notes Knowledge" tags="key" position="1945,814" size="100,100">&lt;&lt;if !$journalKnowledge&gt;&gt;\
+[[Continue|Notes Knowledge]]</tw-passagedata><tw-passagedata pid="145" name="Notes Knowledge" tags="key" position="400,4825" size="100,100">&lt;&lt;if !$journalKnowledge&gt;&gt;\
 Re-reading the journal entry one more time, the naked wolf&#39;s tail wags back and forth. That poor fox, wherever he is, left very useful information in these records! If that fox adventurer could have escaped the tower, then so can &lt;&lt;print $name&gt;&gt;.
 
 All he needs to do is gather the right things...
@@ -3502,19 +3427,19 @@ The wolf&#39;s ears twitch and his smile widens. He, in fact, already has some k
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-  	&lt;li&gt;[[Assess his knowledge...|Knowledge Assessment]]&lt;/li&gt;
+      &lt;li&gt;[[Assess his knowledge...|Knowledge Assessment]]&lt;/li&gt;
   &lt;/ul&gt;\
 &lt;/div&gt;
 &lt;&lt;else&gt;&gt;\
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-  	&lt;li&gt;[[Read something else on the journal.|Journal Notes]]&lt;/li&gt;
-  	&lt;li&gt;[[Sift through the other contents of the desk.|The Desk]]&lt;/li&gt;	
-  	&lt;li&gt;[[Get away from the desk and look somewhere else.|Extraction Room]]&lt;/li&gt;	
+      &lt;li&gt;[[Read something else on the journal.|Journal Notes]]&lt;/li&gt;
+      &lt;li&gt;[[Sift through the other contents of the desk.|The Desk]]&lt;/li&gt;	
+      &lt;li&gt;[[Get away from the desk and look somewhere else.|Extraction Room]]&lt;/li&gt;	
   &lt;/ul&gt;\
 &lt;/div&gt;
-&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="153" name="Gemstone Crafting" tags="key" position="1781,1136" size="100,100">The naked wolf pulls the desk&#39;s chair and sits on it properly. He sets a gray gemstone from the lion&#39;s room on the table and pulls the spellbook closer to himself.
+&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="146" name="Gemstone Crafting" tags="key" position="825,5200" size="100,100">The naked wolf pulls the desk&#39;s chair and sits on it properly. He sets a gray gemstone from the lion&#39;s room on the table and pulls the spellbook closer to himself.
 
 With a frown, he begins looking for the right spell. Luckily, it doesn&#39;t take long for him to smile as he finds what has to be the right one.
 
@@ -3530,7 +3455,7 @@ But then, it does. As anxiety is starting to set on the wolf, the drawn circle i
 
 And then, just like that, the glow goes away. When the wolf looks at it again, he smiles widely. In place of the gray gemstone sits an infused, glowing red one. The stone he supposedly needs.
 
-[[Continue|The Exit]]</tw-passagedata><tw-passagedata pid="154" name="Knowledge Assessment" tags="key" position="1641,849" size="100,100">According to Ivex&#39;s journal, the wolf needs a &lt;span class=&quot;imp-info&quot;&gt;red teleportation gemstone&lt;/span&gt; to get out of the tower.
+[[Continue|The Exit]]</tw-passagedata><tw-passagedata pid="147" name="Knowledge Assessment" tags="key" position="200,4850" size="100,100">According to Ivex&#39;s journal, the wolf needs a &lt;span class=&quot;imp-info&quot;&gt;red teleportation gemstone&lt;/span&gt; to get out of the tower.
 
 Ivex&#39;s journal mentions two ways to get those...
 
@@ -3560,16 +3485,16 @@ Crafting a gemstone could be possible if only the wolf could find all of the req
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
     &lt;&lt;if $spellbookKnowledge &amp;&amp; $lionGemstoneKnowledge&gt;&gt;\
-  	&lt;li&gt;[[Try and craft the red gemstone.|Gemstone Crafting]]&lt;/li&gt;
-	&lt;&lt;else&gt;&gt;\
-	&lt;li&gt;[[Read something else on the journal.|Journal Notes]]&lt;/li&gt;
-	&lt;li&gt;[[Go back to the main hallway to explore more...|Second Floor]]&lt;/li&gt;
-	&lt;&lt;/if&gt;&gt;\
-	&lt;&lt;if $blobGemstoneKnowledge&gt;&gt;\
-	&lt;li&gt;[[Try and get the red gemstone left by the fox.|The Altar]]&lt;/li&gt;
-	&lt;&lt;/if&gt;&gt;\
+      &lt;li&gt;[[Try and craft the red gemstone.|Gemstone Crafting]]&lt;/li&gt;
+    &lt;&lt;else&gt;&gt;\
+    &lt;li&gt;[[Read something else on the journal.|Journal Notes]]&lt;/li&gt;
+    &lt;li&gt;[[Go back to the main hallway to explore more...|Second Floor]]&lt;/li&gt;
+    &lt;&lt;/if&gt;&gt;\
+    &lt;&lt;if $blobGemstoneKnowledge&gt;&gt;\
+    &lt;li&gt;[[Try and get the red gemstone left by the fox.|The Altar]]&lt;/li&gt;
+    &lt;&lt;/if&gt;&gt;\
   &lt;/ul&gt;\
-&lt;/div&gt;</tw-passagedata><tw-passagedata pid="155" name="The Exit" tags="" position="1933,1137" size="100,100">With care, $name grabs the gemstone. He holds it in his paw. It feels warm to the touch. The wolf looks at it, takes a sniff at it, then holds it up with two fingers to inspect it properly. It&#39;s a beautiful gemstone, but... how to use it?
+&lt;/div&gt;</tw-passagedata><tw-passagedata pid="148" name="The Exit" tags="" position="825,5325" size="100,100">With care, $name grabs the gemstone. He holds it in his paw. It feels warm to the touch. The wolf looks at it, takes a sniff at it, then holds it up with two fingers to inspect it properly. It&#39;s a beautiful gemstone, but... how to use it?
 
 Even though he has it, $name frowns. Does he need to go to a certain place? Speak certain words? Ivex didn&#39;t when he left, but the panther mage could do a whole lot of impressive and downright impossible things.
 
@@ -3581,7 +3506,7 @@ Frustrated, $name closes his fist around the gemstone. Just as the wolf pushes t
 
 The whole world around him starts shifting into a blur.
 
-[[Continue|Outside]]</tw-passagedata><tw-passagedata pid="156" name="Outside" tags="" position="2079,1139" size="100,100">The big wolf stumbles forward. A sense of vertigo overwhelms him for a moment as everything spins and loses its shape. However, as quickly as it comes, the feeling goes away. The wolf suddenly feels his feet touching the ground again. His hands find a table behind him to hold onto to keep himself steady and, when he blinks... everything feels different.
+[[Continue|Outside]]</tw-passagedata><tw-passagedata pid="149" name="Outside" tags="restart" position="950,5325" size="100,100">The big wolf stumbles forward. A sense of vertigo overwhelms him for a moment as everything spins and loses its shape. However, as quickly as it comes, the feeling goes away. The wolf suddenly feels his feet touching the ground again. His hands find a table behind him to hold onto to keep himself steady and, when he blinks... everything feels different.
 
 The air on his bare fur feels colder than before. The floor under his feet is simple wood rather than stone. As the wolf looks around, he realizes he is no longer in the large hallway he was before, but rather somewhere else entirely.
 
@@ -3595,7 +3520,7 @@ Inside the gemstone, he can see... a tower. A miniature tower that looks exactly
 
 Before $name can ponder more over the implications of that, the sound of steps coming from outside the room have the warrior twisting on his feet.
 
-[[Continue|Ivex&#39;s Fall]]</tw-passagedata><tw-passagedata pid="157" name="Ivex&#39;s Fall" tags="" position="2228,1141" size="100,100">Not knowing what to expect, the wolf prepares himself as best as he can in his naked, unarmed state. The door opens casually without rush, but the person coming in...
+[[Continue|Ivex&#39;s Fall]]</tw-passagedata><tw-passagedata pid="150" name="Ivex&#39;s Fall" tags="" position="950,5450" size="100,100">Not knowing what to expect, the wolf prepares himself as best as he can in his naked, unarmed state. The door opens casually without rush, but the person coming in...
 
 Is none other than Ivex himself.
 
@@ -3637,25 +3562,7 @@ As he stares at the arrogant, puny mage, however... a few ideas come to his mind
 
 He looks around. All those gemstones scattered across the floor are the source of Ivex&#39;s power. Without them, the panther seemed absolutely helpless.
 
-[[Continue|Tying up]]</tw-passagedata><tw-passagedata pid="158" name="To Be Continued 3" tags="" position="1911,1343" size="100,100">&lt;b&gt;Aaaand... that&#39;s it, once more!&lt;/b&gt;
-
-The final escape and Ivex&#39;s downfall signal the end of this month&#39;s build. The next build will be the last... and it will include nothing but the endings and all the interesting ways you can choose to make the arrogant mage pay for what he&#39;s done.
-
-I have a few things in mind, but I intend on putting up a Patreon vote to let my faithful patrons decide on one of the possibilities we might see here. What kinks will it include? What should our very, very angry wolf put the panther through? We&#39;ll see what people decide!
-
-For now, this is it! As always, I encourage you to go back and try some new things if you haven&#39;t yet. Have you seen all the ways things can go wrong before you reach this point? Their variations? Have you tried doing things in a different order?
-
-Starting from this build, you can check out the [[Archives]] (also always available in the sidebar menu) and see what you have unlocked and what&#39;s still left to be unlocked! Not only that, but in there, you&#39;ll have the ability to easily read through any endings you have already unlocked as many times as you want without having to go through the entire game to reach them. I hope you enjoy it!
-
-As always, thank you so much for playing this prototype interactive story. I really hope it&#39;s been an enjoyable ride so far!
-
-From here, you also can...
-
-[[Return to the start of the second floor|Escape Start]]
-
-OR!
-
-[[Return all the way to the beginning|Bound]]</tw-passagedata><tw-passagedata pid="159" name="Pulled In (Text)" tags="text" position="1311,491" size="100,100">Intent on getting that gemstone, the wolf brings his paw up to the blob. Slowly and carefully, he approaches it to test it with a clawed finger until...
+[[Continue|Tying up]]</tw-passagedata><tw-passagedata pid="151" name="Pulled In (Text)" tags="text" position="925,4100" size="100,100">Intent on getting that gemstone, the wolf brings his paw up to the blob. Slowly and carefully, he approaches it to test it with a clawed finger until...
 
 He pokes at it. The whole surface ripples when he does, but the blob remains firm in place. It feels... strange. Definitely viscous and more &#39;wet&#39; than he thought. Odd. Nothing in particular happens, however, and the wolf pokes it a few more times, seeing it bounce and ripple in response to it. With a small chuckle, the wolf just shakes his head and pulls his paw away.
 
@@ -3665,7 +3572,7 @@ When $name tries to pull his finger away from the slime, he finds that it pulls 
 
 With a small growl and a frown, the wolf pulls harder. The large warrior puts the strength of his muscles into pulling, his other paw coming to wrap around his wrist to pull it more, yet even if he does manage to distend the blob a little further... it still doesn&#39;t let go. It feels like his entire finger might come loose before the blob lets go of it. 
 
-Stopping his pulling for a moment, the wolf stops to catch his breath. Looking at the blob, $name tries to think of a solution for a moment, when all of a sudden...</tw-passagedata><tw-passagedata pid="160" name="Pulled Further (Text)" tags="text" position="1558,464" size="100,100">The wolf&#39;s ears twitch when he feels his wrist getting engulfed in one swift motion. The blob protrudes itself forward to grab more of his paw, and before the wolf can even properly react, &lt;b&gt;it&lt;/b&gt; pulls him.
+Stopping his pulling for a moment, the wolf stops to catch his breath. Looking at the blob, $name tries to think of a solution for a moment, when all of a sudden...</tw-passagedata><tw-passagedata pid="152" name="Pulled Further (Text)" tags="text" position="1050,4100" size="100,100">The wolf&#39;s ears twitch when he feels his wrist getting engulfed in one swift motion. The blob protrudes itself forward to grab more of his paw, and before the wolf can even properly react, &lt;b&gt;it&lt;/b&gt; pulls him.
 
 &quot;Whoa!&quot; The wolf stumbles forward, the entirety of his arm pulled into the viscous blob before he can plant his feet on the ground and use his other hand to grab onto the platform&#39;s edge and keep it from pulling him further in. With a growl, the wolf tries to pull his arm out but meets the same resistance that his finger had met before.
 
@@ -3679,7 +3586,7 @@ The next sudden pull has the wolf stumbling forward once more and his arm sinkin
 
 $name fights bravely, but soon his hand slips and the blob pulls him in so that his neck and the side of his head get pulled in. Desperately, $name tries to fight against it, but with even less leverage...
 
-In one sudden, even more surprising move, the blob suddenly sucks him in with such strength that the wolf as a whole gets taken into its form.</tw-passagedata><tw-passagedata pid="161" name="Extraction 1 (Text)" tags="text" position="1426,235" size="100,100">&lt;&lt;print $name&gt;&gt;&#39;s first instinct is to hold his breath as he gets pulled into the viscous blob. Keeping his muzzle well shut, the wolf thrashes as best as he can inside it. It all feels... sticky, wet and warm. It feels like being underwater, but its texture is thicker and moving inside it is hard. It takes a lot of strength from the wolf to be able to wave his arms in a feeble attempt to &#39;swim&#39; out of the thing, but the blob keeps him engulfed.
+In one sudden, even more surprising move, the blob suddenly sucks him in with such strength that the wolf as a whole gets taken into its form.</tw-passagedata><tw-passagedata pid="153" name="Extraction 1 (Text)" tags="text" position="1175,4100" size="100,100">&lt;&lt;print $name&gt;&gt;&#39;s first instinct is to hold his breath as he gets pulled into the viscous blob. Keeping his muzzle well shut, the wolf thrashes as best as he can inside it. It all feels... sticky, wet and warm. It feels like being underwater, but its texture is thicker and moving inside it is hard. It takes a lot of strength from the wolf to be able to wave his arms in a feeble attempt to &#39;swim&#39; out of the thing, but the blob keeps him engulfed.
 
 Before long, it starts hardening too. Moving becomes harder and harder. The wolf is left in an awkward &#39;floating&#39; position with his limbs half-spread. Grunting, $name&#39;s muscles bulge with effort as he tries to keep moving, but the liquid hardens all around him, stopping the wolf altogether and keeping him well inside it.
 
@@ -3695,7 +3602,7 @@ Breath after eager breath, the frozen wolf takes it all in gladly. Though his si
 
 As $name is busy regaining his breath, though, the wolf&#39;s eyes widen once more. The slime starts moving more around his body. He can feel its slimy caressing in a very weird way. It moves all around him, encasing and feeling his chest, his stomach, his legs, going through his whole body, and then...
 
-$name can&#39;t even frown when he feels it starts focusing on his forcefully erect cock.</tw-passagedata><tw-passagedata pid="162" name="Extraction 2 (Text)" tags="text" position="1084,145" size="100,100">No matter how much the wolf tries to struggle or move, it feels as if he might as well be encased in solid rock. The slime around him does not budge even a little. His arms, legs, paws, everything remains completely immobile and yet, at the same time, the slime&#39;s texture can be felt over it. Always moving, always working.
+$name can&#39;t even frown when he feels it starts focusing on his forcefully erect cock.</tw-passagedata><tw-passagedata pid="154" name="Extraction 2 (Text)" tags="text" position="1300,4100" size="100,100">No matter how much the wolf tries to struggle or move, it feels as if he might as well be encased in solid rock. The slime around him does not budge even a little. His arms, legs, paws, everything remains completely immobile and yet, at the same time, the slime&#39;s texture can be felt over it. Always moving, always working.
 
 Thankfully for $name, his muzzle ended up slightly tilted so that, directing his eyes downwards, he can look down at his own cock. It stands there just as erect as it was when he fell into the slime. The red spire protruding from his sheath with its veiny, dark red surface remains still as well, and yet...
 
@@ -3705,7 +3612,7 @@ The wolf lets out a growl from his throat. The sound barely makes it past his en
 
 Before the wolf can ponder on it further, the movement around his cock changes. The paralyzed wolf&#39;s eyes dart down towards it and, this time, he can see it for sure.
 
-Though the slime seems solid as rock everywhere else, around his cock it moves. It flexes, its surface shifting ever so slightly around his member and, as it does, the wolf can feel... a stroke over his sensitive shaft.</tw-passagedata><tw-passagedata pid="163" name="Extraction 3 (Text)" tags="text" position="1258,31" size="100,100">The slime does it again. And again, and again. It starts a slow, rhythmic set of movements around the wolf&#39;s cock, kneading it at the same time as it strokes it. At first, the strokes are loose and wild, but as the slime moves up and down, it seems to adapt to his length. The strokes become wider, reaching all the way to the wolf&#39;s tapered tip and then going downwards all the way to the top of his knot, which in turn throbs and pulses, growing more engorged for the stimulation.
+Though the slime seems solid as rock everywhere else, around his cock it moves. It flexes, its surface shifting ever so slightly around his member and, as it does, the wolf can feel... a stroke over his sensitive shaft.</tw-passagedata><tw-passagedata pid="155" name="Extraction 3 (Text)" tags="text" position="1425,4100" size="100,100">The slime does it again. And again, and again. It starts a slow, rhythmic set of movements around the wolf&#39;s cock, kneading it at the same time as it strokes it. At first, the strokes are loose and wild, but as the slime moves up and down, it seems to adapt to his length. The strokes become wider, reaching all the way to the wolf&#39;s tapered tip and then going downwards all the way to the top of his knot, which in turn throbs and pulses, growing more engorged for the stimulation.
 
 From within the slime, $name growls again, but he also can&#39;t help but moan. Completely immobilized, the wolf can&#39;t even frown as the weird magical slime starts masturbating him without his consent.
 
@@ -3713,7 +3620,7 @@ Pleasure surges through the bound lupine. The candle&#39;s after-effects still l
 
 At the moment, it&#39;s hard to think. As the slime keeps stroking the wolf&#39;s cock with increased precision and speed, the pleasure is undeniable. A small burst of pre-cum comes from its tip and, with that, the slime seems to redouble its efforts in masturbating him. What the hell does it want?
 
-There&#39;s little the wolf can do. Inside him, his rage swells. He can try harder to fight against this thing. Ivex won&#39;t get him that easily! On the other hand, it&#39;s much, much easier to just give in to the pleasure. It feels so heavenly good. It&#39;s not like there&#39;s anyone watching. Maybe giving in to it just for a little while would be beneficial as well...</tw-passagedata><tw-passagedata pid="164" name="Forceful Extraction 1 (Text)" tags="text" position="1535,323" size="100,100">No! The wolf lets out another muffled growl. A powerful warrior such as him will never, ever give in to this mage&#39;s perverted machinations!
+There&#39;s little the wolf can do. Inside him, his rage swells. He can try harder to fight against this thing. Ivex won&#39;t get him that easily! On the other hand, it&#39;s much, much easier to just give in to the pleasure. It feels so heavenly good. It&#39;s not like there&#39;s anyone watching. Maybe giving in to it just for a little while would be beneficial as well...</tw-passagedata><tw-passagedata pid="156" name="Forceful Extraction 1 (Text)" tags="text" position="1550,4150" size="100,100">No! The wolf lets out another muffled growl. A powerful warrior such as him will never, ever give in to this mage&#39;s perverted machinations!
 
 Huffing in outrage, the wolf redoubles his efforts to fight against the slime encasing him. His biceps, his chest, all of his muscles bulge out with effort as the wolf does his best to ignore the pleasure forcefully enveloping his cock and, instead, puts all of his might into forcing himself against the slime.
 
@@ -3731,7 +3638,7 @@ As it does, however, the slime around him feels, somehow, even more solid than b
 
 And the wolf is left panting from all of his efforts with a lingering ache on his balls. Then, much to his dismay, the slime softens around his cock again and immediately restarts its work in forcefully pleasuring him. If anything, it seems to work with harsher strokes than before.
 
-It can&#39;t be!</tw-passagedata><tw-passagedata pid="165" name="Forceful Extraction 2 (Text)" tags="text" position="1672,321" size="100,100">With even more outrage, the wolf is determined to fight again. Once more, his muscles bulge as he summons his strength. The outrage swells within him. His eyes focus down on his cock, abused by the slime moving around it, pleasuring its surface...
+It can&#39;t be!</tw-passagedata><tw-passagedata pid="157" name="Forceful Extraction 2 (Text)" tags="text" position="1675,4150" size="100,100">With even more outrage, the wolf is determined to fight again. Once more, his muscles bulge as he summons his strength. The outrage swells within him. His eyes focus down on his cock, abused by the slime moving around it, pleasuring its surface...
 
 The wolf does his best to try and ignore it. He huffs from the effort while, at the same time, he groans from the pleasure. The slime goes up and down the smooth surface of his cock, assaulting it from all sides. It feels like the softest of hands is stroking him, like a group of smooth tongues is licking it, from top to bottom, over and over again. The wolf can see its surface displacing itself as it moves from the tip of his cock to the base and back, and then, as it goes down his shaft just like all the other times...
 
@@ -3747,7 +3654,7 @@ His arms, his legs, his head, anything. He growls, desperately trying to move, d
 
 The slime keeps pleasuring his cock, but as the wolf tries and tries to fight against it, the rippling around his member does seem to falter somewhat. It tilts this way or that every now and then, as if the slime is having difficulty keeping him at bay.
 
-It gives the wolf hope! The slime starts speeding up the treatment of his member, maybe trying to distract him with pleasure? He won&#39;t fall for it, though! The wolf is determined to keep fighting no matter what! Just as he thinks he might get some movement done inside the slime again, however...</tw-passagedata><tw-passagedata pid="166" name="Forceful Extraction 3 (Text)" tags="text" position="1797,324" size="100,100">The slime hardens again. This time, however, it does not feel the same as last time.
+It gives the wolf hope! The slime starts speeding up the treatment of his member, maybe trying to distract him with pleasure? He won&#39;t fall for it, though! The wolf is determined to keep fighting no matter what! Just as he thinks he might get some movement done inside the slime again, however...</tw-passagedata><tw-passagedata pid="158" name="Forceful Extraction 3 (Text)" tags="text" position="1800,4150" size="100,100">The slime hardens again. This time, however, it does not feel the same as last time.
 
 All around his body, that pressure comes from the viscous liquid again, yet around his cock, the stroking doesn&#39;t stop. If anything, it increases. While before the wolf could feel a single displacement in the slime&#39;s surface going up and down his length, a second one now appears. Then a third, then a fourth. All of them assault his cock, kneading it from different sides to the point where his cock even bobs back and forth inside the liquid as the different surfaces start masturbating it. The feeling of them around his shaft, around his &lt;b&gt;knot&lt;/b&gt;, makes the wolf let out a drawn-out groan as the pleasure enforced on him increases tenfold.
 
@@ -3759,7 +3666,7 @@ The slime starts softening around his sheath. Then around his balls. The same to
 
 &quot;HMMFGH!&quot; the wolf howls in outrage. With the slime around his upper body feeling harder, the sound barely makes it past his muzzle anymore. $name tries and tries to fight it in outrage, but with the increased assault on his cock and knot joined in by the one on his balls, the stimulation is too much. The wolf&#39;s ears grow red, the humiliation growing as he feels the slime succeeding in extracting the pleasure out of him. It&#39;s close...
 
-And then, things get even worse for the captured adventurer.</tw-passagedata><tw-passagedata pid="167" name="Forceful Extraction End (Text)" tags="text" position="1921,324" size="100,100">As if the stimulation on his cock and balls wasn&#39;t enough, the wolf feels the slime start to soften around the underside of his tail as well.
+And then, things get even worse for the captured adventurer.</tw-passagedata><tw-passagedata pid="159" name="Forceful Extraction End (Text)" tags="text" position="1925,4150" size="100,100">As if the stimulation on his cock and balls wasn&#39;t enough, the wolf feels the slime start to soften around the underside of his tail as well.
 
 Frantically, the wolf&#39;s eyes grow even wider.
 
@@ -3775,7 +3682,7 @@ All the pleasure being inflicted on him comes together. The wolf&#39;s eyes roll
 
 With a drawn-out muffled moan, the wolf&#39;s exposed cock starts pulsing inside the slime and then, as the wolf feels the pleasure of climax overwhelm his entire being, it flexes as the first strong jet of wolf cum is expelled from it.
 
-It doesn&#39;t stop there, and neither does the slime. All the stimulation keeps going as the wolf&#39;s orgasm hits, shooting jet after jet of cum into the slime. His seed seems to be &#39;caught&#39; by the blob. The white, pearly substance is gathered just above his cock, melding together as the wolf is forced to shoot more and more. The slime keeps milking him, kneading his cock, his knot, and pressing hard inside his ass until the wolf&#39;s cock is reduced to quick throbs, spurting the last remnants of his orgasm. Only then does the slime start slowing down, although the stimulation doesn&#39;t truly stop. It allows the wolf to catch his breath, though. And as he looks down...</tw-passagedata><tw-passagedata pid="168" name="Extraction End 1 (Text)" tags="text" position="2058,178" size="100,100">The seed the wolf expelled is taken by the slime. It travels through its surface around the wolf&#39;s body and then it goes down. The wolf remembers the small hole he had seen in the altar beneath the slime and, seeing no more traces of his seed, he can only assume it was taken there.
+It doesn&#39;t stop there, and neither does the slime. All the stimulation keeps going as the wolf&#39;s orgasm hits, shooting jet after jet of cum into the slime. His seed seems to be &#39;caught&#39; by the blob. The white, pearly substance is gathered just above his cock, melding together as the wolf is forced to shoot more and more. The slime keeps milking him, kneading his cock, his knot, and pressing hard inside his ass until the wolf&#39;s cock is reduced to quick throbs, spurting the last remnants of his orgasm. Only then does the slime start slowing down, although the stimulation doesn&#39;t truly stop. It allows the wolf to catch his breath, though. And as he looks down...</tw-passagedata><tw-passagedata pid="160" name="Extraction End 1 (Text)" tags="text" position="2050,4075" size="100,100">The seed the wolf expelled is taken by the slime. It travels through its surface around the wolf&#39;s body and then it goes down. The wolf remembers the small hole he had seen in the altar beneath the slime and, seeing no more traces of his seed, he can only assume it was taken there.
 
 Before $name can ponder on what might happen next, it simply starts over again.
 
@@ -3791,7 +3698,7 @@ Trapped inside the slime completely in the dark feels worse. It keeps assaulting
 
 And then, as always, it does.
 
-As the wolf is being forcefully milked by the slime, a flicker of light suddenly appears above him.</tw-passagedata><tw-passagedata pid="169" name="Forceful Extraction End 2 (Text)" tags="text" position="2194,342" size="100,100">The wolf&#39;s eyes grow wide as his eyes and nose recognize what the light is at the same time. 
+As the wolf is being forcefully milked by the slime, a flicker of light suddenly appears above him.</tw-passagedata><tw-passagedata pid="161" name="Forceful Extraction End 2 (Text)" tags="text" position="2175,4150" size="100,100">The wolf&#39;s eyes grow wide as his eyes and nose recognize what the light is at the same time. 
 
 It&#39;s a candle. It burns on a special candleholder built inside the closed alcove. A bright red, large candle that looks exactly the same as the one he&#39;s seen before.
 
@@ -3823,7 +3730,7 @@ Every now and then, the wolf is aware that he falls asleep, but even as he does,
 
 At one point, $name is barely aware that Ivex opens his alcove to look at him. The mage says a few words that he cannot hear because he&#39;s busy howling as his cock shoots his seed for the slime to collect. The panther mage just laughs, then with his glowing hand, reaches into the blob as if it was water, takes the red gemstone with him, smirks and closes the alcove again, leaving him in the dark with the slime and the candles. The slime kneads his cock, works his knot, pounds his ass...
 
-The pleasure feels unending.</tw-passagedata><tw-passagedata pid="170" name="Gentle Extraction End 2 (Text)" tags="text" position="2198,103" size="100,100">The wolf&#39;s eyes grow wide as his eyes and nose recognize what the light is at the same time. 
+The pleasure feels unending.</tw-passagedata><tw-passagedata pid="162" name="Gentle Extraction End 2 (Text)" tags="text" position="2175,3825" size="100,100">The wolf&#39;s eyes grow wide as his eyes and nose recognize what the light is at the same time. 
 
 It&#39;s a candle. It burns on a special candleholder built inside the closed alcove. A bright red, large candle that looks exactly the same as the one he&#39;s seen before.
 
@@ -3855,7 +3762,7 @@ Every now and then, the wolf is aware that he falls asleep, but even as he does,
 
 At one point, $name is barely aware that Ivex opens his alcove to look at him. The mage says a few words that he cannot hear because he&#39;s busy howling as his cock shoots his seed for the slime to collect. The panther mage just laughs, then with his glowing hand, reaches into the blob as if it was water, takes the red gemstone with him, smirks and closes the alcove again, leaving him in the dark with the slime and the candles. The slime kneads his cock, works his knot and teases his entire body.
 
-The pleasure feels unending.</tw-passagedata><tw-passagedata pid="171" name="Gentle Extraction 1 (Text)" tags="text" position="1533,102" size="100,100">Yeah. The wolf lets out a muffled groan. Just for a moment, $name lets himself relax inside the slime as it continues to treat his cock.
+The pleasure feels unending.</tw-passagedata><tw-passagedata pid="163" name="Gentle Extraction 1 (Text)" tags="text" position="1550,3825" size="100,100">Yeah. The wolf lets out a muffled groan. Just for a moment, $name lets himself relax inside the slime as it continues to treat his cock.
 
 Resting for just a moment feels wise. The wolf is gathering his strength, he tells himself, as he feels pleasure emanating from his loins all over his body because of what the slime does. His face and ears grow red for letting it happen, but what can he do?
 
@@ -3865,7 +3772,7 @@ It&#39;s so hard to resist it. As he lets himself feel it, the wolf&#39;s urge i
 
 His hips try to move reflexively to do that, but they can&#39;t. Of course, they can&#39;t. The wolf lets out a frustrated whine knowing that he&#39;s at the mercy of the slime. At the rate it&#39;s going, though...
 
-As if reading his thoughts, the wolf can swear the slime starts speeding up. Its strokes, up and down the wolf&#39;s smooth, red length, become a little tighter. The pleasure is... almost too much.</tw-passagedata><tw-passagedata pid="172" name="Gentle Extraction 2 (Text)" tags="text" position="1673,101" size="100,100">Despite all the pleasure, the wolf clings to his willpower. He can&#39;t let it overcome him, he has to fight it! With effort, his muscles bulge as he summons his strength. The outrage swells within him. His eyes focus down on his cock, abused by the slime moving around it, pleasuring its surface...
+As if reading his thoughts, the wolf can swear the slime starts speeding up. Its strokes, up and down the wolf&#39;s smooth, red length, become a little tighter. The pleasure is... almost too much.</tw-passagedata><tw-passagedata pid="164" name="Gentle Extraction 2 (Text)" tags="text" position="1675,3825" size="100,100">Despite all the pleasure, the wolf clings to his willpower. He can&#39;t let it overcome him, he has to fight it! With effort, his muscles bulge as he summons his strength. The outrage swells within him. His eyes focus down on his cock, abused by the slime moving around it, pleasuring its surface...
 
 The wolf does his best to try and ignore it. He huffs from the effort while, at the same time, he groans from the pleasure. The slime goes up and down the smooth surface of his cock, assaulting it from all sides. It feels like the softest of hands is stroking him, like a group of smooth tongues is licking it, from top to bottom, over and over again. The wolf can see its surface displacing itself as it moves from the tip of his cock to the base and back, and then, as it goes down his shaft just like all the other times...
 
@@ -3877,7 +3784,7 @@ $name would close his eyes if he could. They lose focus as the pleasure overwhel
 
 The pleasure is overwhelming. The slime keeps pleasuring his cock. It&#39;s impossible to fight it. It just feels too good. Little by little, the rippling around his member gets more and more intense. It makes it incredibly hard to focus on anything else.
 
-The slime starts speeding up the treatment of his member, and then...</tw-passagedata><tw-passagedata pid="173" name="Gentle Extraction 3 (Text)" tags="text" position="1801,101" size="100,100">The slime softens itself even more around the wolf. It starts to feel like floating in water and, though the pleasure is almost overwhelming, even in his relaxed state, $name realizes he can move his head. Thoughts of trying to get away pop up in his head and try to fight the lust he&#39;s feeling, but before he can move at all, the slime itself does.
+The slime starts speeding up the treatment of his member, and then...</tw-passagedata><tw-passagedata pid="165" name="Gentle Extraction 3 (Text)" tags="text" position="1800,3825" size="100,100">The slime softens itself even more around the wolf. It starts to feel like floating in water and, though the pleasure is almost overwhelming, even in his relaxed state, $name realizes he can move his head. Thoughts of trying to get away pop up in his head and try to fight the lust he&#39;s feeling, but before he can move at all, the slime itself does.
 
 When the wolf feels everything shifting around his body, his reflex is to move his arms or his legs to keep himself balanced. He quickly finds that that&#39;s not possible, though. Though the blob around him feels softer, it still feels sticky and impossible to push through for his limbs.
 
@@ -3891,7 +3798,7 @@ The slime starts softening around his sheath. Then around his balls. The same to
 
 &quot;Hmmmffffhh...&quot; the wolf moans in pleasure. With the slime around him feeling softer, the sound echoes through the empty room. $name can&#39;t help but let himself relax once more, the increased assault on his cock and knot joined in by the one on his balls, the stimulation is too much. The wolf&#39;s ears grow red, the humiliation growing as he feels the slime succeeding in extracting the pleasure out of him. It&#39;s close...
 
-And then, things grow even more intense for the captured adventurer.</tw-passagedata><tw-passagedata pid="174" name="Gentle Extraction End (Text)" tags="text" position="1926,102" size="100,100">As if the stimulation on his cock and balls wasn&#39;t enough, the wolf feels the soft slime all around his body start to move and twitch as well.
+And then, things grow even more intense for the captured adventurer.</tw-passagedata><tw-passagedata pid="166" name="Gentle Extraction End (Text)" tags="text" position="1925,3825" size="100,100">As if the stimulation on his cock and balls wasn&#39;t enough, the wolf feels the soft slime all around his body start to move and twitch as well.
 
 The wolf&#39;s eyes grow wide.
 
@@ -3911,7 +3818,7 @@ All the pleasure around him comes together. The wolf&#39;s eyes roll back as the
 
 With a drawn-out moan, the wolf&#39;s exposed cock starts pulsing inside the slime and then, as the wolf feels the pleasure of climax overwhelm his entire being, it flexes as the first strong jet of wolf cum is expelled from it.
 
-It doesn&#39;t stop there, and neither does the slime. All the stimulation keeps going as the wolf&#39;s orgasm hits, shooting jet after jet of cum into the slime. His seed seems to be &#39;caught&#39; by the blob. The white, pearly substance is gathered just above his cock, melding together as the wolf is encouraged to shoot more and more. The slime keeps milking him, kneading his cock, his knot, and inflicting pleasure all around his body until the wolf&#39;s cock is reduced to quick throbs, spurting the last remnants of his orgasm. Only then does the slime start slowing down, although the stimulation doesn&#39;t truly stop. It allows the wolf to catch his breath, though. And as he looks down…</tw-passagedata><tw-passagedata pid="175" name="Extraction Archive Display" tags="" position="180,2911" size="100,100">&lt;&lt;silently&gt;&gt;\
+It doesn&#39;t stop there, and neither does the slime. All the stimulation keeps going as the wolf&#39;s orgasm hits, shooting jet after jet of cum into the slime. His seed seems to be &#39;caught&#39; by the blob. The white, pearly substance is gathered just above his cock, melding together as the wolf is encouraged to shoot more and more. The slime keeps milking him, kneading his cock, his knot, and inflicting pleasure all around his body until the wolf&#39;s cock is reduced to quick throbs, spurting the last remnants of his orgasm. Only then does the slime start slowing down, although the stimulation doesn&#39;t truly stop. It allows the wolf to catch his breath, though. And as he looks down…</tw-passagedata><tw-passagedata pid="167" name="Extraction Archive Display" tags="noreturn" position="1950,1000" size="100,100">&lt;&lt;silently&gt;&gt;\
   &lt;&lt;if $extractionGentleEnd &amp;&amp; $extractionForcefulEnd&gt;&gt;
     &lt;&lt;set $extractionVariant = &#39;gentle&#39;&gt;&gt;
   &lt;&lt;elseif $extractionGentleEnd &amp;&amp; !$extractionForcefulEnd&gt;&gt;
@@ -3927,36 +3834,36 @@ It doesn&#39;t stop there, and neither does the slime. All the stimulation keeps
   &lt;b&gt;[[Bad Ending: Extraction|Extraction Archive]]&lt;/b&gt;
   Variation: &lt;&lt;nobr&gt;&gt;
   &lt;&lt;if $extractionGentleEnd&gt;&gt;
-	&lt;label&gt;&lt;&lt;radiobutton &quot;$extractionVariant&quot; &quot;gentle&quot; autocheck&gt;&gt; Gentle&lt;/label&gt;
+    &lt;label&gt;&lt;&lt;radiobutton &quot;$extractionVariant&quot; &quot;gentle&quot; autocheck&gt;&gt; Gentle&lt;/label&gt;
   &lt;&lt;else&gt;&gt;
     &lt;span class=&quot;helper-container&quot;&gt;
-	  &lt;span&gt;&lt;label&gt;&lt;&lt;radiobutton &quot;$extractionVariant&quot; &quot;&quot;&gt;&gt; &lt;span class=&quot;disabled&quot;&gt;Gentle&lt;/span&gt;&lt;/label&gt;&lt;/span&gt;
-	  &lt;small class=&quot;helper-text&quot;&gt;The slime is fine-tuned to reward those that let it do its work...&lt;/small&gt;
-	&lt;/span&gt;
-	&lt;&lt;done&gt;&gt;&lt;&lt;script&gt;&gt;
-	document.getElementById(&quot;radiobutton-extractionvariant-0&quot;).disabled = true;
-	&lt;&lt;/script&gt;&gt;&lt;&lt;/done&gt;&gt;
+      &lt;span&gt;&lt;label&gt;&lt;&lt;radiobutton &quot;$extractionVariant&quot; &quot;&quot;&gt;&gt; &lt;span class=&quot;disabled&quot;&gt;Gentle&lt;/span&gt;&lt;/label&gt;&lt;/span&gt;
+      &lt;small class=&quot;helper-text&quot;&gt;The slime is fine-tuned to reward those that let it do its work...&lt;/small&gt;
+    &lt;/span&gt;
+    &lt;&lt;done&gt;&gt;&lt;&lt;script&gt;&gt;
+    document.getElementById(&quot;radiobutton-extractionvariant-0&quot;).disabled = true;
+    &lt;&lt;/script&gt;&gt;&lt;&lt;/done&gt;&gt;
   &lt;&lt;/if&gt;&gt;
   &lt;&lt;/nobr&gt;&gt;\
    | &lt;&lt;nobr&gt;&gt;
-	&lt;&lt;if $extractionForcefulEnd&gt;&gt;
-		&lt;label&gt;&lt;&lt;radiobutton &quot;$extractionVariant&quot; &quot;forceful&quot; autocheck&gt;&gt; Forceful&lt;/label&gt;
-	  &lt;&lt;else&gt;&gt;
-		&lt;span class=&quot;helper-container&quot;&gt;
-		  &lt;span&gt;&lt;label&gt;&lt;&lt;radiobutton &quot;$extractionVariant&quot; &quot;&quot;&gt;&gt; &lt;span class=&quot;disabled&quot;&gt;Forceful&lt;/span&gt;&lt;/label&gt;&lt;/span&gt;
-		  &lt;small class=&quot;helper-text&quot;&gt;The slime is fine-tuned to go rougher on those that insist on fighting it...&lt;/small&gt;
-		&lt;/span&gt;
-		&lt;&lt;done&gt;&gt;&lt;&lt;script&gt;&gt;
-			document.getElementById(&quot;radiobutton-extractionvariant-1&quot;).disabled = true;
-		&lt;&lt;/script&gt;&gt;&lt;&lt;/done&gt;&gt;
+    &lt;&lt;if $extractionForcefulEnd&gt;&gt;
+        &lt;label&gt;&lt;&lt;radiobutton &quot;$extractionVariant&quot; &quot;forceful&quot; autocheck&gt;&gt; Forceful&lt;/label&gt;
+      &lt;&lt;else&gt;&gt;
+        &lt;span class=&quot;helper-container&quot;&gt;
+          &lt;span&gt;&lt;label&gt;&lt;&lt;radiobutton &quot;$extractionVariant&quot; &quot;&quot;&gt;&gt; &lt;span class=&quot;disabled&quot;&gt;Forceful&lt;/span&gt;&lt;/label&gt;&lt;/span&gt;
+          &lt;small class=&quot;helper-text&quot;&gt;The slime is fine-tuned to go rougher on those that insist on fighting it...&lt;/small&gt;
+        &lt;/span&gt;
+        &lt;&lt;done&gt;&gt;&lt;&lt;script&gt;&gt;
+            document.getElementById(&quot;radiobutton-extractionvariant-1&quot;).disabled = true;
+        &lt;&lt;/script&gt;&gt;&lt;&lt;/done&gt;&gt;
     &lt;&lt;/if&gt;&gt;
   &lt;&lt;/nobr&gt;&gt;
 &lt;&lt;else&gt;&gt;\
   &lt;span class=&quot;helper-container&quot;&gt;
-  	&lt;b&gt;&lt;span class=&quot;disabled&quot;&gt;Bad Ending: Extraction&lt;/span&gt;&lt;/b&gt;
-	&lt;small class=&quot;helper-text&quot;&gt;Touching unknown magical things always ends badly...&lt;/small&gt;
+      &lt;b&gt;&lt;span class=&quot;disabled&quot;&gt;Bad Ending: Extraction&lt;/span&gt;&lt;/b&gt;
+    &lt;small class=&quot;helper-text&quot;&gt;Touching unknown magical things always ends badly...&lt;/small&gt;
   &lt;/span&gt;
-&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="176" name="Extraction Archive" tags="noreturn" position="475,2917" size="100,100">&lt;&lt;include &quot;Pulled In (Text)&quot;&gt;&gt;
+&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="168" name="Extraction Archive" tags="noreturn" position="1950,1100" size="100,100">&lt;&lt;include &quot;Pulled In (Text)&quot;&gt;&gt;
 
 &lt;&lt;include &quot;Pulled Further (Text)&quot;&gt;&gt;
 
@@ -3998,13 +3905,9 @@ It doesn&#39;t stop there, and neither does the slime. All the stimulation keeps
 
 &lt;span class=&quot;bad-ending&quot;&gt;Bad Ending: &lt;i&gt;Extraction&lt;/i&gt;&lt;/span&gt;
 
-[[Return to the Archives|Archives]]</tw-passagedata><tw-passagedata pid="177" name="Coming Soon" tags="" position="2709,1029" size="100,100">&lt;div class=&quot;action-box&quot;&gt;\
-  &lt;ul class=&quot;actions&quot;&gt;\
-	&lt;li&gt;[[Return to the hallway.|Chastity]]&lt;/li&gt;
-  &lt;/ul&gt;\
-&lt;/div&gt;\</tw-passagedata><tw-passagedata pid="178" name="Title Screen" tags="" position="879,45" size="100,100">&lt;div class=&quot;title-screen&quot;&gt;\
-&lt;&lt;include &quot;Title Screen 1&quot;&gt;&gt;
-&lt;/div&gt;\</tw-passagedata><tw-passagedata pid="179" name="Tying up" tags="" position="2374,1143" size="100,100">Holding the unconscious panther up, he almost looks harmless. $name keeps growling, though. After all that time wandering around naked and erect, it doesn&#39;t bother the wolf as much anymore, but that thought alone is enough for the wolf&#39;s anger to feel bolstered. Who knows what the damned mage has done with his gear? With his trusty sword, even? Punishment of the same level should be inflicted upon him so that he can learn how it feels. But... what, exactly?
+[[Return to the Archives|Archives]]</tw-passagedata><tw-passagedata pid="169" name="Title Screen" tags="restart" position="2500,25" size="100,100">&lt;div class=&quot;title-screen&quot;&gt;\
+&lt;&lt;include [[Title Screen 1]]&gt;&gt;
+&lt;/div&gt;\</tw-passagedata><tw-passagedata pid="170" name="Tying up" tags="" position="1075,5450" size="100,100">Holding the unconscious panther up, he almost looks harmless. $name keeps growling, though. After all that time wandering around naked and erect, it doesn&#39;t bother the wolf as much anymore, but that thought alone is enough for the wolf&#39;s anger to feel bolstered. Who knows what the damned mage has done with his gear? With his trusty sword, even? Punishment of the same level should be inflicted upon him so that he can learn how it feels. But... what, exactly?
 
 Carelessly letting the panther fall down, $name looks around. Ivex&#39;s gems are scattered all over the floor. It is wise to gather them up and make sure he can&#39;t get ahold of them, but before anything, he has to make sure the mage is secure. Going around the house, $name quickly sees that he is in some kind of farmhouse. The tower was stored in the attic, but after going down a crude set of stairs, the windows reveal that there is nothing but fields and a poorly kept road surrounding it. Ivex keeps his hideout well-hidden. Luckily for the wolf, a farmhouse is well-equipped for many things, so he has no trouble finding a good bunch of thick rope in the main room, which he promptly takes upstairs to use.
 
@@ -4012,11 +3915,11 @@ The panther is not his first bounty, so within a few minutes, the unconscious fe
 
 As he shoves each of the many colored gems back into the small sack, he can&#39;t help but be curious. According to Ivex&#39;s notes, he stores the spells from his spellbook into these things so that he can cast them at will. His magical ability seems to be pretty limited to that method, at least outside of the damned tower. Glancing at the unconscious panther, the wolf picks a light blue gemstone up and looks it over.
 
-[[Continue|Gemstones]]</tw-passagedata><tw-passagedata pid="180" name="SFW Finish" tags="" position="2882,1284" size="100,100">Yeah. It&#39;s not his place to punish Ivex. A long time in prison ought to be enough to make him re-think his actions. With aching loins, the wolf moves out of the room with the feline in tow. Despite everything, however, $name can&#39;t help but smile. A lot has happened, but luckily, no one will need to know about it, and his reputation is safe. Not only that, but the criminal is taken and the wolf is victorious.
+[[Continue|Gemstones]]</tw-passagedata><tw-passagedata pid="171" name="SFW Finish" tags="" position="2400,5200" size="100,100">Yeah. It&#39;s not his place to punish Ivex. A long time in prison ought to be enough to make him re-think his actions. With aching loins, the wolf moves out of the room with the feline in tow. Despite everything, however, $name can&#39;t help but smile. A lot has happened, but luckily, no one will need to know about it, and his reputation is safe. Not only that, but the criminal is taken and the wolf is victorious.
 
 There is a lot of satisfaction in the thought that a large sack of gold awaits him for all this effort. In his head, the wolf already makes plans for a night of heavy drinking... and perhaps a few escorts in a tavern to make up for all the built-up need he never got to satisfy.
 
-[[Continue|Bounty Collection]]</tw-passagedata><tw-passagedata pid="181" name="Gemstones" tags="" position="2514,1139" size="100,100">Frowning, the wolf hesitates, but curiosity takes over and, carefully, the wolf lets the gemstone rest on his paw... before closing it around to grip it.
+[[Continue|Bounty Collection]]</tw-passagedata><tw-passagedata pid="172" name="Gemstones" tags="" position="1200,5450" size="100,100">Frowning, the wolf hesitates, but curiosity takes over and, carefully, the wolf lets the gemstone rest on his paw... before closing it around to grip it.
 
 The gemstone starts glowing with a faint blue light.
 
@@ -4038,7 +3941,7 @@ One by one, the wolf picks up all the gemstones on the floor. There are too many
 
 $name shoves each and every one of them into the pouch until there are only four of them left on the ground. Growing enthusiastic, the wolf grabs a yellow-ish one. When he grips it around his paw, it glows, and what this one does...
 
-[[Continue|Chastity]]</tw-passagedata><tw-passagedata pid="182" name="Punishments" tags="" position="2532,1403" size="100,100">The wolf&#39;s hands curl into tight fists. He can barely control his growling, looking down at Ivex. Will getting locked up in some mage&#39;s containment chamber, or whatever else the guild decides to do to him, be enough to make him pay for what he&#39;s done? Of course not. They don&#39;t know half of what he&#39;s done, and even if he tells them, it won&#39;t have the same impact as seeing it.
+[[Continue|Chastity]]</tw-passagedata><tw-passagedata pid="173" name="Punishments" tags="" position="1425,5575" size="100,100">The wolf&#39;s hands curl into tight fists. He can barely control his growling, looking down at Ivex. Will getting locked up in some mage&#39;s containment chamber, or whatever else the guild decides to do to him, be enough to make him pay for what he&#39;s done? Of course not. They don&#39;t know half of what he&#39;s done, and even if he tells them, it won&#39;t have the same impact as seeing it.
 
 With the sack of gemstones in hand, the wolf stomps over to the tied-up feline and lifts him up by the scruff. Ivex shifts and grunts in his sleep, but doesn&#39;t wake up quite yet.
 
@@ -4056,15 +3959,15 @@ Thinking back to his experience in the tower and Ivex&#39;s journal, his report 
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-  	&lt;li&gt;[[Wake him up. He needs to be awake to experience this.|Personal Vengeance]]&lt;/li&gt;
-	&lt;&lt;if $enthrallmentEnding&gt;&gt;\
-  	  &lt;li&gt;[[ [Unlocked: Enthrallment] Put a pendant around his neck.|Enthrallment Vengeance]]&lt;/li&gt;
-	&lt;&lt;/if&gt;&gt;\
-	&lt;&lt;if $extractionEnding&gt;&gt;\
-  	  &lt;li&gt;[[ [Unlocked: Extraction] Throw him into that blob.|Extraction Vengeance]]&lt;/li&gt;
-	&lt;&lt;/if&gt;&gt;\
+      &lt;li&gt;[[Wake him up. He needs to be awake to experience this.|Personal Vengeance]]&lt;/li&gt;
+    &lt;&lt;if $enthrallmentEnding&gt;&gt;\
+        &lt;li&gt;[[ [Unlocked: Enthrallment] Put a pendant around his neck.|Enthrallment Vengeance]]&lt;/li&gt;
+    &lt;&lt;/if&gt;&gt;\
+    &lt;&lt;if $extractionEnding&gt;&gt;\
+        &lt;li&gt;[[ [Unlocked: Extraction] Throw him into that blob.|Extraction Vengeance]]&lt;/li&gt;
+    &lt;&lt;/if&gt;&gt;\
   &lt;/ul&gt;\
-&lt;/div&gt;</tw-passagedata><tw-passagedata pid="183" name="Personal Vengeance" tags="" position="2596,1533" size="100,100">&lt;&lt;silently&gt;&gt;
+&lt;/div&gt;</tw-passagedata><tw-passagedata pid="174" name="Personal Vengeance" tags="end" position="1375,5975" size="100,100">&lt;&lt;silently&gt;&gt;
 &lt;&lt;set $gagged = false&gt;&gt;
 &lt;&lt;set $randomGag to random(1, 2)&gt;&gt;
 &lt;&lt;if $randomGag == 1&gt;&gt;
@@ -4121,19 +4024,19 @@ What to do to him first?
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-  	&lt;li&gt;[[Strip him.|Strip]]&lt;/li&gt;
+      &lt;li&gt;[[Strip him.|Strip]]&lt;/li&gt;
   &lt;/ul&gt;\
-&lt;/div&gt;</tw-passagedata><tw-passagedata pid="184" name="Enthrallment Vengeance" tags="" position="2088,1518" size="100,100">&lt;&lt;include &quot;Enthrallment Vengeance (Text)&quot;&gt;&gt;
+&lt;/div&gt;</tw-passagedata><tw-passagedata pid="175" name="Enthrallment Vengeance" tags="end" position="1600,5575" size="100,100">&lt;&lt;include &quot;Enthrallment Vengeance (Text)&quot;&gt;&gt;
 
 &lt;span class=&quot;good-ending&quot;&gt;Ending: &lt;i&gt;Ivex&#39;s Enthrallment&lt;/i&gt;&lt;/span&gt;
 
-[[Continue|Ivex Enthrallment 1]]</tw-passagedata><tw-passagedata pid="185" name="Extraction Vengeance" tags="" position="3126,1535" size="100,100">&lt;&lt;include &quot;Extraction Vengeance (Text)&quot;&gt;&gt;
+[[Continue|Ivex Enthrallment 1]]</tw-passagedata><tw-passagedata pid="176" name="Extraction Vengeance" tags="end" position="1650,5750" size="100,100">&lt;&lt;include &quot;Extraction Vengeance (Text)&quot;&gt;&gt;
 
 &lt;span class=&quot;good-ending&quot;&gt;Ending: &lt;i&gt;Ivex&#39;s Extraction&lt;/i&gt;&lt;/span&gt;
 
-[[Continue|Ivex Extraction 1]]</tw-passagedata><tw-passagedata pid="186" name="Ivex Extraction 1" tags="" position="3126,1685" size="100,100">&lt;&lt;include &quot;Ivex Extraction 1 (Text)&quot;&gt;&gt;
+[[Continue|Ivex Extraction 1]]</tw-passagedata><tw-passagedata pid="177" name="Ivex Extraction 1" tags="" position="1775,5750" size="100,100">&lt;&lt;include &quot;Ivex Extraction 1 (Text)&quot;&gt;&gt;
 
-[[Continue|Ivex Extraction 2]]</tw-passagedata><tw-passagedata pid="187" name="Chastity" tags="" position="2524,1277" size="100,100">It is just as perverted as some of the other ones he found, yet even though its effects make the wolf&#39;s eyes grow wide, it also makes his tail wag enthusiastically.
+[[Continue|Ivex Extraction 2]]</tw-passagedata><tw-passagedata pid="178" name="Chastity" tags="" position="1325,5450" size="100,100">It is just as perverted as some of the other ones he found, yet even though its effects make the wolf&#39;s eyes grow wide, it also makes his tail wag enthusiastically.
 
 It&#39;s perfect.
 
@@ -4165,37 +4068,37 @@ The wolf&#39;s member throbs in excitement at the thought. Now he can&#39;t wait
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-  	&lt;li&gt;[[Punish Ivex for his misdeeds.|Punishments]]&lt;/li&gt;
-  	&lt;li&gt;[[Turn Ivex in and be done with it.|Turn In]]&lt;/li&gt;
+      &lt;li&gt;[[Punish Ivex for his misdeeds.|Punishments]]&lt;/li&gt;
+      &lt;li&gt;[[Turn Ivex in and be done with it.|Turn In]]&lt;/li&gt;
   &lt;/ul&gt;\
-&lt;/div&gt;</tw-passagedata><tw-passagedata pid="188" name="Ivex Extraction 2" tags="" position="3126,1835" size="100,100">&lt;&lt;include &quot;Ivex Extraction 2 (Text)&quot;&gt;&gt;
+&lt;/div&gt;</tw-passagedata><tw-passagedata pid="179" name="Ivex Extraction 2" tags="" position="1900,5750" size="100,100">&lt;&lt;include &quot;Ivex Extraction 2 (Text)&quot;&gt;&gt;
 
-[[Continue|Ivex Extraction 3]]</tw-passagedata><tw-passagedata pid="189" name="Ivex Extraction 3" tags="" position="3126,1985" size="100,100">&lt;&lt;include &quot;Ivex Extraction 3 (Text)&quot;&gt;&gt;
+[[Continue|Ivex Extraction 3]]</tw-passagedata><tw-passagedata pid="180" name="Ivex Extraction 3" tags="" position="2025,5750" size="100,100">&lt;&lt;include &quot;Ivex Extraction 3 (Text)&quot;&gt;&gt;
 
-[[Continue|Ivex Extraction Final]]</tw-passagedata><tw-passagedata pid="190" name="Ivex Extraction Final" tags="" position="3126,2135" size="100,100">&lt;&lt;include &quot;Ivex Extraction Final (Text)&quot;&gt;&gt;
+[[Continue|Ivex Extraction Final]]</tw-passagedata><tw-passagedata pid="181" name="Ivex Extraction Final" tags="" position="2150,5750" size="100,100">&lt;&lt;include &quot;Ivex Extraction Final (Text)&quot;&gt;&gt;
 
-[[Continue|Ivex Extraction End]]</tw-passagedata><tw-passagedata pid="191" name="Ivex Extraction End" tags="" position="3126,2285" size="100,100">&lt;&lt;include &quot;Ivex Extraction End (Text)&quot;&gt;&gt;
+[[Continue|Ivex Extraction End]]</tw-passagedata><tw-passagedata pid="182" name="Ivex Extraction End" tags="" position="2275,5750" size="100,100">&lt;&lt;include &quot;Ivex Extraction End (Text)&quot;&gt;&gt;
 
-[[To the end|Extraction Finish]]</tw-passagedata><tw-passagedata pid="192" name="Ivex Enthrallment 1" tags="" position="2089,1671" size="100,100">&lt;&lt;include &quot;Ivex Enthrallment 1 (Text)&quot;&gt;&gt;
+[[To the end|Extraction Finish]]</tw-passagedata><tw-passagedata pid="183" name="Ivex Enthrallment 1" tags="" position="1725,5575" size="100,100">&lt;&lt;include &quot;Ivex Enthrallment 1 (Text)&quot;&gt;&gt;
 
-[[Continue|Ivex Enthrallment 2]]</tw-passagedata><tw-passagedata pid="193" name="Ivex Enthrallment 2" tags="" position="2089,1821" size="100,100">&lt;&lt;include &quot;Ivex Enthrallment 2 (Text)&quot;&gt;&gt;
+[[Continue|Ivex Enthrallment 2]]</tw-passagedata><tw-passagedata pid="184" name="Ivex Enthrallment 2" tags="" position="1850,5575" size="100,100">&lt;&lt;include &quot;Ivex Enthrallment 2 (Text)&quot;&gt;&gt;
 
-[[Continue|Ivex Enthrallment 3]]</tw-passagedata><tw-passagedata pid="194" name="Ivex Enthrallment 3" tags="" position="2089,1971" size="100,100">&lt;&lt;include &quot;Ivex Enthrallment 3 (Text)&quot;&gt;&gt;
+[[Continue|Ivex Enthrallment 3]]</tw-passagedata><tw-passagedata pid="185" name="Ivex Enthrallment 3" tags="" position="1975,5575" size="100,100">&lt;&lt;include &quot;Ivex Enthrallment 3 (Text)&quot;&gt;&gt;
 
-[[Continue|Ivex Enthrallment 4]]</tw-passagedata><tw-passagedata pid="195" name="Ivex Enthrallment 4" tags="" position="2087,2119" size="100,100">&lt;&lt;include &quot;Ivex Enthrallment 4 (Text)&quot;&gt;&gt;
+[[Continue|Ivex Enthrallment 4]]</tw-passagedata><tw-passagedata pid="186" name="Ivex Enthrallment 4" tags="" position="2100,5575" size="100,100">&lt;&lt;include &quot;Ivex Enthrallment 4 (Text)&quot;&gt;&gt;
 
-[[Continue|Ivex Enthrallment 5]]</tw-passagedata><tw-passagedata pid="196" name="Ivex Enthrallment 5" tags="" position="2087,2269" size="100,100">&lt;&lt;include &quot;Ivex Enthrallment 5 (Text)&quot;&gt;&gt;
+[[Continue|Ivex Enthrallment 5]]</tw-passagedata><tw-passagedata pid="187" name="Ivex Enthrallment 5" tags="" position="2225,5575" size="100,100">&lt;&lt;include &quot;Ivex Enthrallment 5 (Text)&quot;&gt;&gt;
 
-[[Continue|Ivex Enthrallment Final]]</tw-passagedata><tw-passagedata pid="197" name="Ivex Enthrallment Final" tags="" position="2087,2419" size="100,100">&lt;&lt;include &quot;Ivex Enthrallment Final (Text)&quot;&gt;&gt;
+[[Continue|Ivex Enthrallment Final]]</tw-passagedata><tw-passagedata pid="188" name="Ivex Enthrallment Final" tags="" position="2350,5575" size="100,100">&lt;&lt;include &quot;Ivex Enthrallment Final (Text)&quot;&gt;&gt;
 
-[[Continue|Ivex Enthrallment End]]</tw-passagedata><tw-passagedata pid="198" name="Ivex Enthrallment End" tags="" position="2089,2663" size="100,100">&lt;&lt;include &quot;Ivex Enthrallment End (Text)&quot;&gt;&gt;
+[[Continue|Ivex Enthrallment End]]</tw-passagedata><tw-passagedata pid="189" name="Ivex Enthrallment End" tags="" position="2475,5575" size="100,100">&lt;&lt;include &quot;Ivex Enthrallment End (Text)&quot;&gt;&gt;
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-  	&lt;li&gt;[[Keep Ivex as a personal thrall.|Enthrallment Finish]]&lt;/li&gt;
-  	&lt;li&gt;[[Take him back as he is and collect the bounty.|Bounty Collection]]&lt;/li&gt;
+      &lt;li&gt;[[Keep Ivex as a personal thrall.|Enthrallment Finish]]&lt;/li&gt;
+      &lt;li&gt;[[Take him back as he is and collect the bounty.|Bounty Collection]]&lt;/li&gt;
   &lt;/ul&gt;\
-&lt;/div&gt;</tw-passagedata><tw-passagedata pid="199" name="Gag" tags="" position="2827,1814" size="100,100">&lt;&lt;set $gagged = true&gt;&gt;\
+&lt;/div&gt;</tw-passagedata><tw-passagedata pid="190" name="Gag" tags="" position="1225,6425" size="100,100">&lt;&lt;set $gagged = true&gt;&gt;\
 Yeah, silencing him might be a good idea. Given the place Ivex has chosen to hide, it is unlikely that anyone would hear him, but his prattling is growing annoying pretty quickly.
 
 &quot;-and when you&#39;re done mopping the floor with your tail, I&#39;ll make you do it all over again with your TONGUE! And then-&quot; the panther continues angrily.
@@ -4204,11 +4107,11 @@ The wolf looks around. There&#39;s a few options on how to silence him. What to 
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-  	&lt;li&gt;[[With a piece of rope.|Gag with Rope]]&lt;/li&gt;
-  	&lt;li&gt;[[With a silence spell.|Gag with Spell]]&lt;/li&gt;
-  	&lt;li&gt;[[With his own undergarments.|Gag with Underwear]]&lt;/li&gt;	
+      &lt;li&gt;[[With a piece of rope.|Gag with Rope]]&lt;/li&gt;
+      &lt;li&gt;[[With a silence spell.|Gag with Spell]]&lt;/li&gt;
+      &lt;li&gt;[[With his own undergarments.|Gag with Underwear]]&lt;/li&gt;	
   &lt;/ul&gt;\
-&lt;/div&gt;</tw-passagedata><tw-passagedata pid="200" name="Strip" tags="" position="2481,1665" size="100,100">&lt;&lt;if !$stage0Clear&gt;&gt;\
+&lt;/div&gt;</tw-passagedata><tw-passagedata pid="191" name="Strip" tags="" position="1375,6175" size="100,100">&lt;&lt;if !$stage0Clear&gt;&gt;\
 Memories of the perverted panther getting rid of his clothes back in the tower come to the wolf&#39;s mind. Narrowing his eyes towards the feline, he reaches up to him.
 
 &quot;What?! Stop! Let go of me! Let go of me right NOW!&quot; Ivex demands as wiggles in the wolf&#39;s hold. Still, it takes no effort for $name to lift the feline up by his scruff again.
@@ -4251,12 +4154,12 @@ Still, the show must go on. Kneeling next to the panther, the wolf drags him clo
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-  	&lt;li&gt;[[Show him.|Fondle]]&lt;/li&gt;
-	&lt;&lt;if !$gagged&gt;&gt;\
-  	&lt;li&gt;[[Gag him.|Gag]]&lt;/li&gt;
-	&lt;&lt;/if&gt;&gt;\
+      &lt;li&gt;[[Show him.|Fondle]]&lt;/li&gt;
+    &lt;&lt;if !$gagged&gt;&gt;\
+      &lt;li&gt;[[Gag him.|Gag]]&lt;/li&gt;
+    &lt;&lt;/if&gt;&gt;\
   &lt;/ul&gt;\
-&lt;/div&gt;</tw-passagedata><tw-passagedata pid="201" name="Gag with Rope" tags="" position="2939,1710" size="100,100">Better to go with the classics.
+&lt;/div&gt;</tw-passagedata><tw-passagedata pid="192" name="Gag with Rope" tags="" position="1475,6500" size="100,100">Better to go with the classics.
 
 Cutting a spare piece of rope with his teeth, the wolf then ties it into a thick, single piece and, nonchalantly, shoves it into the maw of the complaining panther.
 
@@ -4274,7 +4177,7 @@ Sweet, sweet silence.
 [[Continue|Hold]]
 &lt;&lt;elseif $revengeStage == 3&gt;&gt;\
 [[Continue|Fucking]]
-&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="202" name="Gag with Spell" tags="" position="2940,1812" size="100,100">Why not use Ivex&#39;s own tools against him?
+&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="193" name="Gag with Spell" tags="" position="1375,6500" size="100,100">Why not use Ivex&#39;s own tools against him?
 
 Shoving his paw into the pouch of gemstones, the wolf pulls out a gray-ish one that he remembers was a spell of silence. Clutching it into his paw, the wolf activates it and sees how to use it.
 
@@ -4294,7 +4197,7 @@ Sweet, sweet silence.
 [[Continue|Hold]]
 &lt;&lt;elseif $revengeStage == 3&gt;&gt;\
 [[Continue|Fucking]]
-&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="203" name="Gag with Underwear" tags="" position="2940,1915" size="100,100">The wolf smirks. It&#39;s time to get creative.
+&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="194" name="Gag with Underwear" tags="" position="1575,6500" size="100,100">The wolf smirks. It&#39;s time to get creative.
 
 Reaching out for Ivex&#39;s cut and discarded clothes, it&#39;s easy to find the stained piece of cloth he had wrapped around his crotch. 
 
@@ -4316,7 +4219,7 @@ Sweet, sweet silence.
 [[Continue|Hold]]
 &lt;&lt;elseif $revengeStage == 3&gt;&gt;\
 [[Continue|Fucking]]
-&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="204" name="Fondle" tags="" position="2481,1815" size="100,100">&lt;&lt;set $revengeStage = 1&gt;&gt;\
+&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="195" name="Fondle" tags="" position="1500,6175" size="100,100">&lt;&lt;set $revengeStage = 1&gt;&gt;\
 The wolf takes a few heavy steps toward the panther. Seeing $name approaching is enough to make Ivex look fearful again. He tries to wiggle away, but a simple pull on his tail is enough to drag him back closer. Then, the wolf gets down on all fours over the bound mage.
 
 Ivex shrinks and closes his eyes to the simple act of the growling wolf&#39;s sharp teeth approaching him. Upon getting on all fours above the feline, however, the wolf stops. His cock flexes between his legs, so very close to the naked panther and, in fact, with a droplet of pre-cum falling to mat the panther&#39;s perfect black fur.
@@ -4361,13 +4264,13 @@ $name continues to hold the panther down and forcefully stimulate him. What to d
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-  	&lt;li&gt;[[Use one of his spells on him.|Spell]]&lt;/li&gt;
-  	&lt;li&gt;[[Continue stimulating him.|Edge]]&lt;/li&gt;	
-	&lt;&lt;if !$gagged&gt;&gt;\
-  	&lt;li&gt;[[Gag him.|Gag]]&lt;/li&gt;
-	&lt;&lt;/if&gt;&gt;\
+      &lt;li&gt;[[Use one of his spells on him.|Spell]]&lt;/li&gt;
+      &lt;li&gt;[[Continue stimulating him.|Edge]]&lt;/li&gt;	
+    &lt;&lt;if !$gagged&gt;&gt;\
+      &lt;li&gt;[[Gag him.|Gag]]&lt;/li&gt;
+    &lt;&lt;/if&gt;&gt;\
   &lt;/ul&gt;\
-&lt;/div&gt;</tw-passagedata><tw-passagedata pid="205" name="Spell" tags="" position="2717,2091" size="100,100">&lt;&lt;if !$spellOptions&gt;&gt;\
+&lt;/div&gt;</tw-passagedata><tw-passagedata pid="196" name="Spell" tags="" position="1875,6375" size="100,100">&lt;&lt;if !$spellOptions&gt;&gt;\
 Yes. Ivex has made so many spells with the sole intent of using them on people for his own perversion. Why not use some of these against him?
 
 The wolf smirks down at the panther and lets go of him. The mage stares daggers up at the wolf but is left panting and looking flustered. His sheath is still full and his cock still fights to grow past it. The frustration of it is plain in Ivex&#39;s face and he takes that moment of reprieve to recover a little from it.
@@ -4392,24 +4295,24 @@ Which spell would be best to use right now?
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-  	&lt;li&gt;[[Use a Lust spell on him.|Lust Spell]]&lt;/li&gt;  
-	&lt;&lt;if $interrogationEndingFreeze&gt;&gt;\
-  	  &lt;li&gt;[[ [Unlocked: Freeze] Use an ice spell on him.|Ice Spell]]&lt;/li&gt;
-	&lt;&lt;else&gt;&gt;\
-	  &lt;li&gt;&lt;span class=&quot;disabled&quot;&gt;[Locked: Interrogation - ???] ???&lt;/span&gt;&lt;/li&gt;
-	&lt;&lt;/if&gt;&gt;\
-	&lt;&lt;if $interrogationEndingShock&gt;&gt;\
-  	  &lt;li&gt;[[ [Unlocked: Shock] Use an lightning spell on him.|Lightning Spell]]&lt;/li&gt;
-	&lt;&lt;else&gt;&gt;\
-	  &lt;li&gt;&lt;span class=&quot;disabled&quot;&gt;[Locked: Interrogation - ???] ???&lt;/span&gt;&lt;/li&gt;
-	&lt;&lt;/if&gt;&gt;\	
-	&lt;&lt;if $revengeStage == 2 || $revengeStage == 1&gt;&gt;\
-	&lt;li&gt;[[On second thought, maybe no spells just yet...|Hold]]&lt;/li&gt;
-	&lt;&lt;elseif $revengeStage == 3&gt;&gt;\
-	&lt;li&gt;[[On second thought, maybe no spells just yet...|Fucking]]&lt;/li&gt;
-	&lt;&lt;/if&gt;&gt;\
+      &lt;li&gt;[[Use a Lust spell on him.|Lust Spell]]&lt;/li&gt;  
+    &lt;&lt;if $interrogationEndingFreeze&gt;&gt;\
+        &lt;li&gt;[[ [Unlocked: Freeze] Use an ice spell on him.|Ice Spell]]&lt;/li&gt;
+    &lt;&lt;else&gt;&gt;\
+      &lt;li&gt;&lt;span class=&quot;disabled&quot;&gt;[Locked: Interrogation - ???] ???&lt;/span&gt;&lt;/li&gt;
+    &lt;&lt;/if&gt;&gt;\
+    &lt;&lt;if $interrogationEndingShock&gt;&gt;\
+        &lt;li&gt;[[ [Unlocked: Shock] Use an lightning spell on him.|Lightning Spell]]&lt;/li&gt;
+    &lt;&lt;else&gt;&gt;\
+      &lt;li&gt;&lt;span class=&quot;disabled&quot;&gt;[Locked: Interrogation - ???] ???&lt;/span&gt;&lt;/li&gt;
+    &lt;&lt;/if&gt;&gt;\	
+    &lt;&lt;if $revengeStage == 2 || $revengeStage == 1&gt;&gt;\
+    &lt;li&gt;[[On second thought, maybe no spells just yet...|Hold]]&lt;/li&gt;
+    &lt;&lt;elseif $revengeStage == 3&gt;&gt;\
+    &lt;li&gt;[[On second thought, maybe no spells just yet...|Fucking]]&lt;/li&gt;
+    &lt;&lt;/if&gt;&gt;\
   &lt;/ul&gt;\
-&lt;/div&gt;</tw-passagedata><tw-passagedata pid="206" name="Edge" tags="" position="2280,2318" size="100,100">&lt;&lt;if !$ivexEdging&gt;&gt;
+&lt;/div&gt;</tw-passagedata><tw-passagedata pid="197" name="Edge" tags="" position="1675,6025" size="100,100">&lt;&lt;if !$ivexEdging&gt;&gt;
 $name is fond of the good, old methods, and this seems to be extra effective on the mage.
 
 Roughly taking hold of Ivex&#39;s sheath, the wolf&#39;s fingers start kneading and teasing it in a firmer manner.
@@ -4457,7 +4360,7 @@ After he&#39;s satisfied, $name wipes his hand on the panther&#39;s already matt
 [[Continue|Hold]]
 &lt;&lt;elseif $revengeStage == 3&gt;&gt;\
 [[Continue|Fucking]]
-&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="207" name="Ice Spell" tags="" position="2905,2218" size="100,100">Pulling out the light blue gemstone, the wolf clutches it in his hand and looks down at Ivex.
+&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="198" name="Ice Spell" tags="" position="1775,6500" size="100,100">Pulling out the light blue gemstone, the wolf clutches it in his hand and looks down at Ivex.
 
 &lt;&lt;if !$freezeSpell&gt;&gt;\
 The panther sees the gemstone in the wolf&#39;s hand and laughs.
@@ -4511,7 +4414,7 @@ After he&#39;s satisfied, Ivex&#39;s member is left shy and cold inside his shea
 [[Continue|Hold]]
 &lt;&lt;elseif $revengeStage == 3&gt;&gt;\
 [[Continue|Fucking]]
-&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="208" name="Lightning Spell" tags="" position="2906,2103" size="100,100">Pulling out the purple gemstone, the wolf clutches it in his hand and looks down at Ivex.
+&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="199" name="Lightning Spell" tags="" position="1875,6500" size="100,100">Pulling out the purple gemstone, the wolf clutches it in his hand and looks down at Ivex.
 
 &lt;&lt;if !$shockSpell&gt;&gt;\
 The panther catches a glimpse of which gemstone the wolf is pulling out and frowns.
@@ -4569,7 +4472,7 @@ Before long, he gets bored of it. Ivex&#39;s member seems to have shirked away a
 [[Continue|Hold]]
 &lt;&lt;elseif $revengeStage == 3&gt;&gt;\
 [[Continue|Fucking]]
-&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="209" name="Hold" tags="" position="2484,1991" size="100,100">&lt;&lt;set $revengeStage = 2&gt;&gt;\
+&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="200" name="Hold" tags="" position="1675,6175" size="100,100">&lt;&lt;set $revengeStage = 2&gt;&gt;\
 &lt;&lt;if !$stage1Clear&gt;&gt;\
   &lt;&lt;if !$gagged&gt;&gt;\
   &quot;Fuck... you!&quot; Ivex mutters between raspy breaths. The wolf merely smirks at it.
@@ -4596,17 +4499,17 @@ Before long, he gets bored of it. Ivex&#39;s member seems to have shirked away a
     &lt;&lt;set $ivexEdges = 0&gt;&gt;\
   &lt;&lt;/if&gt;&gt;\
   &lt;&lt;if $ivexEdges &lt;= 2&gt;&gt;\
-	The wolf roughly grabs the bound mage&#39;s caged sheath to feel it up.
-	The panther&#39;s arousal feels... &lt;span style=&quot;color:#e7d778&quot;&gt;gripping&lt;/span&gt;.
+    The wolf roughly grabs the bound mage&#39;s caged sheath to feel it up.
+    The panther&#39;s arousal feels... &lt;span style=&quot;color:#e7d778&quot;&gt;gripping&lt;/span&gt;.
   &lt;&lt;elseif $ivexEdges &gt; 2 &amp;&amp; $ivexEdges &lt;= 3&gt;&gt;\
-	The wolf roughly grabs the bound mage&#39;s caged sheath to feel it up.
-	The panther&#39;s arousal feels... &lt;span style=&quot;color:#bb5e39&quot;&gt;powerful&lt;/span&gt;.
+    The wolf roughly grabs the bound mage&#39;s caged sheath to feel it up.
+    The panther&#39;s arousal feels... &lt;span style=&quot;color:#bb5e39&quot;&gt;powerful&lt;/span&gt;.
   &lt;&lt;elseif $ivexEdges &gt; 3 &amp;&amp; $ivexEdges &lt;= 5&gt;&gt;\
   The wolf roughly grabs the bound mage&#39;s caged sheath to feel it up.
   The panther&#39;s arousal feels... &lt;span style=&quot;color:#bf5150&quot;&gt;overpowering&lt;/span&gt;.
   &lt;&lt;elseif $ivexEdges &gt; 5&gt;&gt;\
-	The wolf roughly grabs the bound mage&#39;s caged sheath to feel it up.
-	The panther&#39;s arousal feels... &lt;span style=&quot;color:#e92940&quot;&gt;overwhelming&lt;/span&gt;.
+    The wolf roughly grabs the bound mage&#39;s caged sheath to feel it up.
+    The panther&#39;s arousal feels... &lt;span style=&quot;color:#e92940&quot;&gt;overwhelming&lt;/span&gt;.
   &lt;&lt;else&gt;&gt;\
   &lt;&lt;/if&gt;&gt;\
 
@@ -4617,14 +4520,14 @@ Before long, he gets bored of it. Ivex&#39;s member seems to have shirked away a
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-  	&lt;li&gt;[[Use one of his spells on him.|Spell]]&lt;/li&gt;
-  	&lt;li&gt;[[Stimulate and tease him by hand.|Edge]]&lt;/li&gt;
-	&lt;li&gt;[[Fuck him.|Fuck]]&lt;/li&gt;
-	&lt;&lt;if !$gagged&gt;&gt;\
-  	&lt;li&gt;[[Gag him.|Gag]]&lt;/li&gt;
-	&lt;&lt;/if&gt;&gt;\
+      &lt;li&gt;[[Use one of his spells on him.|Spell]]&lt;/li&gt;
+      &lt;li&gt;[[Stimulate and tease him by hand.|Edge]]&lt;/li&gt;
+    &lt;li&gt;[[Fuck him.|Fuck]]&lt;/li&gt;
+    &lt;&lt;if !$gagged&gt;&gt;\
+      &lt;li&gt;[[Gag him.|Gag]]&lt;/li&gt;
+    &lt;&lt;/if&gt;&gt;\
   &lt;/ul&gt;\
-&lt;/div&gt;</tw-passagedata><tw-passagedata pid="210" name="Lust Spell" tags="" position="2788,2337" size="100,100">Pulling out the pink gemstone, the wolf clutches it in his hand and looks down at Ivex.
+&lt;/div&gt;</tw-passagedata><tw-passagedata pid="201" name="Lust Spell" tags="" position="1975,6500" size="100,100">Pulling out the pink gemstone, the wolf clutches it in his hand and looks down at Ivex.
 
 &lt;&lt;if !$lustSpell&gt;&gt;\
 The panther catches a glimpse of the gemstone and starts shaking his head.
@@ -4684,7 +4587,7 @@ Hearing Ivex panting in desperate frustration like he made him pant in the past 
 [[Continue|Hold]]
 &lt;&lt;elseif $revengeStage == 3&gt;&gt;\
 [[Continue|Fucking]]
-&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="211" name="Fuck" tags="" position="2484,2141" size="100,100">It&#39;s high time Ivex deals with the consequences of what he has caused.
+&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="202" name="Fuck" tags="" position="1800,6175" size="100,100">It&#39;s high time Ivex deals with the consequences of what he has caused.
 
 The wolf&#39;s member throbs in excitement. $name keeps one paw firmly on Ivex&#39;s shoulder, holding him down on his back, but the other? The wolf&#39;s eyes lock with the panther&#39;s and he brings it down to his own cock. The wolf gives it a stroke, from top to bottom. The bright red, veiny spire has been aching for this for hours and hours. Ever since he was forced to breathe in that candle. This fire inside him has been burning for too long.
 
@@ -4733,7 +4636,7 @@ In a rough movement, $name pulls back, pulling his cock out and making Ivex yelp
 Ivex is simply forced to take the wolf&#39;s pounding.
 &lt;&lt;set $ivexEdges += 1&gt;&gt;\
 
-[[Continue|Fucking]]</tw-passagedata><tw-passagedata pid="212" name="Fucking" tags="" position="2484,2291" size="100,100">&lt;&lt;if !$stage2Clear&gt;&gt;\
+[[Continue|Fucking]]</tw-passagedata><tw-passagedata pid="203" name="Fucking" tags="" position="1975,6175" size="100,100">&lt;&lt;if !$stage2Clear&gt;&gt;\
 &lt;&lt;set $revengeStage = 3&gt;&gt;\
 &quot;Fuck...&quot; the wolf groans. His lusty growling is constant as he continues to fuck the panther hard. In and out, the smaller feline&#39;s ass already taking his size with more ease, yet still feeling delightfully tight around his cock.
 
@@ -4798,14 +4701,14 @@ Holding himself like that, the wolf wonders, what to do to him next?
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-  	&lt;li&gt;[[Use one of his spells on him.|Spell]]&lt;/li&gt;
-  	&lt;li&gt;[[Stimulate and tease him by hand.|Edge]]&lt;/li&gt;
-	&lt;li&gt;[[Knot him.|Knot]]&lt;/li&gt;
-	&lt;&lt;if !$gagged&gt;&gt;\
-  	&lt;li&gt;[[Gag him.|Gag]]&lt;/li&gt;
-	&lt;&lt;/if&gt;&gt;\
+      &lt;li&gt;[[Use one of his spells on him.|Spell]]&lt;/li&gt;
+      &lt;li&gt;[[Stimulate and tease him by hand.|Edge]]&lt;/li&gt;
+    &lt;li&gt;[[Knot him.|Knot]]&lt;/li&gt;
+    &lt;&lt;if !$gagged&gt;&gt;\
+      &lt;li&gt;[[Gag him.|Gag]]&lt;/li&gt;
+    &lt;&lt;/if&gt;&gt;\
   &lt;/ul&gt;\
-&lt;/div&gt;</tw-passagedata><tw-passagedata pid="213" name="Knot" tags="" position="2484,2441" size="100,100">No holding back. The wolf&#39;s lust is too strong and his instincts start speaking louder. There has been enough messing with the panther. It&#39;s time to finish it.
+&lt;/div&gt;</tw-passagedata><tw-passagedata pid="204" name="Knot" tags="" position="2150,6175" size="100,100">No holding back. The wolf&#39;s lust is too strong and his instincts start speaking louder. There has been enough messing with the panther. It&#39;s time to finish it.
 
 Ivex just yelps and mewls when the wolf pulls him up and grips him hard against his chest again. The smaller feline squirms, certainly knowing what&#39;s coming, but the wolf stops it with nothing but one threatening growl.
 
@@ -4831,7 +4734,7 @@ With brutish shove after brutish shove, the wolf&#39;s growling grows. His insti
 
 Putting more strength into his hips, $name pushes in one last time and, this time, he doesn&#39;t retreat, but rather forces forward, and then finally...
 
-[[Continue|Knotted Mage]]</tw-passagedata><tw-passagedata pid="214" name="Knotted Mage" tags="" position="2484,2591" size="100,100">&lt;&lt;if !$gagged&gt;&gt;\
+[[Continue|Knotted Mage]]</tw-passagedata><tw-passagedata pid="205" name="Knotted Mage" tags="" position="2275,6175" size="100,100">&lt;&lt;if !$gagged&gt;&gt;\
 &quot;AAAH!!&quot; Ivex yells.
 &lt;&lt;else&gt;&gt;\
 &quot;HMMMFGH!!&quot; Ivex yells.
@@ -4874,7 +4777,7 @@ As he descends upon the aftermath of his blissful orgasm, the wolf still pants. 
 
 It will take some time for the wolf&#39;s knot to come down, but $name is not in a hurry.
 
-[[Continue|Pull Out Finish]]</tw-passagedata><tw-passagedata pid="215" name="Pull Out Finish" tags="" position="2573,2733" size="100,100">The wolf spends his time locked with the feline to play with him some more. Watching him squirm and whine turns out to be extremely therapeutic. To &lt;&lt;print $name&gt;&gt;, it&#39;s almost as if all the humiliation he went through in the tower didn&#39;t happen. Almost.
+[[Continue|Pull Out Finish]]</tw-passagedata><tw-passagedata pid="206" name="Pull Out Finish" tags="" position="2400,6175" size="100,100">The wolf spends his time locked with the feline to play with him some more. Watching him squirm and whine turns out to be extremely therapeutic. To &lt;&lt;print $name&gt;&gt;, it&#39;s almost as if all the humiliation he went through in the tower didn&#39;t happen. Almost.
 &lt;&lt;if $ivexClimax&gt;&gt;\
 
 Even though Ivex has managed to cum through his own chastity spell, it must have been quite unsatisfactory, because as soon as the wolf&#39;s fingers touch his sheath and tease it, the panther turns into a mewling puddle of frustration and despair again. His cock seems as eager to grow hard as always, and it doesn&#39;t take long to take him back to the edge of orgasm.
@@ -4901,24 +4804,24 @@ The wolf does. He wonders if Ivex has had enough punishment or if he should add 
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-  	&lt;li&gt;[[Add a punishing touch for the journey.|Pull Out Punishment Finish]]&lt;/li&gt;
-  	&lt;li&gt;[[Take him back as he is and collect the bounty.|Bounty Collection]]&lt;/li&gt;
+      &lt;li&gt;[[Add a punishing touch for the journey.|Pull Out Punishment Finish]]&lt;/li&gt;
+      &lt;li&gt;[[Take him back as he is and collect the bounty.|Bounty Collection]]&lt;/li&gt;
   &lt;/ul&gt;\
-&lt;/div&gt;</tw-passagedata><tw-passagedata pid="216" name="Enthrallment Finish" tags="" position="2394,3056" size="100,100">&lt;&lt;if !$enthralmentIvexEnding&gt;&gt;\
+&lt;/div&gt;</tw-passagedata><tw-passagedata pid="207" name="Enthrallment Finish" tags="" position="2600,5500" size="100,100">&lt;&lt;if !$enthralmentIvexEnding&gt;&gt;\
 &lt;&lt;set $enthralmentIvexEndingUnlock = true&gt;&gt;\
 &lt;&lt;/if&gt;&gt;\
 &lt;&lt;include &quot;Enthrallment Finish (Text)&quot;&gt;&gt;
 
 &lt;span class=&quot;good-ending&quot;&gt;Ending: &lt;i&gt;Ivex&#39;s Enthrallment&lt;/i&gt;&lt;/span&gt;
 
-[[The End|The End]]</tw-passagedata><tw-passagedata pid="217" name="Extraction Finish" tags="" position="2810,3060" size="100,100">&lt;&lt;if !$extractionIvexEnding&gt;&gt;\
+[[The End|The End]]</tw-passagedata><tw-passagedata pid="208" name="Extraction Finish" tags="" position="2400,5750" size="100,100">&lt;&lt;if !$extractionIvexEnding&gt;&gt;\
 &lt;&lt;set $extractionIvexEndingUnlock = true&gt;&gt;\
 &lt;&lt;/if&gt;&gt;\
 &lt;&lt;include &quot;Extraction Finish (Text)&quot;&gt;&gt;
 
 &lt;span class=&quot;good-ending&quot;&gt;Ending: &lt;i&gt;Ivex&#39;s Extraction&lt;/i&gt;&lt;/span&gt;
 
-[[The End|The End]]</tw-passagedata><tw-passagedata pid="218" name="Turn In" tags="" position="2704,1282" size="100,100">Before Ivex can wake up, $name approaches him. He grunts looking down at the mage, but picks him up and places the unconscious, bound mage over his shoulder to get ready to take him back.
+[[The End|The End]]</tw-passagedata><tw-passagedata pid="209" name="Turn In" tags="" position="1450,5450" size="100,100">Before Ivex can wake up, $name approaches him. He grunts looking down at the mage, but picks him up and places the unconscious, bound mage over his shoulder to get ready to take him back.
 
 Looking down, however, the wolf sees his member still aching. Surely Ivex&#39;s candle effect must wear off at some point, but it&#39;s still uncomfortable. Even the large wolf can&#39;t help but blush remembering his time bound on that cross. The way Ivex taunted and touched him, the threats the feline made...
 
@@ -4930,10 +4833,10 @@ $name takes a deep breath. Should he really just take Ivex to be arrested and no
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-  	&lt;li&gt;[[Yes. Turn Ivex in and be done with it.|SFW Finish]]&lt;/li&gt;  
-  	&lt;li&gt;[[No... he deserves some punishment. Punish Ivex for his misdeeds.|Punishments]]&lt;/li&gt;
+      &lt;li&gt;[[Yes. Turn Ivex in and be done with it.|SFW Finish]]&lt;/li&gt;  
+      &lt;li&gt;[[No... he deserves some punishment. Punish Ivex for his misdeeds.|Punishments]]&lt;/li&gt;
   &lt;/ul&gt;\
-&lt;/div&gt;</tw-passagedata><tw-passagedata pid="219" name="Pull Out Punishment Finish" tags="" position="2512,2883" size="100,100">$name decides that, since Ivex&#39;s arrogance seems to know no bounds, he can deal with a little extra punishment during the trip back.
+&lt;/div&gt;</tw-passagedata><tw-passagedata pid="210" name="Pull Out Punishment Finish" tags="" position="2525,6175" size="100,100">$name decides that, since Ivex&#39;s arrogance seems to know no bounds, he can deal with a little extra punishment during the trip back.
 
 With a smirk, the wolf looks down at Ivex, who in turn glares daggers up at him, but is unable to say anything gagged as he is. Not breaking eye contact, the wolf shoves his paw into the gem pouch again and... pulls out the pink, lust spell gemstone.
 
@@ -4953,7 +4856,7 @@ Leaving Ivex squirming on the floor, the wolf then prepares to grab his stuff to
 
 $name just smiles. He has something he can fuck on the way if he needs to.
 
-[[Continue|Bounty Collection]]</tw-passagedata><tw-passagedata pid="220" name="Bounty Collection" tags="" position="2606,3062" size="100,100">Lucky for the wolf, he manages to find a worn, old pair of pants in the farmhouse Ivex had made his base. They are far too short for him, but they will do, so that at least he&#39;s not naked.
+[[Continue|Bounty Collection]]</tw-passagedata><tw-passagedata pid="211" name="Bounty Collection" tags="" position="2950,5650" size="100,100">Lucky for the wolf, he manages to find a worn, old pair of pants in the farmhouse Ivex had made his base. They are far too short for him, but they will do, so that at least he&#39;s not naked.
 
 Gathering what supplies he can, the wolf sets off with everything in hand: Ivex&#39;s tower inside the large gemstone, the pouch of magic gems and, most importantly, Ivex.
 
@@ -4967,7 +4870,7 @@ With a handsome amount of gold in his pocket, the wolf moves on. The life of an 
 
 Or, at least, he will try to.
 
-[[The End|The End]]</tw-passagedata><tw-passagedata pid="221" name="The End" tags="" position="2603,3330" size="100,100">The End.
+[[The End|The End]]</tw-passagedata><tw-passagedata pid="212" name="The End" tags="end" position="2775,5050" size="100,100">The End.
 &lt;&lt;if $personalEndingUnlock&gt;&gt;\
 &lt;&lt;set $personalEnding = true&gt;&gt;\
 &lt;&lt;set $personalEndingUnlock = false&gt;&gt;\
@@ -5003,11 +4906,11 @@ From here on, you can...
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\  
-  	&lt;li&gt;[[Return to the point of escaping the tower.|Outside]]&lt;/li&gt;
-  	&lt;li&gt;[[Return to the point of escaping the first floor.|Escape Start]]&lt;/li&gt;	
-  	&lt;li&gt;[[Return to the beginning of the game.|Title Screen]]&lt;/li&gt;
+      &lt;li&gt;[[Return to the point of escaping the tower.|Outside]]&lt;/li&gt;
+      &lt;li&gt;[[Return to the point of escaping the first floor.|Escape Start]]&lt;/li&gt;	
+      &lt;li&gt;[[Return to the beginning of the game.|Title Screen]]&lt;/li&gt;
   &lt;/ul&gt;\
-&lt;/div&gt;</tw-passagedata><tw-passagedata pid="222" name="Enthrallment Vengeance (Text)" tags="text" position="1986,1518" size="100,100">Deciding on his vengeance, the wolf smirks. While the panther is still unconscious on the floor, the wolf turns towards the tower inside the gemstone, picks the red teleportation stone up and clutches it again.
+&lt;/div&gt;</tw-passagedata><tw-passagedata pid="213" name="Enthrallment Vengeance (Text)" tags="text" position="1600,5475" size="100,100">Deciding on his vengeance, the wolf smirks. While the panther is still unconscious on the floor, the wolf turns towards the tower inside the gemstone, picks the red teleportation stone up and clutches it again.
 
 $name finds the transportation easier this time. Perhaps because he was ready for it? Regardless, the wolf turns up at the exact same spot he left. From there, it is a simple matter to return to the lion&#39;s room where the large feline still squirms on the ground.
 
@@ -5031,7 +4934,7 @@ Recognition flares up in Ivex&#39;s eyes right away.
 
 &quot;NO! Get that thing away from me! You don&#39;t know what you&#39;re doing!&quot; Ivex almost pleads.
 
-The wolf doesn&#39;t stop.</tw-passagedata><tw-passagedata pid="223" name="Ivex Enthrallment 1 (Text)" tags="text" position="1985,1671" size="100,100">&quot;YOU FOOL!&quot; Ivex yells as the pendant is brought up to his head. &quot;When I get out of this, I will make you regret all of this a thousand times ov-&quot;
+The wolf doesn&#39;t stop.</tw-passagedata><tw-passagedata pid="214" name="Ivex Enthrallment 1 (Text)" tags="text" position="1725,5475" size="100,100">&quot;YOU FOOL!&quot; Ivex yells as the pendant is brought up to his head. &quot;When I get out of this, I will make you regret all of this a thousand times ov-&quot;
 
 $name lowers the pendant, placing it around his neck. The gemstone emits a glow for a moment and, as soon as it does, Ivex&#39;s eyes grow wide for just a moment and his words get interrupted. Then, soon after, his expression of outrage and anger fades into a neutral one. The same one the lion holds all the time.
 
@@ -5055,7 +4958,7 @@ The wolf stands up and looks down at him curiously. Does this thing really work?
 
 Watching the bound feline standing still and without expression, the wolf smirks. A series of ideas go through his head and, underneath him... his cock throbs. The arousal Ivex has inflicted on him has been bothering him ever since he escaped that damned cross.
 
-Maybe it&#39;s time to do something about that, too.</tw-passagedata><tw-passagedata pid="224" name="Ivex Enthrallment 2 (Text)" tags="text" position="1986,1821" size="100,100">Deciding to test things out before pushing anything further, the wolf grabs Ivex by his scruff and pulls him up to his knees. The panther stands firm on them, but says nothing and does not change his expression. He does seem to be completely at the wolf&#39;s mercy.
+Maybe it&#39;s time to do something about that, too.</tw-passagedata><tw-passagedata pid="215" name="Ivex Enthrallment 2 (Text)" tags="text" position="1850,5475" size="100,100">Deciding to test things out before pushing anything further, the wolf grabs Ivex by his scruff and pulls him up to his knees. The panther stands firm on them, but says nothing and does not change his expression. He does seem to be completely at the wolf&#39;s mercy.
 
 Placing the bound captive properly in front of him, the wolf keeps one hand on his head holding his fur, but with the other... he points his hard, red member down towards Ivex.
 
@@ -5067,7 +4970,7 @@ The panther does not look at him or show any kind of emotion, again just like th
 
 The red, tapered member throbs in response to Ivex&#39;s continuous licking. The panther does a thorough job, covering the wolf&#39;s member in saliva. At first, $name is wary, keeping a tight grip on Ivex&#39;s fur, ready to pull him off of him at the first sign of aggression, but after a few minutes of constant licking, it is clear that the spell works. The wolf&#39;s grip loosens and, as it does, the panther leans forward to increase his reach. His tongue caresses the whole of the wolf&#39;s member, coating it all the way to the knot. Feeling that rough tongue right against his sensitive knot has $name gritting his teeth as a bead of pre-cum appears at the tip of his member. His arousal flares higher and higher and, seeing Ivex in that position...
 
-There is little to do but take advantage of it.</tw-passagedata><tw-passagedata pid="225" name="Ivex Enthrallment 3 (Text)" tags="text" position="1987,1972" size="100,100">&quot;Stop,&quot; the wolf orders, and the panther ceases his licking right away.
+There is little to do but take advantage of it.</tw-passagedata><tw-passagedata pid="216" name="Ivex Enthrallment 3 (Text)" tags="text" position="1975,5475" size="100,100">&quot;Stop,&quot; the wolf orders, and the panther ceases his licking right away.
 
 With a pleased smile, the wolf grips his cock at the base again and, taking another step forward, presses his member coated with saliva against Ivex&#39;s muzzle. The feline does not react as the wolf grinds and wipes his member against his face, smearing it with both drool and pre-cum.
 
@@ -5089,7 +4992,7 @@ $name smirks. The wolf&#39;s hand on his own cock starts stroking it properly. T
 
 &quot;Yes,&quot; Ivex simply responds.
 
-The wolf&#39;s smile widens. He does not stop stroking his cock as he walks toward the door. &quot;Then follow me.&quot;</tw-passagedata><tw-passagedata pid="226" name="Ivex Enthrallment 4 (Text)" tags="text" position="1983,2119" size="100,100">It doesn&#39;t take long for $name to find the bedroom. It looks neat, but a layer of dust on most furniture indicates it likely hasn&#39;t been used in a while. Ivex probably sleeps inside his magical tower of nonsense. The wolf points at it, though.
+The wolf&#39;s smile widens. He does not stop stroking his cock as he walks toward the door. &quot;Then follow me.&quot;</tw-passagedata><tw-passagedata pid="217" name="Ivex Enthrallment 4 (Text)" tags="text" position="2100,5475" size="100,100">It doesn&#39;t take long for $name to find the bedroom. It looks neat, but a layer of dust on most furniture indicates it likely hasn&#39;t been used in a while. Ivex probably sleeps inside his magical tower of nonsense. The wolf points at it, though.
 
 &quot;Get on the bed, panther. On all fours.&quot;
 
@@ -5109,7 +5012,7 @@ Ivex&#39;s expression, unfortunately, does not change. If he can hear him, the p
 
 Spitting on his paw, the wolf then smears it around his cock, lubricating it a little bit to make it easier, but as he lines himself up with the feline, a new thought occurs to him.
 
-Why should he do all the work?</tw-passagedata><tw-passagedata pid="227" name="Ivex Enthrallment 5 (Text)" tags="text" position="1985,2269" size="100,100">Pushing the feline to the side, $name himself lies on the bed on his back. The panther looks at him with no emotion, remaining on all fours at the corner of the bed as the wolf spreads his legs and brings his hand down to give his knot a small squeeze. Then, he looks at the panther and smiles.
+Why should he do all the work?</tw-passagedata><tw-passagedata pid="218" name="Ivex Enthrallment 5 (Text)" tags="text" position="2225,5475" size="100,100">Pushing the feline to the side, $name himself lies on the bed on his back. The panther looks at him with no emotion, remaining on all fours at the corner of the bed as the wolf spreads his legs and brings his hand down to give his knot a small squeeze. Then, he looks at the panther and smiles.
 
 &quot;Climb up and line your rear with my cock,&quot; he orders.
 
@@ -5129,7 +5032,7 @@ It makes it all the better.
 
 Inch by inch, the feline takes his cock, and the wolf gets a front-row seat watching his ass spread for him. It takes a while and some effort, but eventually, the feline&#39;s rear finally bumps against the wolf&#39;s larger, engorged knot. $name growls. An eagerness to shove his knot into the feline, his most primal instinct, comes over him, but the wolf is patient. The time for that will come. For now, while Ivex sits there impaled on his cock...
 
-&quot;Now... ride it. Fuck yourself with my cock.&quot;</tw-passagedata><tw-passagedata pid="228" name="Ivex Enthrallment Final (Text)" tags="text" position="1986,2419" size="100,100">The sensations of the panther going back up on his cock are amazing for the lust-filled wolf. $name lets himself moan in pleasure as the panther moves up... and then comes down again, impaling himself on his cock all over again. Ivex&#39;s expression does not change, but the little grunts of effort coming from him are like music to the wolf&#39;s ear. The blue gemstone on the feline&#39;s pendant continues glowing as the enthralled mage is forced to obey his every command.
+&quot;Now... ride it. Fuck yourself with my cock.&quot;</tw-passagedata><tw-passagedata pid="219" name="Ivex Enthrallment Final (Text)" tags="text" position="2350,5475" size="100,100">The sensations of the panther going back up on his cock are amazing for the lust-filled wolf. $name lets himself moan in pleasure as the panther moves up... and then comes down again, impaling himself on his cock all over again. Ivex&#39;s expression does not change, but the little grunts of effort coming from him are like music to the wolf&#39;s ear. The blue gemstone on the feline&#39;s pendant continues glowing as the enthralled mage is forced to obey his every command.
 
 &quot;Faster... fuck...&quot; $name growls, and the panther obeys.
 
@@ -5153,7 +5056,7 @@ With a strong throb, the first jet of wolf seed is deposited deep within the mag
 
 Only the sound of Ivex&#39;s small grunts can be heard as the panther keeps jerking himself off, stimulating his sheath and looking for a pleasure he will not achieve with the chastity spell upon him.
 
-The wolf is happy and content in laying down like that for a while, with the mage that fucked him over stuck to his cock and forced to pleasure himself in the most frustrating of ways.</tw-passagedata><tw-passagedata pid="229" name="Ivex Enthrallment End (Text)" tags="text" position="1987,2661" size="100,100">$name takes his sweet time. He is definitely not in a hurry anymore. The wolf enjoys the feeling of the panther&#39;s ass around his cock, the way it grips his grown knot, and the way it clenches while Ivex continues to try and try to jerk off to no avail.
+The wolf is happy and content in laying down like that for a while, with the mage that fucked him over stuck to his cock and forced to pleasure himself in the most frustrating of ways.</tw-passagedata><tw-passagedata pid="220" name="Ivex Enthrallment End (Text)" tags="text" position="2475,5475" size="100,100">$name takes his sweet time. He is definitely not in a hurry anymore. The wolf enjoys the feeling of the panther&#39;s ass around his cock, the way it grips his grown knot, and the way it clenches while Ivex continues to try and try to jerk off to no avail.
 
 While waiting for his knot to recede, he looks at the feline. Ivex stares at nothing in particular while his hand continues to tease and work his sheath. His cock, stuck inside it, looks absolutely desperate to grow, but the magic barrier keeping his sheath sealed is strong. The barrier, however, does not seem to apply to liquids, as a steady flow of pre-cum keeps coming from Ivex&#39;s sheath to run down towards Ivex&#39;s balls and, much to his annoyance, mat the fur of his crotch as well.
 
@@ -5181,7 +5084,7 @@ It&#39;s time to take Ivex back to the adventurer&#39;s guild. Watching the blan
 
 What would it be like to have a thrall himself? Would a large bag of gold really be enough to make up for something like that? What if...?
 
-No, that wouldn&#39;t be right. ...Would it? Ivex has made thralls of others and he had no intention of letting them go. It is poetic justice that he ends up meeting the same fate. Besides, slaves are common in most cities. Wouldn&#39;t that be a fitting punishment for the mage after all he&#39;s done?</tw-passagedata><tw-passagedata pid="230" name="Enthrallment Finish (Text)" tags="text" position="2291,3056" size="100,100">A smile grows across the wolf&#39;s muzzle. Yeah, there is no reason to waste such a good thrall by delivering him in for gold. Thinking back on all Ivex did to him in the tower and, even more so, what Ivex planned to do to him still, fills the wolf with certainty that this is the right way to go about it.
+No, that wouldn&#39;t be right. ...Would it? Ivex has made thralls of others and he had no intention of letting them go. It is poetic justice that he ends up meeting the same fate. Besides, slaves are common in most cities. Wouldn&#39;t that be a fitting punishment for the mage after all he&#39;s done?</tw-passagedata><tw-passagedata pid="221" name="Enthrallment Finish (Text)" tags="text" position="2600,5400" size="100,100">A smile grows across the wolf&#39;s muzzle. Yeah, there is no reason to waste such a good thrall by delivering him in for gold. Thinking back on all Ivex did to him in the tower and, even more so, what Ivex planned to do to him still, fills the wolf with certainty that this is the right way to go about it.
 
 &quot;This is a pretty look for you,&quot; $name comments. &quot;You don&#39;t mind staying naked, do you? I think I might just keep you naked all the time. It&#39;s not like you will mind all the stares, right?&quot;
 
@@ -5207,7 +5110,7 @@ The mages handle his tower. The wolf does not stick around to see it, but the ru
 
 With a new &#39;companion&#39; by his side, the wolf moves on. The life of an adventurer is like that. Ivex wasn&#39;t the first mage he had to fight and it won&#39;t be the last. The events of the tower stick inside &lt;&lt;print $name&gt;&gt;&#39;s mind, though, and they are enough to make him blush every now and then, but whenever that happens, his new panther servant is there to alleviate his rage. He will make sure that such things never happen again.
 
-Or, at least, he will try to.</tw-passagedata><tw-passagedata pid="231" name="Extraction Vengeance (Text)" tags="text" position="3230,1535" size="100,100">Deciding on his vengeance, the wolf smirks. He picks Ivex up. Taking him inside the tower is risky, as he seemed to be more powerful there, therefore it has to be done before he wakes up. It&#39;ll be worth it, hopefully.
+Or, at least, he will try to.</tw-passagedata><tw-passagedata pid="222" name="Extraction Vengeance (Text)" tags="text" position="1650,5850" size="100,100">Deciding on his vengeance, the wolf smirks. He picks Ivex up. Taking him inside the tower is risky, as he seemed to be more powerful there, therefore it has to be done before he wakes up. It&#39;ll be worth it, hopefully.
 
 With ease, the large wolf lifts the unconscious panther up to carry him over his shoulder. He then takes the red gemstone he made to get out of the tower, looks at it, and grips it again, hoping it&#39;ll work...
 
@@ -5221,7 +5124,7 @@ With a heave, the wolf throws the tied-up panther right over the blob.
 
 It softens his impact. The wolf takes a step back, not sure what to expect. Much to his surprise, the thing, even though it looks like water, appears to be... viscous. The panther sinks halfway into it, but the moment it does, the blob starts moving around him. It engulfs and pulls the mage further into it. At first, $name frowns, thinking it&#39;s going to drown the panther, but soon the unconscious feline&#39;s muzzle opens and the wolf can clearly see that the blob creates an airway for him. This thing is clearly created with devious purposes in mind...
 
-It is at that moment that Ivex&#39;s droopy eyes start to open. The blob continues to engulf him, moving the feline to its center. Ivex looks confused for a moment, but then... his eyes grow wide. They meet the wolf&#39;s, then dart all around him, and his expression shifts to one of rage... and panic.</tw-passagedata><tw-passagedata pid="232" name="Ivex Extraction 1 (Text)" tags="text" position="3231,1684" size="100,100">The panther&#39;s muzzle moves, but if he makes any sound, it doesn&#39;t make it past the thick, viscous substance of the blob. Ivex&#39;s bound arms and legs move for a moment, but as soon as they start, they immediately slow down, and the wolf can see that the thing is hardening around them to keep the panther still. Frozen in place, Ivex&#39;s eyes dart back and forth until they meet the wolf&#39;s. $name can see him frown, his expression shifting to one of anger, but his face too freezes inside the thing. Whatever this blob is, it doesn&#39;t seem keen on letting the feline move. Good. It works even better than the wolf expected.
+It is at that moment that Ivex&#39;s droopy eyes start to open. The blob continues to engulf him, moving the feline to its center. Ivex looks confused for a moment, but then... his eyes grow wide. They meet the wolf&#39;s, then dart all around him, and his expression shifts to one of rage... and panic.</tw-passagedata><tw-passagedata pid="223" name="Ivex Extraction 1 (Text)" tags="text" position="1775,5850" size="100,100">The panther&#39;s muzzle moves, but if he makes any sound, it doesn&#39;t make it past the thick, viscous substance of the blob. Ivex&#39;s bound arms and legs move for a moment, but as soon as they start, they immediately slow down, and the wolf can see that the thing is hardening around them to keep the panther still. Frozen in place, Ivex&#39;s eyes dart back and forth until they meet the wolf&#39;s. $name can see him frown, his expression shifting to one of anger, but his face too freezes inside the thing. Whatever this blob is, it doesn&#39;t seem keen on letting the feline move. Good. It works even better than the wolf expected.
 
 $name wipes his paws and smiles triumphantly. Seeing Ivex trapped inside his own device is extremely pleasant. For a few moments, he watches the feline as he clearly struggles to move. His small muscles contract here or there, showing he&#39;s trying to put effort into moving his limbs, but none of it amounts to anything. What a weakling! After a while, it is clear that the feline is trapped and cannot get out. The wolf is ready to leave him there, for in fact, he doesn&#39;t even know how he would go about getting Ivex out of it. The mages in the adventurer&#39;s guild will surely figure something out when he delivers the panther and his tower to them in a few days. Taking a step back, the wolf is about to leave, but then something else catches his eye.
 
@@ -5231,7 +5134,7 @@ But that&#39;s not all of it. The wolf notices how the blob&#39;s movement start
 
 The thing moves around it as if massaging his sheath, except...
 
-The yellow glow surrounding it stops it. The blob seems keen on continuing to stimulate it for some reason, but the yellow glow blocks it. The wolf raises an eyebrow watching it all unfold. Is this thing another one of Ivex&#39;s perverted machinations?</tw-passagedata><tw-passagedata pid="233" name="Ivex Extraction 2 (Text)" tags="text" position="3231,1834" size="100,100">The panther seems angrier and more distressed as time goes on. The blob moving around his sheath grows more active. Even from outside, it looks as if it is actively stroking it, trying to stimulate it for some reason.
+The yellow glow surrounding it stops it. The blob seems keen on continuing to stimulate it for some reason, but the yellow glow blocks it. The wolf raises an eyebrow watching it all unfold. Is this thing another one of Ivex&#39;s perverted machinations?</tw-passagedata><tw-passagedata pid="224" name="Ivex Extraction 2 (Text)" tags="text" position="1900,5850" size="100,100">The panther seems angrier and more distressed as time goes on. The blob moving around his sheath grows more active. Even from outside, it looks as if it is actively stroking it, trying to stimulate it for some reason.
 
 In response to that, $name can see how Ivex&#39;s body reacts. Since the magic&#39;s chastity cage is transparent, the way the panther&#39;s sheath grows thicker is clear. The pink member nestled within reaches the opening of his sheath and bulges it, but because of the spell, it is unable to properly grow hard. It sure seems keen on trying to, though.
 
@@ -5243,7 +5146,7 @@ It gets absorbed by it right away. It is as if the blob knows what it is doing. 
 
 Ivex makes effort after effort to move, to get away from the thing assaulting his genitals. His face shows anger, outrage, and every now and then his furious eyes focus on the wolf, but there doesn&#39;t seem to be anything the feline can do to get away, or else he would already have done so. Even the red gemstone, the one that teleports, sits inside the blob below Ivex, but according to his own journal, it is &#39;unreachable&#39; to him anyway. Now $name can see why.
 
-The wolf smirks with satisfaction. Ivex is finally paying for all he has done.</tw-passagedata><tw-passagedata pid="234" name="Ivex Extraction 3 (Text)" tags="text" position="3230,1986" size="100,100">&lt;&lt;print $name&gt;&gt; can&#39;t help but move his own hand down to his cock as he watches the struggling panther get assaulted inside his own device. The karmic justice in it feels weirdly erotic. Or maybe it&#39;s just the effects of the candle still burning hot within him? Either way, it feels great for the wolf to have the freedom to wrap his paw around his member and stroke it.
+The wolf smirks with satisfaction. Ivex is finally paying for all he has done.</tw-passagedata><tw-passagedata pid="225" name="Ivex Extraction 3 (Text)" tags="text" position="2025,5850" size="100,100">&lt;&lt;print $name&gt;&gt; can&#39;t help but move his own hand down to his cock as he watches the struggling panther get assaulted inside his own device. The karmic justice in it feels weirdly erotic. Or maybe it&#39;s just the effects of the candle still burning hot within him? Either way, it feels great for the wolf to have the freedom to wrap his paw around his member and stroke it.
 
 It feels even better to see Ivex&#39;s eyes shifting downwards towards his cock. The panther is forced to watch the free wolf idly jerking off while, at the same time, the blob keeps working on his cock relentlessly while it is unable to even grow hard.
 
@@ -5255,7 +5158,7 @@ Ivex seems to definitely feel that. The feline&#39;s eyes grow wide, and his fac
 
 &lt;&lt;print $name&gt;&gt;&#39;s paw speeds up on his own cock. The erotic view of his hateful enemy being mistreated feels even better. The wolf&#39;s cock stands as hard as it was before, the red, tapered canine spire hard all the way to the knot. The wolf takes his sweet time stroking it, enjoying the pleasure the mage cannot feel, but because of how strong the arousal inside him is, he doesn&#39;t feel too far from cumming.
 
-And then things get even better.</tw-passagedata><tw-passagedata pid="235" name="Ivex Extraction Final (Text)" tags="text" position="3230,2135" size="100,100">The wolf&#39;s paw speeds up even more on his cock and he laughs when the blob spreads Ivex&#39;s legs even wider. The movement under the panther&#39;s tail makes what&#39;s going to happen next obvious. It&#39;s unbelievable that Ivex made this thing to do that to someone, but it feels incredibly pleasant to see it done to him!
+And then things get even better.</tw-passagedata><tw-passagedata pid="226" name="Ivex Extraction Final (Text)" tags="text" position="2150,5850" size="100,100">The wolf&#39;s paw speeds up even more on his cock and he laughs when the blob spreads Ivex&#39;s legs even wider. The movement under the panther&#39;s tail makes what&#39;s going to happen next obvious. It&#39;s unbelievable that Ivex made this thing to do that to someone, but it feels incredibly pleasant to see it done to him!
 
 The panther seems to be aware of what&#39;s going to happen as well. His struggling to move grows more frantic than ever, every muscle in the panther&#39;s body contracting as he tries to move, but it is as if he is encased in solid ice. The panther remains there, floating inside the blob, even as it moves under his tail...
 
@@ -5275,7 +5178,7 @@ All of its efforts to extract the same thing from Ivex seem to double. The panth
 
 The wolf, on the other hand, slows down his paw. His cock, just as before, remains just as hard, his knot bigger than ever. Because of Ivex&#39;s cursed candle and whatnot, he feels some relief from jerking off, but $name feels as if he can go again right away. Will that lust ever subside?!
 
-Just as he wonders that, the altar where the blob with Ivex inside starts glowing. The wolf takes a step back, readying himself, unsure of what is happening...</tw-passagedata><tw-passagedata pid="236" name="Ivex Extraction End (Text)" tags="text" position="3229,2285" size="100,100">The glowing on the altar grows brighter. Ivex seems to grow more frantic inside it for a moment, and then...
+Just as he wonders that, the altar where the blob with Ivex inside starts glowing. The wolf takes a step back, readying himself, unsure of what is happening...</tw-passagedata><tw-passagedata pid="227" name="Ivex Extraction End (Text)" tags="text" position="2275,5850" size="100,100">The glowing on the altar grows brighter. Ivex seems to grow more frantic inside it for a moment, and then...
 
 It disappears.
 
@@ -5293,7 +5196,7 @@ Keeping his nose covered, the wolf takes a few steps back.
 
 Yet, he smirks. If the panther has really inflicted that upon others, then it is only fitting that he tastes it himself. Completely trapped, it&#39;s clear that Ivex isn&#39;t going anywhere.
 
-The panther&#39;s eyes grow wide with fury when the wolf pushes the first of the alcove&#39;s stone doors closed. Then, $name can see him trying so very hard to move, to say something, all the while his eyes and face start losing themselves in an expression of drunken lust and need before the wolf closes the second door, trapping the crazed mage inside with nothing but his own candles... and his own weird blob-thing.</tw-passagedata><tw-passagedata pid="237" name="Extraction Finish (Text)" tags="text" position="2914,3060" size="100,100">The wolf gets out of the tower and takes pleasure in knowing that, inside this gemstone where the tower is, the target of his bounty is as well.
+The panther&#39;s eyes grow wide with fury when the wolf pushes the first of the alcove&#39;s stone doors closed. Then, $name can see him trying so very hard to move, to say something, all the while his eyes and face start losing themselves in an expression of drunken lust and need before the wolf closes the second door, trapping the crazed mage inside with nothing but his own candles... and his own weird blob-thing.</tw-passagedata><tw-passagedata pid="228" name="Extraction Finish (Text)" tags="text" position="2400,5850" size="100,100">The wolf gets out of the tower and takes pleasure in knowing that, inside this gemstone where the tower is, the target of his bounty is as well.
 
 Lucky for the wolf, he manages to find a worn, old pair of pants in the farmhouse Ivex had made his base. They are far too short for him, but they will do, so that at least he&#39;s not naked.
 
@@ -5309,14 +5212,14 @@ They also handle his tower as a whole. The wolf does not stick around to see it,
 
 With a handsome amount of gold in his hands, the wolf moves on. The life of an adventurer is like that. Ivex wasn&#39;t the first mage he had to fight and it won&#39;t be the last. The events of the tower stick inside &lt;&lt;print $name&gt;&gt;&#39;s mind, though, and they are enough to make him blush every now and then. He will make sure that such things never happen again.
 
-Or, at least, he will try to.</tw-passagedata><tw-passagedata pid="238" name="Ivex Enthrallment Archive Display" tags="" position="177,3127" size="100,100">&lt;&lt;if $enthralmentIvexEnding&gt;&gt;\
+Or, at least, he will try to.</tw-passagedata><tw-passagedata pid="229" name="Ivex Enthrallment Archive Display" tags="noreturn" position="2200,1000" size="100,100">&lt;&lt;if $enthralmentIvexEnding&gt;&gt;\
   &lt;b&gt;[[Ending: A New Servant|Ivex Enthrallment Archive]]&lt;/b&gt;
 &lt;&lt;else&gt;&gt;\
   &lt;span class=&quot;helper-container&quot;&gt;
-  	&lt;b&gt;&lt;span class=&quot;disabled&quot;&gt;Ending: A New Servant&lt;/span&gt;&lt;/b&gt;
-	&lt;small class=&quot;helper-text&quot;&gt;New punishment ideas might come to the adventurer if he has experienced terrible things in different timelines...&lt;/small&gt;
+      &lt;b&gt;&lt;span class=&quot;disabled&quot;&gt;Ending: A New Servant&lt;/span&gt;&lt;/b&gt;
+    &lt;small class=&quot;helper-text&quot;&gt;New punishment ideas might come to the adventurer if he has experienced terrible things in different timelines...&lt;/small&gt;
   &lt;/span&gt;
-&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="239" name="Ivex Enthrallment Archive" tags="noreturn" position="472,3130" size="100,100">&lt;&lt;include &quot;Enthrallment Vengeance (Text)&quot;&gt;&gt;
+&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="230" name="Ivex Enthrallment Archive" tags="noreturn" position="2200,1100" size="100,100">&lt;&lt;include &quot;Enthrallment Vengeance (Text)&quot;&gt;&gt;
 
 &lt;&lt;include &quot;Ivex Enthrallment 1 (Text)&quot;&gt;&gt;
 
@@ -5336,14 +5239,14 @@ Or, at least, he will try to.</tw-passagedata><tw-passagedata pid="238" name="Iv
 
 &lt;span class=&quot;good-ending&quot;&gt;Ending: &lt;i&gt;Ivex&#39;s Enthrallment&lt;/i&gt;&lt;/span&gt;
 
-[[Return to the Archives|Archives]]</tw-passagedata><tw-passagedata pid="240" name="Ivex Extraction Archive Display" tags="" position="176,3235" size="100,100">&lt;&lt;if $extractionIvexEnding&gt;&gt;\
+[[Return to the Archives|Archives]]</tw-passagedata><tw-passagedata pid="231" name="Ivex Extraction Archive Display" tags="noreturn" position="2325,1000" size="100,100">&lt;&lt;if $extractionIvexEnding&gt;&gt;\
   &lt;b&gt;[[Ending: Energy Supply|Ivex Extraction Archive]]&lt;/b&gt;
 &lt;&lt;else&gt;&gt;\
   &lt;span class=&quot;helper-container&quot;&gt;
-  	&lt;b&gt;&lt;span class=&quot;disabled&quot;&gt;Ending: Energy Supply&lt;/span&gt;&lt;/b&gt;
-	&lt;small class=&quot;helper-text&quot;&gt;New punishment ideas might come to the adventurer if he has experienced terrible things in different timelines...&lt;/small&gt;
+      &lt;b&gt;&lt;span class=&quot;disabled&quot;&gt;Ending: Energy Supply&lt;/span&gt;&lt;/b&gt;
+    &lt;small class=&quot;helper-text&quot;&gt;New punishment ideas might come to the adventurer if he has experienced terrible things in different timelines...&lt;/small&gt;
   &lt;/span&gt;
-&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="241" name="Ivex Extraction Archive" tags="noreturn" position="471,3235" size="100,100">&lt;&lt;include &quot;Extraction Vengeance (Text)&quot;&gt;&gt;
+&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="232" name="Ivex Extraction Archive" tags="noreturn" position="2325,1100" size="100,100">&lt;&lt;include &quot;Extraction Vengeance (Text)&quot;&gt;&gt;
 
 &lt;&lt;include &quot;Ivex Extraction 1 (Text)&quot;&gt;&gt;
 
@@ -5359,14 +5262,14 @@ Or, at least, he will try to.</tw-passagedata><tw-passagedata pid="238" name="Iv
 
 &lt;span class=&quot;good-ending&quot;&gt;Ending: &lt;i&gt;Ivex&#39;s Extraction&lt;/i&gt;&lt;/span&gt;
 
-[[Return to the Archives|Archives]]</tw-passagedata><tw-passagedata pid="242" name="Ivex Punishment Archive Display" tags="" position="178,3020" size="100,100">&lt;&lt;if $personalEnding&gt;&gt;\
+[[Return to the Archives|Archives]]</tw-passagedata><tw-passagedata pid="233" name="Ivex Punishment Archive Display" tags="noreturn" position="2075,1000" size="100,100">&lt;&lt;if $personalEnding&gt;&gt;\
   &lt;b&gt;[[Ending: Punishment|Ivex Punishment Archive]]&lt;/b&gt;
 &lt;&lt;else&gt;&gt;\
   &lt;span class=&quot;helper-container&quot;&gt;
-  	&lt;b&gt;&lt;span class=&quot;disabled&quot;&gt;Ending: Punishment&lt;/span&gt;&lt;/b&gt;
-	&lt;small class=&quot;helper-text&quot;&gt;The spoils of victory...&lt;/small&gt;
+      &lt;b&gt;&lt;span class=&quot;disabled&quot;&gt;Ending: Punishment&lt;/span&gt;&lt;/b&gt;
+    &lt;small class=&quot;helper-text&quot;&gt;The spoils of victory...&lt;/small&gt;
   &lt;/span&gt;
-&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="243" name="Ivex Punishment Archive" tags="noreturn" position="471,3023" size="100,100">The wolf, still holding Ivex up by the scruff, lifts him higher so that he can look at the unconscious feline&#39;s face. Then, without hesitation, $name brings a paw up and gives the panther&#39;s muzzle a hard slap.
+&lt;&lt;/if&gt;&gt;\</tw-passagedata><tw-passagedata pid="234" name="Ivex Punishment Archive" tags="noreturn" position="2075,1100" size="100,100">The wolf, still holding Ivex up by the scruff, lifts him higher so that he can look at the unconscious feline&#39;s face. Then, without hesitation, $name brings a paw up and gives the panther&#39;s muzzle a hard slap.
 
 Ivex shakes, awakening with a grunt and a mewl. The feline blinks, his feet wiggling up in the air and he looks around confused for a moment before his eyes focus on the large wolf holding him up. The sight of him trying to do something about it, only to realize that his arms are bound behind his back and his bound feet can&#39;t even touch the floor makes for quite an amusing scene.
 
@@ -5742,7 +5645,7 @@ Or, at least, he will try to.
 
 &lt;span class=&quot;good-ending&quot;&gt;Ending: &lt;i&gt;Punishment&lt;/i&gt;&lt;/span&gt;
 
-[[Return to the Archives|Archives]]</tw-passagedata><tw-passagedata pid="244" name="Credits" tags="noreturn" position="722,2741" size="100,100">[[Return to the game|$return]]
+[[Return to the Archives|Archives]]</tw-passagedata><tw-passagedata pid="235" name="Credits" tags="noreturn" position="2600,700" size="100,100">&lt;&lt;link &quot;Return to the game&quot; $return&gt;&gt;&lt;&lt;/link&gt;&gt;\
 
 The writing and development of this interactive story was made by me, [[Sleth|http://www.slethstories.com/]].
 
@@ -5754,50 +5657,50 @@ Not only that, but I&#39;d also like to extend my deepest gratitude to my patron
 
 First and foremost, my patrons that have supported me in these last 4 months it took for me to develop, learn and finish this project:
 
-&lt;b&gt;&lt;ul&gt;\  
-	&lt;li&gt;John Harris&lt;/li&gt;
-	&lt;li&gt;Timba Saber&lt;/li&gt;
-	&lt;li&gt;Kevin Deiderich&lt;/li&gt;
-	&lt;li&gt;Gd &lt;/li&gt;
-	&lt;li&gt;Rise&lt;/li&gt;
-	&lt;li&gt;Bingturong&lt;/li&gt;
-	&lt;li&gt;Laswer5&lt;/li&gt;
-	&lt;li&gt;Sándor Bajkai&lt;/li&gt;
-	&lt;li&gt;Sameer &lt;/li&gt;
-	&lt;li&gt;wssbxj &lt;/li&gt;
-	&lt;li&gt;Ian Meyers&lt;/li&gt;
-	&lt;li&gt;Daniel Choi&lt;/li&gt;
-	&lt;li&gt;Lathbalrog&lt;/li&gt;
-	&lt;li&gt;Argentcoyote&lt;/li&gt;
-	&lt;li&gt;Rin Ookami&lt;/li&gt;
-	&lt;li&gt;xiaokiroz &lt;/li&gt;
-	&lt;li&gt;Nigel Leiterman&lt;/li&gt;
-	&lt;li&gt;keinok82562 &lt;/li&gt;
-	&lt;li&gt;MagicMinnett&lt;/li&gt;
-	&lt;li&gt;Ishiah &lt;/li&gt;
-	&lt;li&gt;Snow Tastes Great&lt;/li&gt;
-	&lt;li&gt;nikokarro&lt;/li&gt;
-	&lt;li&gt;Nimrax&lt;/li&gt;
-	&lt;li&gt;Maxwell&lt;/li&gt;
-	&lt;li&gt;SASO_PRO&lt;/li&gt;
-	&lt;li&gt;Lykron &lt;/li&gt;
-	&lt;li&gt;Chris &lt;/li&gt;
-	&lt;li&gt;AshfurtheBroken &lt;/li&gt;
-	&lt;li&gt;Hyenatime &lt;/li&gt;
-	&lt;li&gt;Michael &lt;/li&gt;
-	&lt;li&gt;Chris Gordon&lt;/li&gt;
-	&lt;li&gt;Pinecone&lt;/li&gt;
-	&lt;li&gt;Guri Linus&lt;/li&gt;
-	&lt;li&gt;Hyao&lt;/li&gt;
-	&lt;li&gt;fancyhat &lt;/li&gt;
-	&lt;li&gt;llama&lt;/li&gt;
-	&lt;li&gt;Abraxas &lt;/li&gt;
-	&lt;li&gt;Hollud &lt;/li&gt;
-	&lt;li&gt;Lykos Bane&lt;/li&gt;
-	&lt;li&gt;Rex Aurum&lt;/li&gt;
-	&lt;li&gt;Martin Farley&lt;/li&gt;
-	&lt;li&gt;Knight of the Dragon&lt;/li&gt;
-	&lt;li&gt;Raus&lt;/li&gt;
+&lt;b&gt;&lt;ul&gt;\
+    &lt;li&gt;John Harris&lt;/li&gt;
+    &lt;li&gt;Timba Saber&lt;/li&gt;
+    &lt;li&gt;Kevin Deiderich&lt;/li&gt;
+    &lt;li&gt;Gd &lt;/li&gt;
+    &lt;li&gt;Rise&lt;/li&gt;
+    &lt;li&gt;Bingturong&lt;/li&gt;
+    &lt;li&gt;Laswer5&lt;/li&gt;
+    &lt;li&gt;Sándor Bajkai&lt;/li&gt;
+    &lt;li&gt;Sameer &lt;/li&gt;
+    &lt;li&gt;wssbxj &lt;/li&gt;
+    &lt;li&gt;Ian Meyers&lt;/li&gt;
+    &lt;li&gt;Daniel Choi&lt;/li&gt;
+    &lt;li&gt;Lathbalrog&lt;/li&gt;
+    &lt;li&gt;Argentcoyote&lt;/li&gt;
+    &lt;li&gt;Rin Ookami&lt;/li&gt;
+    &lt;li&gt;xiaokiroz &lt;/li&gt;
+    &lt;li&gt;Nigel Leiterman&lt;/li&gt;
+    &lt;li&gt;keinok82562 &lt;/li&gt;
+    &lt;li&gt;MagicMinnett&lt;/li&gt;
+    &lt;li&gt;Ishiah &lt;/li&gt;
+    &lt;li&gt;Snow Tastes Great&lt;/li&gt;
+    &lt;li&gt;nikokarro&lt;/li&gt;
+    &lt;li&gt;Nimrax&lt;/li&gt;
+    &lt;li&gt;Maxwell&lt;/li&gt;
+    &lt;li&gt;SASO_PRO&lt;/li&gt;
+    &lt;li&gt;Lykron &lt;/li&gt;
+    &lt;li&gt;Chris &lt;/li&gt;
+    &lt;li&gt;AshfurtheBroken &lt;/li&gt;
+    &lt;li&gt;Hyenatime &lt;/li&gt;
+    &lt;li&gt;Michael &lt;/li&gt;
+    &lt;li&gt;Chris Gordon&lt;/li&gt;
+    &lt;li&gt;Pinecone&lt;/li&gt;
+    &lt;li&gt;Guri Linus&lt;/li&gt;
+    &lt;li&gt;Hyao&lt;/li&gt;
+    &lt;li&gt;fancyhat &lt;/li&gt;
+    &lt;li&gt;llama&lt;/li&gt;
+    &lt;li&gt;Abraxas &lt;/li&gt;
+    &lt;li&gt;Hollud &lt;/li&gt;
+    &lt;li&gt;Lykos Bane&lt;/li&gt;
+    &lt;li&gt;Rex Aurum&lt;/li&gt;
+    &lt;li&gt;Martin Farley&lt;/li&gt;
+    &lt;li&gt;Knight of the Dragon&lt;/li&gt;
+    &lt;li&gt;Raus&lt;/li&gt;
 &lt;/ul&gt;&lt;/b&gt;\
 
 And, of course, also an honorable mention to everyone that has supported me and my writing in the these last years I have had my patreon going:
@@ -5872,7 +5775,7 @@ And, of course, also an honorable mention to everyone that has supported me and 
 &lt;li&gt;Raus&lt;/li&gt;
 &lt;/ul&gt;\
 
-Thank you so much!</tw-passagedata><tw-passagedata pid="245" name="Title Screen 1" tags="" position="1016,2" size="100,100">&lt;&lt;silently&gt;&gt;
+Thank you so much!</tw-passagedata><tw-passagedata pid="236" name="Title Screen 1" tags="" position="2625,25" size="100,100">&lt;&lt;silently&gt;&gt;
 &lt;&lt;if $personalEnding&gt;&gt;
 &lt;&lt;set $characterDisplay = &quot;images/wolf.png&quot;&gt;&gt;
 &lt;&lt;else&gt;&gt;
@@ -5888,6 +5791,7 @@ Thank you so much!</tw-passagedata><tw-passagedata pid="245" name="Title Screen 
 &lt;div class=&quot;title-options&quot;&gt;\
 &lt;&lt;link &quot;New Game&quot;&gt;&gt;
   &lt;&lt;script&gt;&gt;
+    // [[Bound]]
     Dialog.setup(&quot;Content Warning&quot;);
 	  Dialog.wiki(&quot;This interactive story contains content of an adult nature. If you are easily offended or are under the age of 18, please exit now.&lt;br/&gt;&lt;br/&gt; Moreover, this story contains elements that depict dubious or lack of consent, as well as other fetish sexual topics such as mind control, CBT, chastity, and others. If these themes make you uncomfortable or are not enjoyable for you, proceed only at your own discretion.&lt;br/&gt;&lt;br/&gt;&lt;span style= &#39;float: right;&#39;&gt;&lt;&lt;&quot;+&quot;button Proceed&gt;&gt;&lt;&lt;&quot;+&quot;goto &#39;Bound&#39;&gt;&gt;&lt;&lt;&quot;+&quot;script&gt;&gt;Dialog.close();&lt;&lt;&quot;+&quot;/script&gt;&gt;&lt;&lt;&quot;+&quot;/button&gt;&gt;&lt;/span&gt;&quot;);
     Dialog.open();

--- a/index.html
+++ b/index.html
@@ -172,6 +172,11 @@ var LZString={_keyStr:"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz01234
   background-color: #cb9b32;
 }
 
+#menu {
+  /* make some clear space, since footer is on top */
+  margin-bottom: 50px;
+}
+
 #menu ul {
   border-radius: 15px;
 }
@@ -225,6 +230,13 @@ var LZString={_keyStr:"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz01234
 
 #story-title {
   display: none;
+}
+
+#story-version {
+  color: rgb(90 90 90);
+  font-size: 12px;
+  font-weight: normal;
+  line-height: 1;
 }
 
 #story-caption {
@@ -327,7 +339,6 @@ ul.actions {
 }
 
 ul.actions li {
-  /*list-style-image: url('https://i.imgur.com/VdVEJPV.png');*/
   padding: 10px 0 10px 25px;
   list-style: none;
   background-image: url("images/quote.png");
@@ -335,6 +346,12 @@ ul.actions li {
   background-position: left center;
   background-size: 15px;
 }
+
+/* fixup for debug/test mode */
+.debugging ul.actions li {
+  background-image: url("https://magestower.slethstories.com/images/quote.png");
+}
+
 /* Action Box - End */
 
 
@@ -442,15 +459,35 @@ ul.actions li {
     background-color: #ebe6ff;
   }
 }</style><script role="script" id="twine-user-script" type="text/twine-javascript">Config.ui.stowBarInitially = true;
-Config.history.controls = false;
+
+if (!Config.debug) {
+  Config.history.controls = false;
+}
+
+if (Config.debug) {
+  // set flag for StoryMenu (can't use Config.debug; it's always false for StoryMenu)
+  setup.enableDebugMenu = true;
+
+  // set base url for html images (this happens too late for css images)
+  $('head').prepend('<base href="https://magestower.slethstories.com/">');
+
+  // add debugging class for css
+  $('html').addClass('debugging');
+
+  // start with debugview off
+  setTimeout(() => DebugView.disable());
+}
+
+l10nStrings.restartTitle = 'Reset';
+l10nStrings.restartPrompt = 'Archive unlocks and unsaved progress will be lost.<br><br>Are you sure you want to reset everything and start over?';
 
 $(document.head).append("<link rel='icon' href='images/mt_icon_tr.png'>");
 
-predisplay["Menu Return"] = function (taskName) {
-	if (! tags().contains("noreturn")) {
-		State.variables.return = passage();
+$(document).on(':passagestart', function (ev) {
+    if (! ev.passage.tags.contains("noreturn")) {
+        State.variables.return = ev.passage.title;
     }
-};
+});
 
 /* Health Bar code - Start */
 window.Health = function (CurHP, MaxHP, BarID, Horizontal, Container) {
@@ -483,7 +520,8 @@ macros.arousalbar = {
         new Wikifier(place, "<div id=\"horizontalhealthbarbkg\" class=\"hzbarbkg\"><div id=\"horizontalhealthbar\" class=\"hzbar\"></div></div>");
     }
 }
-/* Arousal Bar Macro - End */</script><tw-tag name="incomplete" color="red"></tw-tag><tw-tag name="key" color="red"></tw-tag><tw-tag name="noreturn" color="red"></tw-tag><tw-tag name="start" color="green"></tw-tag><tw-tag name="text" color="blue"></tw-tag><tw-tag name="hub" color="purple"></tw-tag><tw-passagedata pid="1" name="Bound" tags="" position="2500,175" size="100,100">The sound of snapping fingers feels distant at first. As consciousness returns, it grows closer and closer until it starts becoming loud.
+/* Arousal Bar Macro - End */</script><tw-tag name="done" color="purple"></tw-tag><tw-tag name="has-hole" color="yellow"></tw-tag><tw-tag name="init" color="blue"></tw-tag><tw-tag name="key" color="orange"></tw-tag><tw-tag name="maybe-password" color="blue"></tw-tag><tw-tag name="restart" color="green"></tw-tag><tw-tag name="end" color="red"></tw-tag><tw-tag name="incomplete" color="red"></tw-tag><tw-tag name="must-fix" color="orange"></tw-tag><tw-tag name="noreturn" color="yellow"></tw-tag><tw-tag name="text" color="blue"></tw-tag><tw-passagedata pid="1" name="Bound" tags="" position="2500,175" size="100,100">&lt;&lt;set $passedContentWarning = true&gt;&gt;\
+The sound of snapping fingers feels distant at first. As consciousness returns, it grows closer and closer until it starts becoming loud.
 
 The snapping comes from right beside his ear. The adventurer frowns, but consciousness has not returned in its entirety just yet. He feels as if... as if he had fallen down a well. At least that&#39;s all he can remember, sort of. It was bright, it was sudden, and now...
 
@@ -491,9 +529,15 @@ The snapping comes from right beside his ear. The adventurer frowns, but conscio
 
 The bound wolf only lets out a pained groan at first. Everything hurts. Slowly but surely, memories start to return. Memories of who he is...
 
-[[Continue|Wolf Warrior Chosen]]</tw-passagedata><tw-passagedata pid="2" name="StoryAuthor" tags="" position="1825,150" size="100,100">by &lt;a href=&quot;http://www.slethstories.com/&quot; target=&quot;_blank&quot;&gt;Sleth&lt;/a&gt;</tw-passagedata><tw-passagedata pid="3" name="StoryBanner" tags="" position="2075,150" size="100,100">&lt;img src=&quot;images/logo_tr.png&quot; width=&quot;220&quot;&gt;\
+[[Continue|Drekkar Start]]</tw-passagedata><tw-passagedata pid="2" name="StoryAuthor" tags="" position="1825,150" size="100,100">by &lt;a href=&quot;http://www.slethstories.com/&quot; target=&quot;_blank&quot;&gt;Sleth&lt;/a&gt;\
+&lt;div id=&quot;story-version&quot;&gt;
+  v1.2002910.0
+&lt;/div&gt;</tw-passagedata><tw-passagedata pid="3" name="StoryBanner" tags="" position="2075,150" size="100,100">&lt;img src=&quot;images/logo_tr.png&quot; width=&quot;220&quot;&gt;\
 &lt;div class=&quot;divider div-transparent div-arrow-down&quot;&gt;&lt;/div&gt;</tw-passagedata><tw-passagedata pid="4" name="StoryDisplayTitle" tags="" position="1950,150" size="100,100">The Mage&#39;s Tower</tw-passagedata><tw-passagedata pid="5" name="StoryMenu" tags="" position="2500,500" size="100,100">[[Archives]]
-[[Credits]]</tw-passagedata><tw-passagedata pid="6" name="Soft Awakening" tags="" position="900,625" size="100,100">&lt;&lt;set $warrior = true&gt;&gt;\
+[[Credits]]
+&lt;&lt;if setup.enableDebugMenu&gt;&gt;
+    [[Debug: Goto Title|Title Screen]]
+&lt;&lt;/if&gt;&gt;</tw-passagedata><tw-passagedata pid="6" name="Soft Awakening" tags="" position="900,625" size="100,100">&lt;&lt;set $warrior = true&gt;&gt;\
 It takes some effort, but the wolf opens his eyes. It takes a few seconds to regain their focus. At the same time, the stiffness of his body feels worse than ever. This nap was anything but comfortable.
 
 As his vision clears, $name realizes that he&#39;s not quite lying down. In fact, he&#39;s pretty much standing up. The feeling of the leather wrappings around his wrists, ankles, and mid-section becomes obvious upon his first attempts to move with a groan. \
@@ -578,7 +622,7 @@ The panther opens a cocky grin.
 
 &quot;The reward, however, is quite substantial. I do wonder who exactly hired you to find me, and how you managed to reach my location. I&#39;d very much like to know that before I decide what to do with you.&quot;
 
-The wolf&#39;s narrow eyes focus on the panther. Bound in an unknown location and at the wizard&#39;s mercy, the lupine $class knows that the situation isn&#39;t good. Still, to just give out the name and location of the adventurer&#39;s guild that hired him to go after the mage would put all of them in danger, to say the least...
+The wolf&#39;s narrow eyes focus on the panther. Bound in an unknown location and at the wizard&#39;s mercy, the lupine $class knows that the situation isn&#39;t good. Still, to just give out the name and location of the Wayward Adventurer Guild would put all of them in danger, to say the least...
 
 The panther stares at the wolf expecting an answer.
 
@@ -587,12 +631,12 @@ The panther stares at the wolf expecting an answer.
     &lt;li&gt;[[&#39;&quot;You won\&#39;t get anything out of me!&quot;&#39;|Refusal]]&lt;/li&gt;
     &lt;li&gt;[[&#39;&quot;...If I tell you what you want to know, then what?&quot;&#39;|Consideration]]	  &lt;/li&gt;
   &lt;/ul&gt;\
-&lt;/div&gt;</tw-passagedata><tw-passagedata pid="11" name="Wolf Warrior Chosen" tags="" position="950,500" size="100,100">&lt;&lt;set $name = &quot;Drekkar&quot;&gt;&gt;\
+&lt;/div&gt;</tw-passagedata><tw-passagedata pid="11" name="Drekkar Start" tags="" position="950,500" size="100,100">&lt;&lt;set $name = &quot;Drekkar&quot;&gt;&gt;\
 &lt;&lt;set $class = &quot;warrior&quot;&gt;&gt;\
 &lt;&lt;set $warrior = true&gt;&gt;\
 &lt;&lt;set $mage = false&gt;&gt;\
 &lt;&lt;set $rough_awakening = false&gt;&gt;\
-An adventurer, a fighter, a large wolf that takes pride in his strength. He goes by the name of Drekkar, with his older name being way more complex and difficult to pronounce. Hailing from the less advanced wolven tribes from the north, Drekkar left his kind early and adapted well to the world. With a sword in hand, there&#39;s little he cannot accomplish. Now, however...
+A seasoned fighter, a large wolf that takes pride in his strength. He goes by the name of Drekkar, with his older name being more complex and difficult to pronounce. Hailing from the less advanced wolven tribes from the north, Drekkar left his kind early and adapted well to the wider world. He&#39;s known among his friends at the Wayward Adventurers Guild as &quot;that crazy bastard who took down the Mad Wizard of Carcenvellathrop by punching him in the face&quot;. With a sword in hand, there&#39;s little Drekkar cannot accomplish. Now, however...
 
 Drekkar&#39;s muscles, usually his most powerful weapon, ache. They feel stiff. An aching to stretch them comes upon the big wolf, but his body is only just recovering its proper responses. Drekkar lets out another tired groan. This feels worse than his last hangover...
 
@@ -625,62 +669,67 @@ With a spring to his step, the panther approaches, closing in the last distance 
   &lt;ul class=&quot;actions&quot;&gt;\
     &lt;li&gt;[[Growl at Ivex.|Molesting]]&lt;/li&gt;
   &lt;/ul&gt;\
-&lt;/div&gt;</tw-passagedata><tw-passagedata pid="14" name="StoryInit" tags="" position="2200,150" size="100,100">&lt;&lt;set $name = &quot;Drekkar&quot;&gt;&gt;\
-&lt;&lt;set $class = &quot;warrior&quot;&gt;&gt;\
-&lt;&lt;set $warrior = true&gt;&gt;\
-&lt;&lt;set $mage = false&gt;&gt;\
+&lt;/div&gt;</tw-passagedata><tw-passagedata pid="14" name="StoryInit" tags="" position="2200,150" size="100,100">&lt;&lt;script&gt;&gt;
+const v = variables();
+v.name = &quot;Drekkar&quot;;
+v.class = &quot;warrior&quot;;
+v.warrior = true;
+v.mage = false;
 
-&lt;&lt;set $rough_awakening = true&gt;&gt;
-&lt;&lt;set $FurtherDefiance = false&gt;&gt;
+v.rough_awakening = true;
+v.FurtherDefiance = false;
 
-&lt;&lt;set $CurArousal = 10&gt;&gt;
-&lt;&lt;set $MaxArousal = 100&gt;&gt;
+v.CurArousal = 10;
+v.MaxArousal = 100;
 
-&lt;&lt;set $candleTimer = &quot;2s&quot;&gt;&gt;
-&lt;&lt;set $window = false&gt;&gt;
-&lt;&lt;set $office = false&gt;&gt;
-&lt;&lt;set $door = false&gt;&gt;
+v.candleTimer = &quot;2s&quot;;
+v.window = false;
+v.office = false;
+v.door = false;
 
-&lt;&lt;set $lionwatch1 = 40&gt;&gt;
-&lt;&lt;set $lionwatch2 = 20&gt;&gt;
-&lt;&lt;set $lionwatch3 = 20&gt;&gt;
-&lt;&lt;set $lionwatch4 = 40&gt;&gt;
-&lt;&lt;set $lionwatch5 = 50&gt;&gt;
-&lt;&lt;set $lionwatch6 = 60&gt;&gt;
-&lt;&lt;set $lionwatch7 = 90&gt;&gt;
-&lt;&lt;set $lionwatchFinal = ($lionwatch1 + $lionwatch2 + $lionwatch3 + $lionwatch4+ $lionwatch5 + $lionwatch6 + $lionwatch7)&gt;&gt;
+v.lionwatch1 = 40;
+v.lionwatch2 = 20;
+v.lionwatch3 = 20;
+v.lionwatch4 = 40;
+v.lionwatch5 = 50;
+v.lionwatch6 = 60;
+v.lionwatch7 = 90;
+v.lionwatchFinal = v.lionwatch1 + v.lionwatch2 + v.lionwatch3 +
+  v.lionwatch4 + v.lionwatch5 + v.lionwatch6 + v.lionwatch7;
 
-&lt;&lt;set $interrogationEndingUnlock = false&gt;&gt;
-&lt;&lt;set $interrogationEndingShockUnlock = false&gt;&gt;
-&lt;&lt;set $interrogationEndingFreezeUnlock = false&gt;&gt;
-&lt;&lt;set $interrogationEndingMildUnlock = false&gt;&gt;
-&lt;&lt;set $interrogationEndingRoughUnlock = false&gt;&gt;
-&lt;&lt;set $interrogationEnding = false&gt;&gt;
-&lt;&lt;set $interrogationEndingShock = false&gt;&gt;
-&lt;&lt;set $interrogationEndingFreeze = false&gt;&gt;
-&lt;&lt;set $interrogationEndingMild = false&gt;&gt;
-&lt;&lt;set $interrogationEndingRough = false&gt;&gt;
+v.interrogationEndingUnlock = false;
+v.interrogationEndingShockUnlock = false;
+v.interrogationEndingFreezeUnlock = false;
+v.interrogationEndingMildUnlock = false;
+v.interrogationEndingRoughUnlock = false;
+v.interrogationEnding = false;
+v.interrogationEndingShock = false;
+v.interrogationEndingFreeze = false;
+v.interrogationEndingMild = false;
+v.interrogationEndingRough = false;
 
-&lt;&lt;set $enthrallmentEndingUnlock = false&gt;&gt;
-&lt;&lt;set $enthrallmentLionUnlock = false&gt;&gt;
-&lt;&lt;set $enthrallmentEnding = false&gt;&gt;
-&lt;&lt;set $enthrallmentLion = false&gt;&gt;
+v.enthrallmentEndingUnlock = false;
+v.enthrallmentLionUnlock = false;
+v.enthrallmentEnding = false;
+v.enthrallmentLion = false;
 
-&lt;&lt;set $extractionEndingUnlock = false&gt;&gt;
-&lt;&lt;set $extractionForcefulEndUnlock = false&gt;&gt;
-&lt;&lt;set $extractionGentleEndUnlock = false&gt;&gt;
-&lt;&lt;set $extractionEnding = false&gt;&gt;
-&lt;&lt;set $extractionForcefulEnd = false&gt;&gt;
-&lt;&lt;set $extractionGentleEnd = false&gt;&gt;
+v.extractionEndingUnlock = false;
+v.extractionForcefulEndUnlock = false;
+v.extractionGentleEndUnlock = false;
+v.extractionEnding = false;
+v.extractionForcefulEnd = false;
+v.extractionGentleEnd = false;
 
-&lt;&lt;set $enthralmentIvexEndingUnlock = false&gt;&gt;
-&lt;&lt;set $enthralmentIvexEnding = false&gt;&gt;
-&lt;&lt;set $extractionIvexEndingUnlock = false&gt;&gt;
-&lt;&lt;set $extractionIvexEnding = false&gt;&gt;
-&lt;&lt;set $personalEndingUnlock = false&gt;&gt;
-&lt;&lt;set $personalEnding = false&gt;&gt;
-
+v.enthralmentIvexEndingUnlock = false;
+v.enthralmentIvexEnding = false;
+v.extractionIvexEndingUnlock = false;
+v.extractionIvexEnding = false;
+v.personalEndingUnlock = false;
+v.personalEnding = false;
+&lt;&lt;/script&gt;&gt;\
+\
 &lt;&lt;nobr&gt;&gt;
+
 &lt;&lt;append &quot;#ui-bar-body&quot;&gt;&gt;
   &lt;div id=&quot;ui-bar-footer&quot;&gt;
     &lt;span&gt;
@@ -694,7 +743,7 @@ With a spring to his step, the panther approaches, closing in the last distance 
     &lt;/span&gt;
   &lt;/div&gt;
 &lt;&lt;/append&gt;&gt;
-&lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="15" name="Molesting" tags="" position="950,1000" size="100,100">&lt;&lt;print $name&gt;&gt; opens a warning growl, but even though the wolf tugs against the restraints of the cross he&#39;s bound to, there is nothing that can be done against the feeling of extreme vulnerability. The panther, the enemy, stands right there, well within the range of touch, and all the wolf can do is remain there with his limbs spread wide.
+&lt;&lt;/nobr&gt;&gt;\</tw-passagedata><tw-passagedata pid="15" name="Molesting" tags="" position="950,1000" size="100,100">&lt;&lt;print $name&gt;&gt; opens a warning growl, but even though the wolf tugs against the restraints of the cross he&#39;s bound to, there is nothing that can be done against the feeling of extreme vulnerability. The panther, the enemy, stands right there, well within the range of touch, and all the wolf can do is remain there with his limbs spread wide.
 
 &quot;Look at you, wolf. Such a powerful &lt;&lt;print $class&gt;&gt;...&quot; The panther licks his lips. His hand comes to the wolf&#39;s chest. His touch feels invasive as he places his hand upon &lt;&lt;print $name&gt;&gt;&#39;s broad pectorals and feels it up. All $name can do is snarl once more, but the wolf knows that his growling is nothing but a fake threat at that moment. There has to be a way to turn the tables on that damned mage, but how...?
 
@@ -771,7 +820,7 @@ The panther approaches again.
 
 &lt;div class=&quot;action-box&quot;&gt;\
   &lt;ul class=&quot;actions&quot;&gt;\
-	&lt;li&gt;[[&quot;Whatever you&#39;re trying to do, it won&#39;t work!&quot; Keep holding your breath in defiance.|Hold Breath Defiantly]]&lt;/li&gt;
+    &lt;li&gt;[[&quot;Whatever you&#39;re trying to do, it won&#39;t work!&quot; Keep holding his breath in defiance.|Hold Breath Defiantly]]&lt;/li&gt;
     &lt;li&gt;[[He has a point. Breathe out and at least give him a warning growl.|Growl Defiantly]]&lt;/li&gt;
   &lt;/ul&gt;\
 &lt;/div&gt;</tw-passagedata><tw-passagedata pid="18" name="Hold Breath Defiantly" tags="" position="1325,1000" size="100,100">$name keeps holding his breath, but it becomes harder to do so as Ivex steps towards him again. The feeling of vulnerability towards the panther grows tenfold when he is within the range of touch. Bound to the cross in a spread position, holding his breath and now completely naked, it feels even worse than before.
@@ -2222,28 +2271,31 @@ To change the adventurer&#39;s fate, you can...
       &lt;li&gt;[[Return to the beginning of the game.|Title Screen]]&lt;/li&gt;
   &lt;/ul&gt;\
 &lt;/div&gt;</tw-passagedata><tw-passagedata pid="85" name="Archives" tags="noreturn" position="2400,700" size="100,100">&lt;&lt;link &quot;Return to the game&quot; $return&gt;&gt;&lt;&lt;/link&gt;&gt;\
-
-&lt;h1&gt;Archives&lt;/h1&gt;
+\
+&lt;h1&gt;Archives&lt;/h1&gt;\
 Welcome to the Mage&#39;s Tower Archives.
+
 Here you can revisit the different endings the adventurer has met in his time in the Mage&#39;s Tower. When the adventurer goes through an ending in the game for the first time, it will be unlocked here to be revisited at any time. If an ending has different variations due to the adventurer&#39;s choices during the game, these also can be set here, provided they have been seen before.
 
 Grayed out endings are paths that have not yet been found, although there are hints under them as to what path the adventurer should take to reach them. The same applies to different variations of endings.
 
 &lt;i&gt;Unlocked endings are only kept within a save. To keep all unlocked endings, make sure to always use and load the same save file.&lt;/i&gt;
+\
+&lt;hr&gt;\
+&lt;h2&gt;Endings unlocked:&lt;/h2&gt;\
+&lt;&lt;include [[Interrogation Archive Display]]&gt;&gt;\
+\
+&lt;&lt;include [[Enthrallment Archive Display]]&gt;&gt;\
+\
+&lt;&lt;include [[Extraction Archive Display]]&gt;&gt;\
+\
+&lt;&lt;include [[Ivex Punishment Archive Display]]&gt;&gt;\
+\
+&lt;&lt;include [[Ivex Enthrallment Archive Display]]&gt;&gt;\
+\
+&lt;&lt;include [[Ivex Extraction Archive Display]]&gt;&gt;\
 
-&lt;hr&gt;
-&lt;h2&gt;Endings unlocked:&lt;/h2&gt;
-&lt;&lt;include [[Interrogation Archive Display]]&gt;&gt;
-
-&lt;&lt;include [[Enthrallment Archive Display]]&gt;&gt;
-
-&lt;&lt;include [[Extraction Archive Display]]&gt;&gt;
-
-&lt;&lt;include [[Ivex Punishment Archive Display]]&gt;&gt;
-
-&lt;&lt;include [[Ivex Enthrallment Archive Display]]&gt;&gt;
-
-&lt;&lt;include [[Ivex Extraction Archive Display]]&gt;&gt;</tw-passagedata><tw-passagedata pid="86" name="The Desk" tags="" position="900,4350" size="100,100">&lt;&lt;if $theDesk&gt;&gt;\
+&lt;&lt;link &quot;Return to the game&quot; $return&gt;&gt;&lt;&lt;/link&gt;&gt;\</tw-passagedata><tw-passagedata pid="86" name="The Desk" tags="" position="900,4350" size="100,100">&lt;&lt;if $theDesk&gt;&gt;\
 The only interesting things the wolf can see on the desk are the &lt;span class=&quot;imp-info&quot;&gt;thick book&lt;/span&gt; and the &lt;span class=&quot;imp-info&quot;&gt;journal&lt;/span&gt;.
 &lt;&lt;else&gt;&gt;\
 &lt;&lt;set $theDesk = true&gt;&gt;\
@@ -2472,7 +2524,7 @@ Its arousing scent lingers for a few more moments, but soon enough the wolf&#39;
 
 Still panting, $name finally stops struggling and lets himself relax against his bonds for a moment. He realizes how sore all of his muscles are from the continuous desperate effort. Everything aches. Even as his mind clears up to some extent, however, the burning fire of arousal within him doesn&#39;t subside. It merely stops growing. His cock still remains fully hard, knot engorged and everything, and just looking at it makes his heart race with an urge to touch it.
 
-At least the wolf has enough awareness back to know he won&#39;t be able, to while bound as he is. And to worry about the panther standing in front of him.
+At least the wolf has enough awareness back to know he won&#39;t be able to, while bound as he is. And to worry about the panther standing in front of him.
 
 Ivex pulls the cloth covering his nose down as well to reveal his large grin.
 
@@ -2512,9 +2564,9 @@ The mage finally takes hold of the wolf&#39;s exposed cock with a paw. The feeli
 
 It gets even worse when Ivex starts massaging it ever so lightly with his fingers. The pleasure contrasts with the pain of his balls being so mercilessly pulled by the crystal&#39;s weight.
 
-&quot;I know the adventurer&#39;s guild sent you. What do they have on me?&quot;
+&quot;I know the Wayward Adventurers Guild sent you. What do they have on me?&quot;
 
-A vague question. The wolf&#39;s knowledge is limited, but any details he tells Ivex could put the Adventurer&#39;s guild or whoever else they send after Ivex in the same danger he is facing. Betraying his comrades is something the wolf would never do, and just the fact that Ivex believes he would is an offense in itself.</tw-passagedata><tw-passagedata pid="109" name="Hard Way (Text)" tags="text" position="1375,2200" size="100,100">&quot;Aahh... still so full of fire, aren&#39;t you? Even knowing how small you are next to me?&quot; Ivex says with his usual lingering smile of amusement. &quot;I suppose it&#39;s only fair. I haven&#39;t even begun to show you what I can do to you.&quot;
+A vague question. The wolf&#39;s knowledge is limited, but any details he tells Ivex could put Guild or whoever else they send after Ivex in the same danger he is facing. Betraying his comrades is something the wolf would never do, and just the fact that Ivex believes he would is an offense in itself.</tw-passagedata><tw-passagedata pid="109" name="Hard Way (Text)" tags="text" position="1375,2200" size="100,100">&quot;Aahh... still so full of fire, aren&#39;t you? Even knowing how small you are next to me?&quot; Ivex says with his usual lingering smile of amusement. &quot;I suppose it&#39;s only fair. I haven&#39;t even begun to show you what I can do to you.&quot;
 
 &lt;&lt;print $name&gt;&gt;&#39;s growling continues. &quot;You wouldn&#39;t stand a fucking chance against a warrior like me if it weren&#39;t for your magic tricks!&quot;
 
@@ -2534,9 +2586,9 @@ The mage grabs the wolf&#39;s exposed cock with a paw. The feeling around it alo
 
 It gets even worse when Ivex starts massaging it ever so lightly with his fingers. The pleasure is a terrible contrast to the pain of his balls being so mercifully pulled by the crystal&#39;s weight.
 
-&quot;I know the adventurer&#39;s guild sent you. What do they have on me?&quot;
+&quot;I know the Wayward Adventurers Guild sent you. What do they have on me?&quot;
 
-A vague question. The wolf&#39;s knowledge is limited, but any details he tells Ivex could put the Adventurer&#39;s guild or whoever else they send after Ivex in the same danger he is facing. Betraying his comrades is something the wolf would never do.</tw-passagedata><tw-passagedata pid="110" name="Resistance (Text)" tags="text" position="1525,2200" size="100,100">&quot;Not willing to tell me, hmm? A shame... such a shame...&quot; Ivex speaks with obviously fake disappointment. In fact, he smiles, the panther&#39;s tail swishing back and forth lazily as a sign of worrying satisfaction and amusement.
+A vague question. The wolf&#39;s knowledge is limited, but any details he tells Ivex could put the Guild or whoever else they send after Ivex in the same danger he is facing. Betraying his comrades is something the wolf would never do.</tw-passagedata><tw-passagedata pid="110" name="Resistance (Text)" tags="text" position="1525,2200" size="100,100">&quot;Not willing to tell me, hmm? A shame... such a shame...&quot; Ivex speaks with obviously fake disappointment. In fact, he smiles, the panther&#39;s tail swishing back and forth lazily as a sign of worrying satisfaction and amusement.
 
 $name decides to remain quiet. It is hard enough to endure the weight on his balls on one side and the urge to let out sounds of pleasure as Ivex&#39;s fingers still continue to tease his oversensitive cock. If only that cursed arousal would go away! Looking down at his member, hard as a rock and leaking, a small wave of shame comes over the wolf, but this is all the sick mage&#39;s doing, $name tells himself. Only his doing...
 
@@ -2858,7 +2910,7 @@ Everything about it is unnatural. Invasive! And the worst part? $name can tell t
 
 For some reason, that smell feels incredibly &lt;b&gt;arousing&lt;/b&gt;. If he could look at the lion by his side, he would. The wolf starts to understand why the lion was hard and dripping the whole time while working. He himself cannot help it. His cock throbs between his legs, unattended, but the arousal is there, coming from the herbs he&#39;s forced to grind. With how boring the work is, the lust surrounding his body is the only thing his mind can focus on. It feels like torture to feel it and be completely unable to even get close to tend to it. 
 
-No matter how much he tries, $name cannot find a way out. He&#39;s trapped there grinding herbs and getting aroused by it until who knows how long after that, Ivex himself opens the door.</tw-passagedata><tw-passagedata pid="124" name="Interrogation Archive Display" tags="noreturn" position="1700,1000" size="100,100">&lt;&lt;silently&gt;&gt;\
+No matter how much he tries, $name cannot find a way out. He&#39;s trapped there grinding herbs and getting aroused by it until who knows how long after that, Ivex himself opens the door.</tw-passagedata><tw-passagedata pid="124" name="Interrogation Archive Display" tags="noreturn" position="1700,1000" size="100,100">&lt;&lt;silently&gt;&gt;
   &lt;&lt;if $interrogationEndingFreeze &amp;&amp; $interrogationEndingShock&gt;&gt;
     &lt;&lt;set $interrogationSpell = &#39;freeze&#39;&gt;&gt;
   &lt;&lt;elseif $interrogationEndingFreeze &amp;&amp; !$interrogationEndingShock&gt;&gt;
@@ -3905,9 +3957,65 @@ It doesn&#39;t stop there, and neither does the slime. All the stimulation keeps
 
 &lt;span class=&quot;bad-ending&quot;&gt;Bad Ending: &lt;i&gt;Extraction&lt;/i&gt;&lt;/span&gt;
 
-[[Return to the Archives|Archives]]</tw-passagedata><tw-passagedata pid="169" name="Title Screen" tags="restart" position="2500,25" size="100,100">&lt;div class=&quot;title-screen&quot;&gt;\
-&lt;&lt;include [[Title Screen 1]]&gt;&gt;
-&lt;/div&gt;\</tw-passagedata><tw-passagedata pid="170" name="Tying up" tags="" position="1075,5450" size="100,100">Holding the unconscious panther up, he almost looks harmless. $name keeps growling, though. After all that time wandering around naked and erect, it doesn&#39;t bother the wolf as much anymore, but that thought alone is enough for the wolf&#39;s anger to feel bolstered. Who knows what the damned mage has done with his gear? With his trusty sword, even? Punishment of the same level should be inflicted upon him so that he can learn how it feels. But... what, exactly?
+[[Return to the Archives|Archives]]</tw-passagedata><tw-passagedata pid="169" name="Title Screen" tags="restart" position="2500,25" size="100,100">&lt;&lt;script&gt;&gt;
+    const v = variables();
+    if (v.personalEnding) {
+        v.characterDisplay = &#39;images/wolf.png&#39;;
+    } else {
+        v.characterDisplay = &#39;images/panther.png&#39;;
+    }
+    if (v.titleDelay1) {
+        // already seen title, speed it up.
+        v.titleDelay1 = &#39;0.1s&#39;;
+        v.titleDelay2 = &#39;1s&#39;;
+        v.titleDelay3 = &#39;0.2s&#39;;
+    } else {
+        v.titleDelay1 = &#39;1s&#39;;
+        v.titleDelay2 = &#39;2s&#39;;
+        v.titleDelay3 = &#39;3s&#39;;
+    }
+    if (v.passedContentWarning) {
+        // we&#39;re here without clearing data
+        v.startGameText = &#39;Try Again&#39;;
+    } else {
+        v.startGameText = &#39;New Game&#39;;
+    }
+&lt;&lt;/script&gt;&gt;\
+\
+&lt;div class=&quot;title-screen&quot;&gt;\
+&lt;div class=&quot;title-container&quot;&gt;\
+\
+&lt;&lt;timed $titleDelay1 t8n&gt;&gt;\
+&lt;img class=&quot;title-character&quot; @src=&quot;$characterDisplay&quot;&gt;\
+\
+&lt;&lt;next $titleDelay2&gt;&gt;\
+&lt;img class=&quot;title-logo&quot; src=&quot;images/logo_tr.png&quot;&gt;\
+\
+&lt;&lt;next $titleDelay3&gt;&gt;
+&lt;div class=&quot;title-options&quot;&gt;\
+\
+&lt;&lt;link $startGameText&gt;&gt;
+    &lt;&lt;if $passedContentWarning&gt;&gt;
+        &lt;&lt;goto [[Bound]]&gt;&gt;
+    &lt;&lt;else&gt;&gt;
+        &lt;&lt;script&gt;&gt;
+            Dialog.setup(&quot;Content Warning&quot;);
+            Dialog.wiki(&quot;&lt;&lt;include [[Content Warning]]&gt;&gt;&quot;);
+            Dialog.open();
+        &lt;&lt;/script&gt;&gt;
+    &lt;&lt;/if&gt;&gt;
+&lt;&lt;/link&gt;&gt;
+\
+&lt;&lt;link &#39;Load Game&#39;&gt;&gt;
+    &lt;&lt;run UI.saves()&gt;&gt;
+&lt;&lt;/link&gt;&gt;
+\
+[[Credits]]
+\
+&lt;/div&gt; &lt;!--title-options--&gt;\
+&lt;&lt;/timed&gt;&gt;\
+&lt;/div&gt; &lt;!--title-container--&gt;\
+&lt;/div&gt; &lt;!--title-screen--&gt;\</tw-passagedata><tw-passagedata pid="170" name="Tying up" tags="" position="1075,5450" size="100,100">Holding the unconscious panther up, he almost looks harmless. $name keeps growling, though. After all that time wandering around naked and erect, it doesn&#39;t bother the wolf as much anymore, but that thought alone is enough for the wolf&#39;s anger to feel bolstered. Who knows what the damned mage has done with his gear? With his trusty sword, even? Punishment of the same level should be inflicted upon him so that he can learn how it feels. But... what, exactly?
 
 Carelessly letting the panther fall down, $name looks around. Ivex&#39;s gems are scattered all over the floor. It is wise to gather them up and make sure he can&#39;t get ahold of them, but before anything, he has to make sure the mage is secure. Going around the house, $name quickly sees that he is in some kind of farmhouse. The tower was stored in the attic, but after going down a crude set of stairs, the windows reveal that there is nothing but fields and a poorly kept road surrounding it. Ivex keeps his hideout well-hidden. Luckily for the wolf, a farmhouse is well-equipped for many things, so he has no trouble finding a good bunch of thick rope in the main room, which he promptly takes upstairs to use.
 
@@ -3941,7 +4049,7 @@ One by one, the wolf picks up all the gemstones on the floor. There are too many
 
 $name shoves each and every one of them into the pouch until there are only four of them left on the ground. Growing enthusiastic, the wolf grabs a yellow-ish one. When he grips it around his paw, it glows, and what this one does...
 
-[[Continue|Chastity]]</tw-passagedata><tw-passagedata pid="173" name="Punishments" tags="" position="1425,5575" size="100,100">The wolf&#39;s hands curl into tight fists. He can barely control his growling, looking down at Ivex. Will getting locked up in some mage&#39;s containment chamber, or whatever else the guild decides to do to him, be enough to make him pay for what he&#39;s done? Of course not. They don&#39;t know half of what he&#39;s done, and even if he tells them, it won&#39;t have the same impact as seeing it.
+[[Continue|Chastity]]</tw-passagedata><tw-passagedata pid="173" name="Punishments" tags="" position="1425,5575" size="100,100">The wolf&#39;s hands curl into tight fists. He can barely control his growling, looking down at Ivex. Will getting locked up in some mage&#39;s containment chamber, or whatever else the Guild decides to do to him, be enough to make him pay for what he&#39;s done? Of course not. They don&#39;t know half of what he&#39;s done, and even if he tells them, it won&#39;t have the same impact as seeing it.
 
 With the sack of gemstones in hand, the wolf stomps over to the tied-up feline and lifts him up by the scruff. Ivex shifts and grunts in his sleep, but doesn&#39;t wake up quite yet.
 
@@ -4419,7 +4527,11 @@ After he&#39;s satisfied, Ivex&#39;s member is left shy and cold inside his shea
 &lt;&lt;if !$shockSpell&gt;&gt;\
 The panther catches a glimpse of which gemstone the wolf is pulling out and frowns.
 
+&lt;&lt;if !$gagged&gt;&gt;\
 &quot;You idiot! Be careful what you touch! You don&#39;t even know what you&#39;re doing!&quot; The panther hisses and wiggles trying to get away.
+&lt;&lt;else&gt;&gt;\
+&quot;Ymm mmfgh! Mm gmfmf hmmgff gmfhgh!&quot; The panther hisses and wiggles trying to get away.
+&lt;&lt;/if&gt;&gt;\
 
 The wolf&#39;s grip on Ivex simply tightens while he clutches the gemstone with the other hand. The cackle of lightning around his paw creates a tingle. A funny one. It definitely seems like it does more than just tingle when his paw touches something, though.
 
@@ -4797,7 +4909,7 @@ Wiping his hands, the wolf looks down at Ivex. Bound, gagged and without his gem
 
 $name steps towards him to pick him up. Ivex still squirms and complains, obviously still angry over having lost. He no longer gets a choice, though.
 
-The wolf does. He wonders if Ivex has had enough punishment or if he should add a finishing touch to his reckoning. After all, it will be a few days&#39; journey back to the adventurer&#39;s guild. Maybe adding something to... &lt;b&gt;entertain&lt;/b&gt; Ivex in the meantime would be fun as well.
+The wolf does. He wonders if Ivex has had enough punishment or if he should add a finishing touch to his reckoning. After all, it will be a few days&#39; journey back to the Wayward Adventurers Guild. Maybe adding something to... &lt;b&gt;entertain&lt;/b&gt; Ivex in the meantime would be fun as well.
 &lt;&lt;if !$personalEnding&gt;&gt;\
 &lt;&lt;set $personalEndingUnlock = true&gt;&gt;\
 &lt;&lt;/if&gt;&gt;\
@@ -4827,7 +4939,7 @@ Looking down, however, the wolf sees his member still aching. Surely Ivex&#39;s 
 
 Not to mention the rest of his time trudging naked through his tower with a permanent hard-on. The wolf has captured many bounties before, some of them mages, but none of them had taken so much effort and humiliation to defeat.
 
-Glancing at the mage, he wonders. If he wants to give Ivex some reckoning for all he has done to him and to others, it has to be now. Once he&#39;s in the hands of the adventurer&#39;s guild officers, then another kind of justice will be served to him.
+Glancing at the mage, he wonders. If he wants to give Ivex some reckoning for all he has done to him and to others, it has to be now. Once he&#39;s in the hands of the Wayward Adventurers Guild officers, then another kind of justice will be served to him.
 
 $name takes a deep breath. Should he really just take Ivex to be arrested and nothing more?
 
@@ -4860,11 +4972,11 @@ $name just smiles. He has something he can fuck on the way if he needs to.
 
 Gathering what supplies he can, the wolf sets off with everything in hand: Ivex&#39;s tower inside the large gemstone, the pouch of magic gems and, most importantly, Ivex.
 
-The journey back to the adventurer&#39;s guild takes a few days. It could go quicker, but after the deeply distressing effort to capture the mage, $name is not exactly in a hurry to get there anymore. The wolf takes his sweet time recovering from everything he went through inside the mage&#39;s crazy tower, and basking in his success.
+The journey back to the Wayward Adventurers Guild takes a few days. It could go quicker, but after the deeply distressing effort to capture the mage, $name is not exactly in a hurry to get there anymore. The wolf takes his sweet time recovering from everything he went through inside the mage&#39;s crazy tower, and basking in his success.
 
-When he gets to the guild, both the adventurers and officers there are deeply amused by the way $name delivers Ivex to them. After a thorough re-telling of what he went through and what he has in tow, the official mages in the adventurer&#39;s guild take Ivex to a prison where his magic will be kept in check.
+When he gets to the Guild, both the adventurers and officers there are deeply amused by the way $name delivers Ivex to them. After a thorough re-telling of what he went through and what he has in tow, the official mages in the Wayward Adventures Guild take Ivex to a prison where his magic will be kept in check.
 
-They also handle his tower. The wolf does not stick around to see it, but the rumors of the insane tower a mage possessed spread like wildfire. Apparently, the mages of the guild had to go through an arduous, delicate process to save the over fifty people Ivex had trapped inside his tower. All of them males.
+They also handle his tower. The wolf does not stick around to see it, but the rumors of the insane tower a mage possessed spread like wildfire. Apparently, the mages of the Guild had to go through an arduous, delicate process to save the over fifty people Ivex had trapped inside his tower. All of them males.
 
 With a handsome amount of gold in his pocket, the wolf moves on. The life of an adventurer is like that. Ivex wasn&#39;t the first mage he had to fight and it won&#39;t be the last. The events of the tower stick inside &lt;&lt;print $name&gt;&gt;&#39;s mind, though, and they are enough to make him blush every now and then. He will make sure that such things never happen again.
 
@@ -5080,7 +5192,7 @@ The enthralled panther finally stops licking himself to sit up straight. Then, p
 
 Standing up himself, $name looks down at the mage. With the wolf&#39;s seed running down the back of his thighs, he smirks.
 
-It&#39;s time to take Ivex back to the adventurer&#39;s guild. Watching the blank-faced mage and knowing he&#39;s trapped like that, however, the wolf gets to thinking...
+It&#39;s time to take Ivex back to the Wayward Adventurers Guild. Watching the blank-faced mage and knowing he&#39;s trapped like that, however, the wolf gets to thinking...
 
 What would it be like to have a thrall himself? Would a large bag of gold really be enough to make up for something like that? What if...?
 
@@ -5102,11 +5214,11 @@ $name packs everything. The sack of gemstones with Ivex&#39;s spells and the lar
 
 Ivex, with the pendant around his neck, is made to walk behind the wolf the whole way. Never before had delivering a bounty been so easy. True to his word, the wolf leaves the panther completely naked. There is no point in wasting gold buying clothes for someone that does not deserve them.
 
-The journey back to the adventurer&#39;s guild is a few days long and the wolf is not in a hurry to return. In fact, $name makes a point to include as many towns as he can on the way back and, each time, he takes immense pleasure in watching the stares of folk as they see the naked panther parading around the city. In one of them, the wolf went as far as ordering the panther to clutch a gemstone containing a lust spell so he was mewling and dripping the whole time as well.
+The journey back to the Wayward Adventurers Guild is a few days long and the wolf is not in a hurry to return. In fact, $name makes a point to include as many towns as he can on the way back and, each time, he takes immense pleasure in watching the stares of folk as they see the naked panther parading around the city. In one of them, the wolf went as far as ordering the panther to clutch a gemstone containing a lust spell so he was mewling and dripping the whole time as well.
 
-When they arrive back in the adventurer&#39;s guild, the wolf delivers Ivex&#39;s tower and his gemstones to the official mages, but claims that he could not capture Ivex himself. It fills him with pleasure to know that he, in fact, left the panther jerking himself off in the alley behind the building.
+When they arrive back in the Guild, the wolf delivers Ivex&#39;s tower and his gemstones to the official mages, but claims that he could not capture Ivex himself. It fills him with pleasure to know that he, in fact, left the panther jerking himself off in the alley behind the building.
 
-The mages handle his tower. The wolf does not stick around to see it, but the rumors of the insane tower a mage possessed spread like wildfire. Apparently, the mages of the guild had to go through an arduous, delicate process to save the over fifty people Ivex had trapped inside his tower. All of them males. It makes $name feel all the better for having such a previously dangerous and deranged mage at his disposal, ready to lick his feet if he feels like it. Literally.
+The mages handle his tower. The wolf does not stick around to see it, but the rumors of the insane tower a mage possessed spread like wildfire. Apparently, the mages of the Wayward Adventurers Guild had to go through an arduous, delicate process to save the over fifty people Ivex had trapped inside his tower. All of them males. It makes $name feel all the better for having such a previously dangerous and deranged mage at his disposal, ready to lick his feet if he feels like it. Literally.
 
 With a new &#39;companion&#39; by his side, the wolf moves on. The life of an adventurer is like that. Ivex wasn&#39;t the first mage he had to fight and it won&#39;t be the last. The events of the tower stick inside &lt;&lt;print $name&gt;&gt;&#39;s mind, though, and they are enough to make him blush every now and then, but whenever that happens, his new panther servant is there to alleviate his rage. He will make sure that such things never happen again.
 
@@ -5126,7 +5238,7 @@ It softens his impact. The wolf takes a step back, not sure what to expect. Much
 
 It is at that moment that Ivex&#39;s droopy eyes start to open. The blob continues to engulf him, moving the feline to its center. Ivex looks confused for a moment, but then... his eyes grow wide. They meet the wolf&#39;s, then dart all around him, and his expression shifts to one of rage... and panic.</tw-passagedata><tw-passagedata pid="223" name="Ivex Extraction 1 (Text)" tags="text" position="1775,5850" size="100,100">The panther&#39;s muzzle moves, but if he makes any sound, it doesn&#39;t make it past the thick, viscous substance of the blob. Ivex&#39;s bound arms and legs move for a moment, but as soon as they start, they immediately slow down, and the wolf can see that the thing is hardening around them to keep the panther still. Frozen in place, Ivex&#39;s eyes dart back and forth until they meet the wolf&#39;s. $name can see him frown, his expression shifting to one of anger, but his face too freezes inside the thing. Whatever this blob is, it doesn&#39;t seem keen on letting the feline move. Good. It works even better than the wolf expected.
 
-$name wipes his paws and smiles triumphantly. Seeing Ivex trapped inside his own device is extremely pleasant. For a few moments, he watches the feline as he clearly struggles to move. His small muscles contract here or there, showing he&#39;s trying to put effort into moving his limbs, but none of it amounts to anything. What a weakling! After a while, it is clear that the feline is trapped and cannot get out. The wolf is ready to leave him there, for in fact, he doesn&#39;t even know how he would go about getting Ivex out of it. The mages in the adventurer&#39;s guild will surely figure something out when he delivers the panther and his tower to them in a few days. Taking a step back, the wolf is about to leave, but then something else catches his eye.
+$name wipes his paws and smiles triumphantly. Seeing Ivex trapped inside his own device is extremely pleasant. For a few moments, he watches the feline as he clearly struggles to move. His small muscles contract here or there, showing he&#39;s trying to put effort into moving his limbs, but none of it amounts to anything. What a weakling! After a while, it is clear that the feline is trapped and cannot get out. The wolf is ready to leave him there, for in fact, he doesn&#39;t even know how he would go about getting Ivex out of it. The mages in the Wayward Adventurers Guild will surely figure something out when he delivers the panther and his tower to them in a few days. Taking a step back, the wolf is about to leave, but then something else catches his eye.
 
 Ivex seems to start growing more frantic in his entrapment. As the wolf&#39;s eyes go over the feline, he can see why. Little by little, the blob seems to &lt;b&gt;dissolve&lt;/b&gt; Ivex&#39;s clothing. It moves around the panther as a whole, its surface full of ripples as it does its work while keeping the mage still at the same time. Ivex&#39;s robes start tearing, then little by little, holes start appearing in the fabric and these grow wider and wider, expanding until, soon enough, there is nothing left. The wolf smirks. The panther is left not only trapped but also &lt;b&gt;naked&lt;/b&gt;. The rope that bound him dissolve as well, which worries the wolf for a moment, but the panther can&#39;t even manage to move them out of the position they were while bound inside the slime.
 
@@ -5202,13 +5314,13 @@ Lucky for the wolf, he manages to find a worn, old pair of pants in the farmhous
 
 Gathering what supplies he can, the wolf sets off with everything in hand: Ivex&#39;s tower inside the large gemstone, the pouch of magic gemstones and, most importantly, Ivex.
 
-The journey back to the adventurer&#39;s guild takes a few days. It could go quicker, but after the deeply distressing effort to capture the mage, $name is not exactly in a hurry to get there anymore. The wolf takes his sweet time recovering from everything he went through inside the mage&#39;s crazy tower, and basking in his success.
+The journey back to the Wayward Adventurers Guild takes a few days. It could go quicker, but after the deeply distressing effort to capture the mage, $name is not exactly in a hurry to get there anymore. The wolf takes his sweet time recovering from everything he went through inside the mage&#39;s crazy tower, and basking in his success.
 
 A few times during his journey he goes back in to check on Ivex. Every time he does, the panther&#39;s eyes dart to him, but they are glazed. He&#39;s lost in an infinite loop of pleasure. Pleasure he can&#39;t have. The blob always looks like it&#39;s working its hardest to stimulate the panther, but with the chastity spell still on him, all he can provide is pre-cum as his cock always strains to grow hard, but can&#39;t. Other than his pleasurable torment, Ivex seems fine. Whatever magics he has going on in this system with the blob-things, it seems to be made to sustain who is inside and keep them well and healthy.
 
-When the wolf gets back to the guild, he gives them a thorough re-telling of what he went through and what he has in tow, the official mages in the adventurer&#39;s guild take a while to extract Ivex himself from his own torment, but from there, they throw him straight into a prison where his magic will be kept in check.
+When the wolf gets back to the Guild, he gives them a thorough re-telling of what he went through and what he has in tow, the official mages in the Wayward Adventurers Guild take a while to extract Ivex himself from his own torment, but from there, they throw him straight into a prison where his magic will be kept in check.
 
-They also handle his tower as a whole. The wolf does not stick around to see it, but the rumors of the insane tower a mage possessed spread like wildfire. Apparently, the mages of the guild had to go through an arduous, delicate process to save the over fifty people Ivex had trapped inside his tower in the same way he was trapped. All of them males, and all of them kept there to provide energy for the tower&#39;s existence with their seed inside these things that would perpetually extract it from them while, at the same time, stimulating their bodies to produce more. A truly twisted device.
+They also handle his tower as a whole. The wolf does not stick around to see it, but the rumors of the insane tower a mage possessed spread like wildfire. Apparently, the mages of the Guild had to go through an arduous, delicate process to save the over fifty people Ivex had trapped inside his tower in the same way he was trapped. All of them males, and all of them kept there to provide energy for the tower&#39;s existence with their seed inside these things that would perpetually extract it from them while, at the same time, stimulating their bodies to produce more. A truly twisted device.
 
 With a handsome amount of gold in his hands, the wolf moves on. The life of an adventurer is like that. Ivex wasn&#39;t the first mage he had to fight and it won&#39;t be the last. The events of the tower stick inside &lt;&lt;print $name&gt;&gt;&#39;s mind, though, and they are enough to make him blush every now and then. He will make sure that such things never happen again.
 
@@ -5605,7 +5717,7 @@ Wiping his hands, the wolf looks down at Ivex. Bound, gagged and without his gem
 
 $name steps towards him to pick him up. Ivex still squirms and complains, obviously still angry over having lost. He no longer gets a choice, though.
 
-The wolf does. He wonders if Ivex has had enough punishment or if he should add a finishing touch to his reckoning. After all, it will be a few days&#39; journey back to the adventurer&#39;s guild. Maybe adding something to... &lt;b&gt;entertain&lt;/b&gt; Ivex in the meantime would be fun as well.
+The wolf does. He wonders if Ivex has had enough punishment or if he should add a finishing touch to his reckoning. After all, it will be a few days&#39; journey back to the Wayward Adventurers Guild. Maybe adding something to... &lt;b&gt;entertain&lt;/b&gt; Ivex in the meantime would be fun as well.
 
 Yeah... Ivex has certainly done enough to deserve an extra.
 
@@ -5633,11 +5745,11 @@ Lucky for the wolf, he manages to find a worn, old pair of pants in the farmhous
 
 Gathering what supplies he can, the wolf sets off with everything in hand: Ivex&#39;s tower inside the large gemstone, the pouch of magic gems and, most importantly, Ivex.
 
-The journey back to the adventurer&#39;s guild takes a few days. It could go quicker, but after the deeply distressing effort to capture the mage, $name is not exactly in a hurry to get there anymore. The wolf takes his sweet time recovering from everything he went through inside the mage&#39;s crazy tower, and basking in his success.
+The journey back to the Wayward Adventurers Guild takes a few days. It could go quicker, but after the deeply distressing effort to capture the mage, $name is not exactly in a hurry to get there anymore. The wolf takes his sweet time recovering from everything he went through inside the mage&#39;s crazy tower, and basking in his success.
 
-When he gets to the guild, both the adventurers and officers there are deeply amused by the way $name delivers Ivex to them. After a thorough re-telling of what he went through and what he has in tow, the official mages in the adventurer&#39;s guild take Ivex to a prison where his magic will be kept in check.
+When he gets to the Guild, both the adventurers and officers there are deeply amused by the way $name delivers Ivex to them. After a thorough re-telling of what he went through and what he has in tow, the official mages in the Wayward Adventurers Guild take Ivex to a prison where his magic will be kept in check.
 
-They also handle his tower. The wolf does not stick around to see it, but the rumors of the insane tower a mage possessed spread like wildfire. Apparently, the mages of the guild had to go through an arduous, delicate process to save the over fifty people Ivex had trapped inside his tower. All of them males.
+They also handle his tower. The wolf does not stick around to see it, but the rumors of the insane tower a mage possessed spread like wildfire. Apparently, the mages of the Guild had to go through an arduous, delicate process to save the over fifty people Ivex had trapped inside his tower. All of them males.
 
 With a handsome amount of gold in his pocket, the wolf moves on. The life of an adventurer is like that. Ivex wasn&#39;t the first mage he had to fight and it won&#39;t be the last. The events of the tower stick inside &lt;&lt;print $name&gt;&gt;&#39;s mind, though, and they are enough to make him blush every now and then. He will make sure that such things never happen again.
 
@@ -5646,7 +5758,8 @@ Or, at least, he will try to.
 &lt;span class=&quot;good-ending&quot;&gt;Ending: &lt;i&gt;Punishment&lt;/i&gt;&lt;/span&gt;
 
 [[Return to the Archives|Archives]]</tw-passagedata><tw-passagedata pid="235" name="Credits" tags="noreturn" position="2600,700" size="100,100">&lt;&lt;link &quot;Return to the game&quot; $return&gt;&gt;&lt;&lt;/link&gt;&gt;\
-
+\
+&lt;h1&gt;Credits&lt;/h1&gt;\
 The writing and development of this interactive story was made by me, [[Sleth|http://www.slethstories.com/]].
 
 The amazing artwork you see in the game, including the character art and the Mage&#39;s Tower logo, was done by commission by [[BlainWolf|https://twitter.com/Blain_Wolf]]. You can check out more of his stuff in his [[Twitter|https://twitter.com/Blain_Wolf]] or [[FurAffinity|https://www.furaffinity.net/user/blainwolf]] pages!
@@ -5656,7 +5769,7 @@ I&#39;d also like to give a special, personal thanks to [[Raus|https://twitter.c
 Not only that, but I&#39;d also like to extend my deepest gratitude to my patrons, who have been supporting me and my craft through the months it took to develop this interactive story! None of this would be possible without you all!
 
 First and foremost, my patrons that have supported me in these last 4 months it took for me to develop, learn and finish this project:
-
+\
 &lt;b&gt;&lt;ul&gt;\
     &lt;li&gt;John Harris&lt;/li&gt;
     &lt;li&gt;Timba Saber&lt;/li&gt;
@@ -5702,9 +5815,9 @@ First and foremost, my patrons that have supported me in these last 4 months it 
     &lt;li&gt;Knight of the Dragon&lt;/li&gt;
     &lt;li&gt;Raus&lt;/li&gt;
 &lt;/ul&gt;&lt;/b&gt;\
-
+\
 And, of course, also an honorable mention to everyone that has supported me and my writing in the these last years I have had my patreon going:
-
+\
 &lt;ul&gt;\
 &lt;li&gt;John Harris&lt;/li&gt;
 &lt;li&gt;Timba Saber&lt;/li&gt;
@@ -5774,33 +5887,28 @@ And, of course, also an honorable mention to everyone that has supported me and 
 &lt;li&gt;Martin Farley&lt;/li&gt;
 &lt;li&gt;Raus&lt;/li&gt;
 &lt;/ul&gt;\
+\
+Thank you so much!
 
-Thank you so much!</tw-passagedata><tw-passagedata pid="236" name="Title Screen 1" tags="" position="2625,25" size="100,100">&lt;&lt;silently&gt;&gt;
-&lt;&lt;if $personalEnding&gt;&gt;
-&lt;&lt;set $characterDisplay = &quot;images/wolf.png&quot;&gt;&gt;
-&lt;&lt;else&gt;&gt;
-&lt;&lt;set $characterDisplay = &quot;images/panther.png&quot;&gt;&gt;
-&lt;&lt;/if&gt;&gt;
-&lt;&lt;/silently&gt;&gt;
-&lt;div class=&quot;title-container&quot;&gt;
-&lt;&lt;timed 1s t8n&gt;&gt;\
-&lt;img class=&quot;title-character&quot; @src=&quot;$characterDisplay&quot;&gt;\
-&lt;&lt;next 2s&gt;&gt;\
-&lt;img class=&quot;title-logo&quot; src=&quot;images/logo_tr.png&quot;&gt;\
-&lt;&lt;next 3s&gt;&gt;
-&lt;div class=&quot;title-options&quot;&gt;\
-&lt;&lt;link &quot;New Game&quot;&gt;&gt;
-  &lt;&lt;script&gt;&gt;
-    // [[Bound]]
-    Dialog.setup(&quot;Content Warning&quot;);
-	  Dialog.wiki(&quot;This interactive story contains content of an adult nature. If you are easily offended or are under the age of 18, please exit now.&lt;br/&gt;&lt;br/&gt; Moreover, this story contains elements that depict dubious or lack of consent, as well as other fetish sexual topics such as mind control, CBT, chastity, and others. If these themes make you uncomfortable or are not enjoyable for you, proceed only at your own discretion.&lt;br/&gt;&lt;br/&gt;&lt;span style= &#39;float: right;&#39;&gt;&lt;&lt;&quot;+&quot;button Proceed&gt;&gt;&lt;&lt;&quot;+&quot;goto &#39;Bound&#39;&gt;&gt;&lt;&lt;&quot;+&quot;script&gt;&gt;Dialog.close();&lt;&lt;&quot;+&quot;/script&gt;&gt;&lt;&lt;&quot;+&quot;/button&gt;&gt;&lt;/span&gt;&quot;);
-    Dialog.open();
-  &lt;&lt;/script&gt;&gt;
-&lt;&lt;/link&gt;&gt;
-&lt;&lt;link &#39;Load Game&#39;&gt;&gt;&lt;&lt;script&gt;&gt;UI.saves()&lt;&lt;/script&gt;&gt;&lt;&lt;/link&gt;&gt;
-[[Credits]]
-&lt;/div&gt;\
-&lt;&lt;/timed&gt;&gt;
+&lt;&lt;link &quot;Return to the game&quot; $return&gt;&gt;&lt;&lt;/link&gt;&gt;</tw-passagedata><tw-passagedata pid="236" name="Choose Character" tags="" position="2500,325" size="100,100">&lt;i&gt;Choose Your Adventurer&lt;/i&gt;\
+
+&lt;dl&gt;
+&lt;dt&gt;Drekkar&lt;/dt&gt;
+&lt;dd&gt;A seasoned fighter, a large wolf that takes pride in his strength. He goes by the name of Drekkar, with his older name being more complex and difficult to pronounce. Hailing from the less advanced wolven tribes from the north, Drekkar left his kind early and adapted well to the wider world. He&#39;s known among his friends at the Wayward Adventurers Guild as &quot;that crazy bastard who took down the Mad Wizard of Carcenvellathrop by punching him in the face&quot;. With a sword in hand, there&#39;s little Drekkar cannot accomplish. Now, however...
+
+&lt;/dd&gt;
+
+&lt;dt&gt;Nero&lt;/dt&gt;
+&lt;dd&gt;A slender wolf, and unusually handsome for a mage. But he&#39;s always valued his mind more than his body. Nero is an unacknowledged son of one of Lady Garloch&#39;s nephews (or so he says). He&#39;s equally at ease covering for absent professors at the prestigious Windbone Magic Academy as he is when singing with drunken sailors at a Seaside tavern. His talent for magic has turned out to be very useful in his career of discreetly handling difficult problems for patrons who have way more money than sense. But this time...
+&lt;/dd&gt;&lt;/dl&gt;\</tw-passagedata><tw-passagedata pid="237" name="Content Warning" tags="" position="2625,75" size="100,100">This interactive story contains content of an adult nature. If you are easily offended or are under the age of 18, please exit now.
+
+Moreover, this story contains elements that depict dubious or lack of consent, as well as other fetish sexual topics such as mind control, CBT, chastity, and others. If these themes make you uncomfortable or are not enjoyable for you, proceed only at your own discretion.
+
+&lt;div style=&#39;float: right;&#39;&gt;\
+&lt;&lt;button Proceed&gt;&gt;
+    &lt;&lt;run Dialog.close()&gt;&gt;
+    &lt;&lt;goto [[Bound]]&gt;&gt;
+&lt;&lt;/button&gt;&gt;\
 &lt;/div&gt;</tw-passagedata></tw-storydata>
 	<script id="script-sugarcube" type="text/javascript">
 	/*! SugarCube JS */

--- a/index.html
+++ b/index.html
@@ -520,7 +520,7 @@ macros.arousalbar = {
         new Wikifier(place, "<div id=\"horizontalhealthbarbkg\" class=\"hzbarbkg\"><div id=\"horizontalhealthbar\" class=\"hzbar\"></div></div>");
     }
 }
-/* Arousal Bar Macro - End */</script><tw-tag name="done" color="purple"></tw-tag><tw-tag name="has-hole" color="yellow"></tw-tag><tw-tag name="init" color="blue"></tw-tag><tw-tag name="key" color="orange"></tw-tag><tw-tag name="maybe-password" color="blue"></tw-tag><tw-tag name="restart" color="green"></tw-tag><tw-tag name="end" color="red"></tw-tag><tw-tag name="incomplete" color="red"></tw-tag><tw-tag name="must-fix" color="orange"></tw-tag><tw-tag name="noreturn" color="yellow"></tw-tag><tw-tag name="text" color="blue"></tw-tag><tw-passagedata pid="1" name="Bound" tags="" position="2500,175" size="100,100">&lt;&lt;set $passedContentWarning = true&gt;&gt;\
+/* Arousal Bar Macro - End */</script><tw-tag name="restart" color="green"></tw-tag><tw-tag name="text" color="blue"></tw-tag><tw-tag name="has-hole" color="yellow"></tw-tag><tw-tag name="incomplete" color="red"></tw-tag><tw-tag name="init" color="blue"></tw-tag><tw-tag name="must-fix" color="orange"></tw-tag><tw-tag name="noreturn" color="yellow"></tw-tag><tw-tag name="done" color="purple"></tw-tag><tw-tag name="end" color="red"></tw-tag><tw-tag name="key" color="orange"></tw-tag><tw-tag name="maybe-password" color="blue"></tw-tag><tw-passagedata pid="1" name="Bound" tags="" position="2500,175" size="100,100">&lt;&lt;set $passedContentWarning = true&gt;&gt;\
 The sound of snapping fingers feels distant at first. As consciousness returns, it grows closer and closer until it starts becoming loud.
 
 The snapping comes from right beside his ear. The adventurer frowns, but consciousness has not returned in its entirety just yet. He feels as if... as if he had fallen down a well. At least that&#39;s all he can remember, sort of. It was bright, it was sudden, and now...
@@ -531,7 +531,7 @@ The bound wolf only lets out a pained groan at first. Everything hurts. Slowly b
 
 [[Continue|Drekkar Start]]</tw-passagedata><tw-passagedata pid="2" name="StoryAuthor" tags="" position="1825,150" size="100,100">by &lt;a href=&quot;http://www.slethstories.com/&quot; target=&quot;_blank&quot;&gt;Sleth&lt;/a&gt;\
 &lt;div id=&quot;story-version&quot;&gt;
-  v1.2002910.0
+  v1.20220910.0
 &lt;/div&gt;</tw-passagedata><tw-passagedata pid="3" name="StoryBanner" tags="" position="2075,150" size="100,100">&lt;img src=&quot;images/logo_tr.png&quot; width=&quot;220&quot;&gt;\
 &lt;div class=&quot;divider div-transparent div-arrow-down&quot;&gt;&lt;/div&gt;</tw-passagedata><tw-passagedata pid="4" name="StoryDisplayTitle" tags="" position="1950,150" size="100,100">The Mage&#39;s Tower</tw-passagedata><tw-passagedata pid="5" name="StoryMenu" tags="" position="2500,500" size="100,100">[[Archives]]
 [[Credits]]

--- a/story.tw
+++ b/story.tw
@@ -471,7 +471,7 @@ The bound wolf only lets out a pained groan at first. Everything hurts. Slowly b
 :: StoryAuthor {"position":"1825,150","size":"100,100"}
 by <a href="http://www.slethstories.com/" target="_blank">Sleth</a>\
 <div id="story-version">
-  v1.2002910.0
+  v1.20220910.0
 </div>
 
 

--- a/story.tw
+++ b/story.tw
@@ -16,7 +16,7 @@ The Mage's Tower
 		"start": "green",
 		"text": "blue"
 	},
-	"zoom": 1
+	"zoom": 0.6
 }
 
 
@@ -263,28 +263,28 @@ ul.actions li {
 
 /* Horizontal Health Bar - Start */
 .hzbarbkg {  /* default class for all horizontal bar backgrounds */
-	position: relative;
-	height: 15px;
-	width: 50%;
-	background-color: #111;
-	background-image: linear-gradient(to right, rgba(68, 68, 68, 0.5), rgba(34, 34, 34, 0.5) 5px), linear-gradient(to bottom, rgba(68, 68, 68, 0.5), rgba(0, 0, 0, 0) 5px), linear-gradient(to left, rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0) 5px), linear-gradient(to top, rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0) 5px);
+    position: relative;
+    height: 15px;
+    width: 50%;
+    background-color: #111;
+    background-image: linear-gradient(to right, rgba(68, 68, 68, 0.5), rgba(34, 34, 34, 0.5) 5px), linear-gradient(to bottom, rgba(68, 68, 68, 0.5), rgba(0, 0, 0, 0) 5px), linear-gradient(to left, rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0) 5px), linear-gradient(to top, rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0) 5px);
     border-radius: 10px;
-	z-index: 10;
-	visibility: visible;
+    z-index: 10;
+    visibility: visible;
 }
 .hzbar {  /* default class for all horizontal bars */
-	position: absolute;
-	bottom: 0px;
-	left: 0px;
-	height: 15px;
+    position: absolute;
+    bottom: 0px;
+    left: 0px;
+    height: 15px;
     border-radius: 10px;
-	background-color: transparent;
-	background-image: linear-gradient(to left, rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0) 5px), linear-gradient(to top, rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0) 5px), linear-gradient(to right, rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0) 5px), linear-gradient(to bottom, rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0) 5px);
-	z-index: 20;
-	transition: width ease 1s, background-color ease 1s;
+    background-color: transparent;
+    background-image: linear-gradient(to left, rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0) 5px), linear-gradient(to top, rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0) 5px), linear-gradient(to right, rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0) 5px), linear-gradient(to bottom, rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0) 5px);
+    z-index: 20;
+    transition: width ease 1s, background-color ease 1s;
 }
 #horizontalhealthbar {  /* colors for specific fixed-color horizontal bars */
-	background-image: linear-gradient(to left, rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0) 5px), linear-gradient(to top, rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0) 5px), linear-gradient(to right, rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0) 5px), linear-gradient(to bottom, rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0) 5px), radial-gradient( circle at bottom right, #a1001e, #a1001e 60% );
+    background-image: linear-gradient(to left, rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0) 5px), linear-gradient(to top, rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0) 5px), linear-gradient(to right, rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0) 5px), linear-gradient(to bottom, rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0) 5px), radial-gradient( circle at bottom right, #a1001e, #a1001e 60% );
 }
 .pulsingbar {
   box-shadow: 0 0 0 0 rgba(0, 0, 0, 1);
@@ -293,20 +293,20 @@ ul.actions li {
 }
 
 @keyframes pulse {
-	0% {
-		transform: scale(1.05);
-		box-shadow: 0 0 0 0 rgba(0, 0, 0, 0.7);
-	}
+    0% {
+        transform: scale(1.05);
+        box-shadow: 0 0 0 0 rgba(0, 0, 0, 0.7);
+    }
 
-	70% {
-		transform: scale(1);
-		box-shadow: 0 0 0 10px rgba(0, 0, 0, 0);
-	}
+    70% {
+        transform: scale(1);
+        box-shadow: 0 0 0 10px rgba(0, 0, 0, 0);
+    }
 
-	100% {
-		transform: scale(1.05);
-		box-shadow: 0 0 0 0 rgba(0, 0, 0, 0);
-	}
+    100% {
+        transform: scale(1.05);
+        box-shadow: 0 0 0 0 rgba(0, 0, 0, 0);
+    }
 }
 /* Horizontal Health Bar - End */
 
@@ -376,44 +376,44 @@ $(document.head).append("<link rel='icon' href='images/mt_icon_tr.png'>");
 predisplay["Menu Return"] = function (taskName) {
 	if (! tags().contains("noreturn")) {
 		State.variables.return = passage();
-	}
+    }
 };
 
 /* Health Bar code - Start */
 window.Health = function (CurHP, MaxHP, BarID, Horizontal, Container) {
-	if (Container == undefined) {
-		console.log("Container undefined!!");
-		Container = document;
-	}
-	var HP = parseInt((CurHP / MaxHP) * 100).clamp(0, 100);
-	var BarElement = $(Container).find("#" + BarID);
-	if (Horizontal) {
-		BarElement.css({ width: HP + "%" });
-	} else {
-		BarElement.css({ height: HP + "%" });
-	}
-	//BarElement.attr("title", CurHP + "/" + MaxHP);
-	//$(Container).find("#" + BarID + "bkg").attr("title", CurHP + "/" + MaxHP + " HP");
+    if (Container == undefined) {
+        console.log("Container undefined!!");
+        Container = document;
+    }
+    var HP = parseInt((CurHP / MaxHP) * 100).clamp(0, 100);
+    var BarElement = $(Container).find("#" + BarID);
+    if (Horizontal) {
+        BarElement.css({ width: HP + "%" });
+    } else {
+        BarElement.css({ height: HP + "%" });
+    }
+    //BarElement.attr("title", CurHP + "/" + MaxHP);
+    //$(Container).find("#" + BarID + "bkg").attr("title", CurHP + "/" + MaxHP + " HP");
 };
 /* Health Bar code - End */
 
 /* Arousal Bar Macro - Start */
 macros.arousalbar = {
-	handler: function(place, macroName, params, parser) {
-		var CurArousal = params[0];
-		var MaxArousal = params[1];
-		
-		$(document).one(':passagerender', function (ev) {
-			Health(CurArousal, MaxArousal, "horizontalhealthbar", true, ev.content);
-		});
-		
-		new Wikifier(place, "<div id=\"horizontalhealthbarbkg\" class=\"hzbarbkg\"><div id=\"horizontalhealthbar\" class=\"hzbar\"></div></div>");
-	}
+    handler: function(place, macroName, params, parser) {
+        var CurArousal = params[0];
+        var MaxArousal = params[1];
+        
+        $(document).one(':passagerender', function (ev) {
+            Health(CurArousal, MaxArousal, "horizontalhealthbar", true, ev.content);
+        });
+        
+        new Wikifier(place, "<div id=\"horizontalhealthbarbkg\" class=\"hzbarbkg\"><div id=\"horizontalhealthbar\" class=\"hzbar\"></div></div>");
+    }
 }
 /* Arousal Bar Macro - End */
 
 
-:: Bound [start] {"position":"24,188","size":"100,100"}
+:: Bound {"position":"2500,175","size":"100,100"}
 The sound of snapping fingers feels distant at first. As consciousness returns, it grows closer and closer until it starts becoming loud.
 
 The snapping comes from right beside his ear. The adventurer frowns, but consciousness has not returned in its entirety just yet. He feels as if... as if he had fallen down a well. At least that's all he can remember, sort of. It was bright, it was sudden, and now...
@@ -425,25 +425,25 @@ The bound wolf only lets out a pained groan at first. Everything hurts. Slowly b
 [[Continue|Wolf Warrior Chosen]]
 
 
-:: StoryAuthor {"position":"24,8","size":"100,100"}
+:: StoryAuthor {"position":"1825,150","size":"100,100"}
 by <a href="http://www.slethstories.com/" target="_blank">Sleth</a>
 
 
-:: StoryBanner {"position":"248,8","size":"100,100"}
+:: StoryBanner {"position":"2075,150","size":"100,100"}
 <img src="images/logo_tr.png" width="220">\
 <div class="divider div-transparent div-arrow-down"></div>
 
 
-:: StoryDisplayTitle {"position":"137,8","size":"100,100"}
+:: StoryDisplayTitle {"position":"1950,150","size":"100,100"}
 The Mage's Tower
 
 
-:: StoryMenu {"position":"103,2545","size":"100,100"}
+:: StoryMenu {"position":"2500,500","size":"100,100"}
 [[Archives]]
 [[Credits]]
 
 
-:: Soft Awakening {"position":"543,221","size":"100,100"}
+:: Soft Awakening {"position":"900,625","size":"100,100"}
 <<set $warrior = true>>\
 It takes some effort, but the wolf opens his eyes. It takes a few seconds to regain their focus. At the same time, the stiffness of his body feels worse than ever. This nap was anything but comfortable.
 
@@ -467,7 +467,7 @@ He is also smirking triumphantly.
 [[Continue|Awakened]]
 
 
-:: Rough Awakening {"position":"543,331","size":"100,100"}
+:: Rough Awakening {"position":"1025,625","size":"100,100"}
 <<set $rough_awakening = true>>\
 \
 Sleeping is easier. The wolf groans, but goes limp again. The sweet embrace of darkness feels good. Maybe just for a little while longer...
@@ -497,7 +497,7 @@ He is also smirking triumphantly.
 [[Continue|Awakened]]
 
 
-:: Ivex Description {"position":"748,114","size":"100,100"}
+:: Ivex Description {"position":"750,825","size":"100,100"}
 As advertised, Ivex is a black panther.
 
 The wolf had never seen the mage outside of the drawings in his wanted poster, but on those he looked to be more on the slim side, as most magic users are. The mage that stands before the bound adventurer, however, is not slim at all. Though not extremely muscular, there are clear outlines of them on the visible parts of his arms and legs. His chest is broad, and the panther is remarkably tall for a feline.
@@ -509,7 +509,7 @@ Unlike most mages as well, Ivex doesn't wear robes, but rather regular clothing 
 [[Return|Awakened]]
 
 
-:: Office Description {"position":"626,112","size":"100,100"}
+:: Office Description {"position":"750,700","size":"100,100"}
 The mage's office does not look special in itself, but it is rather curious.
 
 The office is sleek and fancy with luxurious furniture. Strange objects adorn the cabinets here or there, but most of all the wolf can see bookcases filled with books about magic. At its center and off to the wolf's side, a large desk with the basics can be seen: parchment, ink, quill and stacks of papers and letters spread over the table.
@@ -521,7 +521,7 @@ Another curious aspect to the wolf is that, off to the side, he can see a window
 [[Return|Awakened]]
 
 
-:: Awakened {"position":"677,247","size":"100,100"}
+:: Awakened {"position":"950,750","size":"100,100"}
 "Finally awake," the panther continues, "most people put up more of a fight when they are foolish enough to hunt me."
 
 The wolf's eyes follow the panther, still having trouble focusing properly, but slowly the $class regains his proper sight. For the first time, the wolf is able to see that the cross he's bound to looks out of place in some kind of [[office|Office Description]].
@@ -551,36 +551,13 @@ The panther stares at the wolf expecting an answer.
 
 <div class="action-box">\
   <ul class="actions">\
-	<li>[['"You won\'t get anything out of me!"'|Refusal]]</li>
-	<li>[['"...If I tell you what you want to know, then what?"'|Consideration]]	  </li>
+    <li>[['"You won\'t get anything out of me!"'|Refusal]]</li>
+    <li>[['"...If I tell you what you want to know, then what?"'|Consideration]]	  </li>
   </ul>\
 </div>
 
 
-:: Choose your character {"position":"110,351","size":"100,100"}
-CHARACTER SELECTION
-
-[[Wolf Warrior|Wolf Warrior Character Sheet]]
-[[Wolf Mage|Wolf Mage Character Sheet]]
-
-
-:: Wolf Warrior Character Sheet [incomplete] {"position":"249,276","size":"100,100"}
-(wolf warrior character sheet display)
-
-
-[[Return to character selection|Choose your character]]
-[[Continue as Drekkar|Wolf Warrior Chosen]]
-
-
-:: Wolf Mage Character Sheet [incomplete] {"position":"247,396","size":"100,100"}
-(wolf mage character sheet display)
-
-
-[[Return to character selection|Choose your character]]
-[[Continue as Nero|Wolf Mage Chosen]]
-
-
-:: Wolf Warrior Chosen {"position":"398,178","size":"100,100"}
+:: Wolf Warrior Chosen {"position":"950,500","size":"100,100"}
 <<set $name = "Drekkar">>\
 <<set $class = "warrior">>\
 <<set $warrior = true>>\
@@ -594,42 +571,25 @@ Drekkar's muscles, usually his most powerful weapon, ache. They feel stiff. An a
 
 <div class="action-box">\
   <ul class="actions">\
-	<li>[[Make an effort to wake up.|Soft Awakening]]</li>
-	<li>[[...Cling to the comfort of sleep.|Rough Awakening]]</li>
+    <li>[[Make an effort to wake up.|Soft Awakening]]</li>
+    <li>[[...Cling to the comfort of sleep.|Rough Awakening]]</li>
   </ul>\
 </div>
 
 
-:: Wolf Mage Chosen {"position":"398,300","size":"100,100"}
-<<set $name = "Nero">>\
-<<set $class = "mage">>\
-<<set $warrior = false>>\
-<<set $mage = true>>\
-<<set $rough_awakening = false>>\
-
-Nero's mind, usually his most powerful weapon, feels muddled. Thinking straight is a struggle, but little by little the wolf's thoughts start to reorganize themselves. Whatever he was under must have been either a very powerful anethesiac or a deep sleep spell of some kind. Although the symptoms of light vertigo also suggest some sort of teleportation...
-
-Thinking hurts. This is too much to try to reason in this state. Nero lets out another small groan...
-
-"Last chance, buddy. Wake up, or else..." the voice says again. The wolf can hear a mix of amusement and impatience in it...
-
-[[Make an effort to wake up|Soft Awakening]]
-[[Cling to the comfort of sleep|Rough Awakening]]
-
-
-:: Refusal {"position":"816,223","size":"100,100"}
+:: Refusal {"position":"900,875","size":"100,100"}
 Much to <<print $name>>'s delight, the reaction at least seems to wipe that smirk out of the panther's face for a second. Only for a second, though, as a different kind of smile opens up. A smile that makes the wolf's ears lower themselves even if just a little.
 
 "I was kind of hoping you would say that. I enjoy the brave types very much." The panther approaches, closing in the last distance between him and the wolf.
 
 <div class="action-box">\
   <ul class="actions">\
-	<li>[[Growl at Ivex.|Molesting]]</li>
+    <li>[[Growl at Ivex.|Molesting]]</li>
   </ul>\
 </div>
 
 
-:: Consideration {"position":"816,327","size":"100,100"}
+:: Consideration {"position":"1025,875","size":"100,100"}
 "Aahh... the good boy type," the panther muses. "I am ever so glad. Or am I? Perhaps we won't have too much trouble here after all."
 
 The panther took a step forward and opened a sinister smile. "Unfortunately, I regret to say that regardless of your collaboration, you won't be getting out of here. I have plans for you."
@@ -642,12 +602,12 @@ With a spring to his step, the panther approaches, closing in the last distance 
 
 <div class="action-box">\
   <ul class="actions">\
-	<li>[[Growl at Ivex.|Molesting]]</li>
+    <li>[[Growl at Ivex.|Molesting]]</li>
   </ul>\
 </div>
 
 
-:: StoryInit {"position":"363,9","size":"100,100"}
+:: StoryInit {"position":"2200,150","size":"100,100"}
 <<set $name = "Drekkar">>\
 <<set $class = "warrior">>\
 <<set $warrior = true>>\
@@ -707,20 +667,20 @@ With a spring to his step, the panther approaches, closing in the last distance 
 <<append "#ui-bar-body">>
   <div id="ui-bar-footer">
     <span>
-	  <a class="footer-element" target="_blank" href="https://www.patreon.com/sleth"><img alt="Patreon" src="images/pa_logo.png" height="30"></a>
+      <a class="footer-element" target="_blank" href="https://www.patreon.com/sleth"><img alt="Patreon" src="images/pa_logo.png" height="30"></a>
 
-	  <a class="footer-element" target="_blank" href="https://twitter.com/slethwulf"><img alt="Twitter" src="images/tw_logo.png" height="30"></a>
+      <a class="footer-element" target="_blank" href="https://twitter.com/slethwulf"><img alt="Twitter" src="images/tw_logo.png" height="30"></a>
 
-	  <a class="footer-element" target="_blank" href="https://www.furaffinity.net/user/sleth/"><img alt="FurAffinity" src="images/fa_logo.png" height="30"></a>
+      <a class="footer-element" target="_blank" href="https://www.furaffinity.net/user/sleth/"><img alt="FurAffinity" src="images/fa_logo.png" height="30"></a>
 
-	  <a class="footer-element" target="_blank" href="https://sleth.sofurry.com/"><img alt="SoFurry" src="images/sf_logo.png" height="30"></a>
-	</span>
+      <a class="footer-element" target="_blank" href="https://sleth.sofurry.com/"><img alt="SoFurry" src="images/sf_logo.png" height="30"></a>
+    </span>
   </div>
 <</append>>
 <</nobr>>
 
 
-:: Molesting {"position":"960,271","size":"100,100"}
+:: Molesting {"position":"950,1000","size":"100,100"}
 <<print $name>> opens a warning growl, but even though the wolf tugs against the restraints of the cross he's bound to, there is nothing that can be done against the feeling of extreme vulnerability. The panther, the enemy, stands right there, well within the range of touch, and all the wolf can do is remain there with his limbs spread wide.
 
 "Look at you, wolf. Such a powerful <<print $class>>..." The panther licks his lips. His hand comes to the wolf's chest. His touch feels invasive as he places his hand upon <<print $name>>'s broad pectorals and feels it up. All $name can do is snarl once more, but the wolf knows that his growling is nothing but a fake threat at that moment. There has to be a way to turn the tables on that damned mage, but how...?
@@ -754,7 +714,7 @@ And simply snaps his fingers.
 [[Continue|Naked]]
 
 
-:: Naked {"position":"1092,274","size":"100,100"}
+:: Naked {"position":"1075,1000","size":"100,100"}
 In an instant, all the wolf feels is... bare.
 
 With an urgent look, $name looks down and realizes that, just like that, without moving an inch from his bound state, he now stands there not only bound, but also completely and entirely <b>naked</b>.
@@ -780,7 +740,7 @@ The panther then turns away, thankfully, but to reach into one of the cabinets s
 [[Continue|Candle]]
 
 
-:: Candle {"position":"1074,421","size":"100,100"}
+:: Candle {"position":"1200,1000","size":"100,100"}
 <<set $FurtherDefiance = false>>\
 ...a candle.
 
@@ -807,12 +767,12 @@ The panther approaches again.
 <div class="action-box">\
   <ul class="actions">\
 	<li>[["Whatever you're trying to do, it won't work!" Keep holding your breath in defiance.|Hold Breath Defiantly]]</li>
-	<li>[[He has a point. Breathe out and at least give him a warning growl.|Growl Defiantly]]</li>
+    <li>[[He has a point. Breathe out and at least give him a warning growl.|Growl Defiantly]]</li>
   </ul>\
 </div>
 
 
-:: Hold Breath Defiantly {"position":"1067,555","size":"100,100"}
+:: Hold Breath Defiantly {"position":"1325,1000","size":"100,100"}
 $name keeps holding his breath, but it becomes harder to do so as Ivex steps towards him again. The feeling of vulnerability towards the panther grows tenfold when he is within the range of touch. Bound to the cross in a spread position, holding his breath and now completely naked, it feels even worse than before.
 
 "You really are something else," the panther chuckles, "thinking you can defy me. Most of them are regretting their actions and begging me to let them go at this point..."
@@ -843,15 +803,15 @@ Drekkar has years of training enduring pain, though. The thought of having his p
 
 <div class="action-box">\
   <ul class="actions">\
-  	<<if $rough_awakening == false || ($rough_awakening == true && $warrior == true)>>\
-	<li>[[Defy Ivex and keep holding his breath.|Further Defiance]]</li>
+      <<if $rough_awakening == false || ($rough_awakening == true && $warrior == true)>>\
+    <li>[[Defy Ivex and keep holding his breath.|Further Defiance]]</li>
 <</if>>\
-	<li>[[There is no choice. Breathe out and at least give him a warning growl.|Growl Defiantly]]</li>
+    <li>[[There is no choice. Breathe out and at least give him a warning growl.|Growl Defiantly]]</li>
   </ul>\
 </div>
 
 
-:: Growl Defiantly {"position":"927,480","size":"100,100"}
+:: Growl Defiantly {"position":"1325,1125","size":"100,100"}
 "You look cute when you growl. The last defiant adventurer I had was a lion. He couldn't growl like you, but he sure as hell could roar. Oh, how he roared when he was in your place breathing in what you're breathing..."
 
 Ivex lets out a small laugh. The candle continues to burn off to the side and the spicy smell seems stronger than before. <<print $name>>'s canine nose can detect even the subtleties of the smell and, indeed, it smells like nothing he has ever felt before.
@@ -877,7 +837,7 @@ The panther's words cease suddenly when Ivex turns his head back in a sudden mov
 [[Continue|Alarm]]
 
 
-:: Further Defiance {"position":"997,678","size":"100,100"}
+:: Further Defiance {"position":"1450,1000","size":"100,100"}
 The seconds go by and $name makes every effort to keep holding his breath. Eyes locked, the panther seems to take notice of the active defiance. It is with much satisfaction that the wolf can see his smile fading, even if just a little, in annoyance. The thought of irritating the cocky mage is enough to bring the bound wolf some pleasure in this terrible situation.
 
 Unfortunately, that pleasure soon becomes radiating, blinding pain. In a swift move, the panther's hand holding the wolf's balls closes in a tight grip. The wolf's sensitive nuts get squeezed inside the panther's relentless paw.
@@ -898,12 +858,12 @@ Ivex's hand returns to the wolf's thigh. The invasive touch makes the wolf grow 
 
 <div class="action-box">\
   <ul class="actions">\
-	<li>[[Give him a weak warning growl...|Growl Defiantly]]</li>
+    <li>[[Give him a weak warning growl...|Growl Defiantly]]</li>
   </ul>\
 </div>
 
 
-:: Alarm {"position":"795,503","size":"100,100"}
+:: Alarm {"position":"1325,1250","size":"100,100"}
 Thankfully, the panther then lets go of the wolf entirely. Before turning towards the door, $name can see that Ivex is frowning.
 
 "How unfortunate," the mage finally says. "An interruption. Right when things were about to get interesting! What a busy day..."
@@ -923,7 +883,7 @@ Then, poof. In the blink of an eye, the mage disappears, leaving $name alone. Bo
 [[Continue|Alone]]
 
 
-:: Alone {"position":"672,500","size":"100,100"}
+:: Alone {"position":"1200,1250","size":"100,100"}
 With the panther mage gone, all that remains is silence. The wolf finds himself alone in the office and bound at its center like some sort of depraved display. Looking down at himself, <<print $name>>'s ears fold back a little.
 
 Jutting from his sheath, his erection stands at full mast now. It even throbs in the air every now and then. The canine-shaped, tapered member practically glows in its bright red, veiny shape. Even the wolf's sheath starts to bulge a little as his knot threatens to start growing as well.
@@ -943,7 +903,7 @@ He had to find a way to escape. Ivex being gone gives him his best chance! But..
 [[Continue|The Candle]]
 
 
-:: The Candle {"position":"549,466","size":"100,100"}
+:: The Candle {"position":"1075,1250","size":"100,100"}
 Bound and alone in the room without Ivex's cocky blabbering as a distraction, $name can feel the effects of the candle more sharply.
 
 It burns there on the corner, innocently, yet the magically-enhanced scent that the candle produces, fills the air with, grows stronger by the minute. Every breath the wolf takes is filled with that strong scent. It heats up the canine's sensitive nose and, more than that, it heats up his very core.
@@ -965,7 +925,7 @@ He needs to escape... before the crazed mage returns and before that thing's mag
 [[Continue|Escape Options]]
 
 
-:: Escape Options {"position":"399,454","size":"100,100"}
+:: Escape Options [restart] {"position":"525,1625","size":"100,100"}
 <<silently>>
 <<set $CurArousal = 10>>
 <<set $observation1 = false>>
@@ -1008,14 +968,14 @@ A way out. There must be a way out! There isn't much choice left, but to...
 
 <div class="action-box">\
   <ul class="actions">\
-	<li>[[Keep looking around the room for a solution.|Observation 1]]</li>
-	<li>[[Try and pull at the leather bindings with vigor!|Struggle 1]]</li>
+    <li>[[Keep looking around the room for a solution.|Observation 1]]</li>
+    <li>[[Try and pull at the leather bindings with vigor!|Struggle 1]]</li>
   </ul>\
 </div>
 <</timed>>\
 
 
-:: Observation 1 {"position":"237,582","size":"100,100"}
+:: Observation 1 {"position":"450,1775","size":"100,100"}
 As his eyes scan the room for the tenth time, the wolf's ears drop low. His hope starts to wane, but as his vision sweeps over the left side with care, something catches his eye.
 
 It's a mirror. A small, handheld mirror resting on its side casually against \
@@ -1036,7 +996,7 @@ The crystals are, of course, completely unreachable to the naked wolf bound to t
 <<if $escapeActions>>\
 <div class="action-box">\
   <ul class="actions">\
-	<li>[[Reevaluate his options.|Escape Actions]]</li>
+    <li>[[Reevaluate his options.|Escape Actions]]</li>
   </ul>\
 </div>
 <<else>>\
@@ -1044,7 +1004,7 @@ The crystals are, of course, completely unreachable to the naked wolf bound to t
 <</if>>\
 
 
-:: Struggle 1 {"position":"456,583","size":"100,100"}
+:: Struggle 1 {"position":"600,1775","size":"100,100"}
 $name growls in frustration and tries, with more vehemence, to pull against the bindings with brute strength.
 
 Grunting with effort, the wolf puts all of his physical prowess behind the act. It takes quite a bunch of pulling and tugging, but while the leather bands wrapped around his wrists and ankles are as unyielding as the wood the cross is made of, the wolf does notice something.
@@ -1066,7 +1026,7 @@ Unfortunately, all the physical effort also served to quicken the wolf's breathi
 <<if $escapeActions>>\
 <div class="action-box">\
   <ul class="actions">\
-	<li>[[Reevaluate his options.|Escape Actions]]</li>
+    <li>[[Reevaluate his options.|Escape Actions]]</li>
   </ul>\
 </div>
 <<else>>\
@@ -1074,7 +1034,7 @@ Unfortunately, all the physical effort also served to quicken the wolf's breathi
 <</if>>\
 
 
-:: Escape Actions [hub] {"position":"250,716","size":"200,200"}
+:: Escape Actions {"position":"475,1925","size":"200,200"}
 <<nobr>>
   <<set $escapeActions = true>>
   <<if $CurArousal > 90 && $CurArousal < 100>>
@@ -1083,7 +1043,7 @@ Unfortunately, all the physical effort also served to quicken the wolf's breathi
     <<set $CurArousal += 9>>
   <</if>>
   <<if $CurArousal >= 100>>
-	<<goto "Arousal Overwhelmed">>
+    <<goto "Arousal Overwhelmed">>
   <</if>>
 <</nobr>>
 Candle's Influence: <<arousalbar $CurArousal $MaxArousal>>
@@ -1098,7 +1058,7 @@ The candle still burns silently at the corner.
 <<if $CurArousal <= 30>>\
 The wolf's forced arousal feels... <span style="color:#46bb26">distracting</span>.
 <br><br>
-<<include "Arousal Level 1">>
+<<include "Arousal Level 1">> <!-- [[Arousal Level 1]] -->
 
 <<elseif $CurArousal > 30 && $CurArousal <= 50>>
 The wolf's forced arousal feels... <span style="color:#e7d778">gripping</span>.
@@ -1132,23 +1092,23 @@ There must be a way to get out of his bonds, but how?
 <div class="action-box">\
   <ul class="actions">\
     <<if $observation1>>\
-	  <li>[[Look around the room for a solution once more...|Observation 2]]</li>
-	<<else>>\
-	  <li>[[Look around the room for a solution.|Observation 1]]</li>
-	<</if>>\
-	<<if $struggle1>>\
-	  <li>[[Try harder to wear down the bindings with strength and effort!|Struggle 2]]</li>
-	<<else>>\
-	  <li>[[Try and pull at the leather bindings with vigor!|Struggle 1]]</li>
-	<</if>>\
-	or...
-	<li>[[Take a moment to gather his thoughts about everything learned so far...|Gather Thoughts]]</li>
+      <li>[[Look around the room for a solution once more...|Observation 2]]</li>
+    <<else>>\
+      <li>[[Look around the room for a solution.|Observation 1]]</li>
+    <</if>>\
+    <<if $struggle1>>\
+      <li>[[Try harder to wear down the bindings with strength and effort!|Struggle 2]]</li>
+    <<else>>\
+      <li>[[Try and pull at the leather bindings with vigor!|Struggle 1]]</li>
+    <</if>>\
+    or...
+    <li>[[Take a moment to gather his thoughts about everything learned so far...|Gather Thoughts]]</li>
   </ul>\
 </div>
 <</timed>>
 
 
-:: Arousal Level 1 {"position":"36,502","size":"100,100"}
+:: Arousal Level 1 {"position":"725,1925","size":"100,100"}
 Avoiding taking deep breaths, $name just tries his best not to think about the constant distraction throbbing between his legs. He can seldom help glancing down towards it, though. It's always within his field of vision and trying to jump to the front of his mind.
 
 The wolf's cock. It stands there, fully aroused. His knot has inflated some, although not completely, and having it still trapped inside his sheath brings the wolf some discomfort, but he tries not to think about that either.
@@ -1158,7 +1118,7 @@ Small jolts of pleasure keep coming from his cock, though. Every time he breathe
 The bead of pre-cum lingering at the very tip of his firm arousal glistens as a constant threat of how those very instincts might betray him.
 
 
-:: Arousal Level 2 {"position":"35,614","size":"100,100"}
+:: Arousal Level 2 {"position":"825,1925","size":"100,100"}
 It's getting harder and harder to resist. After breathing so much of the candle's foul air, the heat coursing inside the wolf now feels constant. His fur feels too warm and an urge to pant, to let his tongue loll out is always there, but he resists it to avoid breathing even more of the cursed affliction.
 
 The wolf's cock reflects his increased state of arousal. It stands rock hard, as erect as the wolf ever remembers feeling it, and the small veins on its bright red surface bulge ever so slightly as well from how incredibly aroused he feels. It throbs more often than before, pulsing alongside the wolf's quickened heartbeat while, at the same time, serving as a beacon that promises unending pleasure to the wolf's affected mind. The urge to touch it, to feel his fingers trailing over that sensitive surface, is crushing.
@@ -1166,7 +1126,7 @@ The wolf's cock reflects his increased state of arousal. It stands rock hard, as
 The lupine's knot bulges his sheath in a very uncomfortable way being pretty much fully grown. From its very tip, a tendril of pre-cum lingers. Another droplet soon comes, then slowly falls down to the floor below his bound self. It's constant now. Every instinct the wolf has is slowly turning towards one thing and one thing alone: sex.
 
 
-:: Arousal Level 3 {"position":"35,723","size":"100,100"}
+:: Arousal Level 3 {"position":"925,1925","size":"100,100"}
 Panting becomes inevitable. Every breath is like a new log thrown into a bonfire of arousal burning within the wolf. It's getting harder and harder to think, to keep his eyes away from his cock. It stands there, proud, pulsing. Pleasure without end promised, if he could just touch it...!
 
 The wolf's cock throbs constantly now. Its surface glistens against the candlelight, the wolf's length covered in his own pre-cum that now keeps oozing from his tip without pause. Some of it runs down his length and brings involuntary groans from the wolf, some of it drips down to the ground below. His knot has grown as big as it can get outside of a tie and, much to both the wolf's relief and dismay, it has managed to push his sheath back. The bulb of sensitive flesh, thick and large, pulses alongside the whole of the wolf's length just begging to be touched. To be shoved into something. Something tight, something that would-
@@ -1176,7 +1136,7 @@ With a shake of his head, $name tries his best to keep his focus away from his c
 It takes a growl to break himself off of it. With increased urgency, $name realizes he has to find a way out soon, or else he will for sure be doomed, just as Ivex said.
 
 
-:: Arousal Level 4 {"position":"33,832","size":"100,100"}
+:: Arousal Level 4 {"position":"725,2025","size":"100,100"}
 Every breath is fire. $name can feel his eyes tearing up, but is it from the way his whole body burns up, or out of sheer frustration due to being unable to sate his lust?
 
 This is the cruelest of tortures. The wolf's breathing is quick and short and, even as he actively tries to slow it down, it's impossible now. His blood feels hot, his heart races and, most of all... his cock.
@@ -1188,7 +1148,7 @@ It feels impossible, but for the wolf, he swears he can feel it. It's not quite 
 It's maddening! With bated breath, $name shakes his head and grits his teeth together trying his hardest to keep his focus away from his cock.
 
 
-:: Arousal Overwhelmed {"position":"147,1057","size":"100,100"}
+:: Arousal Overwhelmed [end] {"position":"925,2025","size":"100,100"}
 <<set $CurArousal = 110>>\
 Candle's Influence: <<arousalbar $CurArousal $MaxArousal>>
 <<done>>
@@ -1230,7 +1190,7 @@ With a laugh, Ivex withdraws his hand.
 <</timed>>
 
 
-:: Arousal Level 5 {"position":"34,944","size":"100,100"}
+:: Arousal Level 5 {"position":"825,2025","size":"100,100"}
 "FUCK!" $name yells in a growl. It's hard to even shift his eyes away from his cock. Small veins bulge from its side as the canine-shaped length almost glows as it throbs there in the air. Untouched. No stimulation, even though the wolf needs it. He NEEDS IT!
 
 Drool runs down the sides of <<print $name>>'s muzzle, but he does not care. It doesn't matter. Nothing matters, only the constant waves of arousal his burning body feels. It radiates from his loins, from his cock, from his fucking knot, and he needs to touch it! He needs it!
@@ -1244,7 +1204,7 @@ He <i>needs</i> to get out. It's almost impossible to think now. The candle's fi
 Fighting to stay conscious and absolutely desperate, $name fights to resist, but it's a battle he's about to lose.
 
 
-:: Gather Thoughts {"position":"490,724","size":"100,100"}
+:: Gather Thoughts {"position":"450,2200","size":"100,100"}
 Exercising patience despite the urgency of his situation, $name takes a moment to reevaluate everything he knows so far, in an attempt to figure out the best way to escape. Before Ivex's cursed candle overwhelms him, that is.
 <<if $CurArousal < 60>>\
 
@@ -1314,7 +1274,7 @@ That can work! Now to manage that before the candle's influence grows too strong
 <<if $baseCrystal>>\
 <div class="action-box">\
   <ul class="actions">\
-	<li>[[Attempt to dislodge the crystal at the cross' base.|Dislodge Crystal]]</li>
+    <li>[[Attempt to dislodge the crystal at the cross' base.|Dislodge Crystal]]</li>
   </ul>\
 </div>
 <<else>>\
@@ -1322,13 +1282,13 @@ The time gathering his thoughts was valuable, but the breathing never stops and,
 
 <div class="action-box">\
   <ul class="actions">\
-	<li>[[Ponder on what action to take next...|Escape Actions]]</li>
+    <li>[[Ponder on what action to take next...|Escape Actions]]</li>
   </ul>\
 </div>
 <</if>>\
 
 
-:: Observation 2 {"position":"182,938","size":"100,100"}
+:: Observation 2 {"position":"300,2000","size":"100,100"}
 The wolf's eyes scan the room again. With increasing urgency, $name attempts to focus on each thing and think about how it could possibly help get out of that damned cross.
 
 Most things are useless or, if they would have some use, it does not matter because he cannot reach them. The sharp leather opener at the desk taunts him with its usefulness, but it is completely out of reach with him stuck to that cross.
@@ -1348,12 +1308,12 @@ And the whole time, he still has to breathe. The fire inside him grows by the mi
 
 <div class="action-box">\
   <ul class="actions">\
-	<li>[[Reevaluate his options.|Escape Actions]]</li>
+    <li>[[Reevaluate his options.|Escape Actions]]</li>
   </ul>\
 </div>
 
 
-:: Struggle 2 {"position":"393,936","size":"100,100"}
+:: Struggle 2 {"position":"600,2200","size":"100,100"}
 <<if $warrior && $CurArousal > 90>>\
 It's too much. Drekkar pants, huffs and drools like a wild beast. Rage swells within him as he stares down at his cock. The arousal, the impossible, infinite arousal he feels fuels his anger. Those bonds... they keep him from reaching what he needs, and he cannot take it anymore.
 
@@ -1376,8 +1336,8 @@ As his paw envelops his cock, the wolf lets out a moan of relief. At that moment
 <<set $bound = false>>\
 <div class="action-box">\
   <ul class="actions">\
-	<li>[[Fight the urges and snuff out the candle first.|Snuff Candle]]</li>
-	<li>[[Choose pleasure. Sate the needs burning within.|Jerk off]]</li>
+    <li>[[Fight the urges and snuff out the candle first.|Snuff Candle]]</li>
+    <li>[[Choose pleasure. Sate the needs burning within.|Jerk off]]</li>
   </ul>\
 </div>
 <<else>>\
@@ -1396,13 +1356,13 @@ The bound lupine takes a moment to catch his breath and recover his strength.
 
 <div class="action-box">\
   <ul class="actions">\
-	<li>[[Reevaluate his options.|Escape Actions]]</li>
+    <li>[[Reevaluate his options.|Escape Actions]]</li>
   </ul>\
 </div>
 <</if>>\
 
 
-:: Dislodge Crystal {"position":"583,875","size":"100,100"}
+:: Dislodge Crystal {"position":"400,2325","size":"100,100"}
 <<set $finalArousal = $curArousal>>\
 With a grunt, the wolf starts his desperate attempt to get rid of the crystals holding the cross he's bound to. Drawing from what he has learned so far, $name pulls with his right arm against the bindings with all of his strength while, at the same time, he <i>pushes</i> back against the cross with his left leg. With the directed tension, the cross shifts to the side.
 
@@ -1429,13 +1389,13 @@ At the same time, the letter opener sitting on the desk is well within reach now
 <<set $bound = true>>\
 <div class="action-box">\
   <ul class="actions">\
-	<li>[[Rush to the candle to put it out.|Snuff Candle]]</li>
-	<li>[[Rush to the leather opener to cut out the bonds.|Free Himself]]</li>
+    <li>[[Rush to the candle to put it out.|Snuff Candle]]</li>
+    <li>[[Rush to the leather opener to cut out the bonds.|Free Himself]]</li>
   </ul>\
 </div>
 
 
-:: Snuff Candle {"position":"653,1012","size":"100,100"}
+:: Snuff Candle {"position":"400,2500","size":"100,100"}
 <<set $candle = false>>\
 <<if $bound>>\
 With urgency, the wolf awkwardly stumbles and hops towards the candle, even still stuck to the loose cross. Luckily, despite its insane magical properties, the candle itself works just like a normal candle. Leaning over it and blowing at it is enough to snuff out its fire.
@@ -1450,7 +1410,7 @@ His eyes shift to the table. The next step has to be freeing himself from these 
 
 <div class="action-box">\
   <ul class="actions">\
-	<li>[[Finally cut the bonds away.|Free Himself]]</li>
+    <li>[[Finally cut the bonds away.|Free Himself]]</li>
   </ul>\
 </div>
 <<else>>\
@@ -1470,13 +1430,13 @@ Working hard to ignore his arousal, the wolf focuses on what really matters.
 
 <div class="action-box">\
   <ul class="actions">\
-	<li>[[Start working on escaping this tower...|Escape Start]]</li>
+    <li>[[Start working on escaping this tower...|Escape Start]]</li>
   </ul>\
 </div>
 <</if>>\
 
 
-:: Jerk off {"position":"440,1136","size":"100,100"}
+:: Jerk off [end] {"position":"800,2200","size":"100,100"}
 Fuck it! $name needs it. He needs the pleasure! After that is taken care of, then the wolf can deal with the candle and think about escaping. Only one thing matters now!
 
 With his paw blissfully wrapped around his cock, $name lets himself fall forward to his knees. An involuntary smile comes to his muzzle and he feels himself tearing up from the sheer happiness of being able to sate the lust burning within him. Every breath is fire, and now his paw can fan the fire.
@@ -1517,7 +1477,7 @@ Ivex approaches him and the mindless wolf can only look up at the panther.
 [[Continue|Ivex Torture 1]]
 
 
-:: Ivex Torture 1 {"position":"208,1198","size":"100,100"}
+:: Ivex Torture 1 {"position":"1100,2025","size":"100,100"}
 <<silently>>
 <<set $defiance = 0>>
 <<if $rough_awakening>>
@@ -1532,7 +1492,7 @@ Ivex approaches him and the mindless wolf can only look up at the panther.
 [[Continue|Ivex Torture 2]]
 
 
-:: Free Himself {"position":"520,1010","size":"100,100"}
+:: Free Himself {"position":"600,2375","size":"100,100"}
 Stumbling awkwardly with the cross' weight upon his back and still stuck in a spread-eagle position, the wolf hops and steps towards the desk on the side. Turning to the side and leaning in, it still takes some effort for him to be able to take hold of the letter opener with his hand, but he succeeds.
 
 With it in hand, it's only a matter of awkwardly cutting the leather binding without harming himself in the process. It does not take too long and, with one hand free, cutting the others is a breeze.
@@ -1546,7 +1506,7 @@ A smile opens in the corner of the wolf's muzzle.
 
 <div class="action-box">\
   <ul class="actions">\
-	<li>[[It's too late. It's impossible to resist. Start jerking off.|Jerk off]]</li>
+    <li>[[It's too late. It's impossible to resist. Start jerking off.|Jerk off]]</li>
   </ul>\
 </div>
 <<elseif $candle>>\
@@ -1558,8 +1518,8 @@ The wolf's mind is torn with indecision.
 
 <div class="action-box">\
   <ul class="actions">\
-	<li>[[It's too hard to resist. Start jerking off.|Jerk off]]</li>
-	<li>[[Don't yield! Go to the candle and snuff it out.|Snuff Candle]]</li>
+    <li>[[It's too hard to resist. Start jerking off.|Jerk off]]</li>
+    <li>[[Don't yield! Go to the candle and snuff it out.|Snuff Candle]]</li>
   </ul>\
 </div>
 <<else>>\
@@ -1573,14 +1533,14 @@ Working hard to ignore his arousal, the wolf focuses on what really matters.
   <ul class="actions">\
     <<if ($CurArousal > 80)>>\
       <li>[[It's really hard to resist. Start jerking off.|Jerk off]]</li>
-	<</if>>\
-	<li>[[Start working on escaping this tower...|Escape Start]]</li>
+    <</if>>\
+    <li>[[Start working on escaping this tower...|Escape Start]]</li>
   </ul>\
 </div>
 <</if>>\
 
 
-:: Escape Start [start] {"position":"616,1164","size":"100,100"}
+:: Escape Start [restart] {"position":"500,2650","size":"100,100"}
 <<silently>>
 <<set $candleTimer = "0s">>
 <<set $window = false>>
@@ -1624,31 +1584,7 @@ This is not the time to be worried about his modesty. This is the time to be wor
 [[Continue|The Upper Office]]
 
 
-:: To Be Continued 1 {"position":"548,1304","size":"100,100"}
-<b>Aaaand... that's it!</b>
-
-You've managed to escape the perverted mage Ivex's bondage and moved on to escape the tower! This marks the first half of the game completed and, unfortunately, it is where this first version ends.
-
-I have a few spicier plans for the second part leading to a (or a few) even spicier conclusions! I hope you enjoyed this first attempt at an interactive story so far!
-
-This game is a prototype, a test, a tryout before I move on to something bigger and more serious that I have in mind! I'm trying things out here, both story-wise and coding-wise, and trying to learn as much as I can while entertaining everybody in the process as well!
-
-This prototype also comes as the results of the polls that all my patrons voted on, by the way! The setting that won the poll was 'High Magic' and the kinks were, in order, 'Bondage' first, 'CBT' second and 'Milking' third. I can promise that all of these will be included and, as you might have seen, some already were.
-
-Big thanks to my patrons for their support while I work on this!
-
-For now, you can still play around with different options. Was it easy to get here? Did it take you a few tries? There are a few different ways to successfully reach the way of escaping and some ways that don't lead you here at all!
-
-If you haven't, I do recommend trying different choices and seeing what changes! There's one particularly risky way to get here that I don't know how many people will find. There's also dire consequences of different kinds for failing to escape in time…
-
-My Patreon is also slightly ahead of the public build with some new content available for them first. If you'd like, check it out over at <a class="footer-element" target="_blank" href="https://www.patreon.com/sleth">Patreon</a> where <a class="footer-element" target="_blank" href="https://www.patreon.com/posts/64812733">version 0.7</a> is already out, which the next one coming soon as well!
-
-If you'd like,
-
-[[Return to the beginning|Bound]]
-
-
-:: The Upper Office [hub] {"position":"811,1166","size":"100,100"}
+:: The Upper Office {"position":"500,2900","size":"100,100"}
 With the freedom to move around the office space, the wolf can now properly assess what is in this room. The many desks and cabinets seem to have nothing but documents on them with the occasional thick book lying here or there.
 
 The wolf's best bets, however, are of course the open window on one side of the wall and the simple wooden door on the opposite one.
@@ -1660,34 +1596,34 @@ The wolf feels that, using his hand, he could bring himself to an immensely sati
 
 <div class="action-box">\
   <ul class="actions">\
-  	<<if !$room>>\
-  	<li>[[Look around the room some more.|Room]]</li>
-	<</if>>
-	<<if !$window>>\
-	<li>[[Investigate the window.|Window]]</li>
-	<</if>>\
+      <<if !$room>>\
+      <li>[[Look around the room some more.|Room]]</li>
+    <</if>>
+    <<if !$window>>\
+    <li>[[Investigate the window.|Window]]</li>
+    <</if>>\
     <<if !$jerkoff>>\
-	<li>[[...Jerk off.|Arousal Relief]]</li>
-	<</if>>\
-	<li>[[Try the door.|Door]]</li>
+    <li>[[...Jerk off.|Arousal Relief]]</li>
+    <</if>>\
+    <li>[[Try the door.|Door]]</li>
   </ul>\
 </div>
 <<else>>\
 <div class="action-box">\
   <ul class="actions">\
-  	<<if !$room>>\
-  	<li>[[Look around the room some more.|Room]]</li>
-	<</if>>
-	<<if !$window>>\
-	<li>[[Investigate the window.|Window]]</li>
-	<</if>>\
-	<li>[[Try the door.|Door]]</li>
+      <<if !$room>>\
+      <li>[[Look around the room some more.|Room]]</li>
+    <</if>>
+    <<if !$window>>\
+    <li>[[Investigate the window.|Window]]</li>
+    <</if>>\
+    <li>[[Try the door.|Door]]</li>
   </ul>\
 </div>
 <</if>>\
 
 
-:: Room {"position":"862,1316","size":"100,100"}
+:: Room {"position":"300,2925","size":"100,100"}
 With his erection bobbing between his legs, the wolf searches the room with haste.
 
 Throwing the cabinets open, $name frowns. More papers, candles, ink and quills. Standard utilities and nothing else. The wolf doesn't waste too much time going through that stuff.
@@ -1698,7 +1634,7 @@ Nothing of note is found.
 [[Continue|The Upper Office]]
 
 
-:: Window {"position":"963,1200","size":"100,100"}
+:: Window {"position":"300,3050","size":"100,100"}
 $name approaches the window. Maybe it's climbable?
 
 Upon putting his paws on the window's sill, the wolf's hopes of climbing out of there vanish. Not only that, though... something is wrong.
@@ -1715,7 +1651,7 @@ Regardless... there is no way out through the window. Climbing down the smooth w
 [[Continue|The Upper Office]]
 
 
-:: Door {"position":"851,1029","size":"100,100"}
+:: Door {"position":"650,2900","size":"100,100"}
 Narrowing his eyes, $name heads towards the door. The wolf lets out a low growl, measuring the door's apparent sturdiness as he approaches it fully expecting to have to tackle it down.
 
 When his paw tries the door's handle, however, it twists. The door is not locked and it just opens.
@@ -1725,7 +1661,7 @@ Outside of it, there's a small hallway with no other doors, but it leads to a st
 <<if $room && $window>>\
 <div class="action-box">\
   <ul class="actions">\
-	<li>[[Leave the office and head down the stairs.|Head Downstairs]]</li>
+    <li>[[Leave the office and head down the stairs.|Head Downstairs]]</li>
   </ul>\
 </div>
 <<else>>\
@@ -1733,14 +1669,14 @@ There might still be useful things to see in the office before leaving, though.
 
 <div class="action-box">\
   <ul class="actions">\
-  	<li>[[Close the door and keep looking.|The Upper Office]]</li>
-	<li>[[Leave the office and head down the stairs.|Head Downstairs]]</li>
+      <li>[[Close the door and keep looking.|The Upper Office]]</li>
+    <li>[[Leave the office and head down the stairs.|Head Downstairs]]</li>
   </ul>\
 </div>
 <</if>>\
 
 
-:: Head Downstairs {"position":"987,966","size":"100,100"}
+:: Head Downstairs {"position":"775,2900","size":"100,100"}
 <<silently>>\
   <<set $stoneDoor = false>>
   <<set $lionDoor = false>>
@@ -1761,7 +1697,7 @@ There is little choice but to proceed, though.
 [[Continue|Second Floor]]
 
 
-:: Interrogation End {"position":"28,1345","size":"100,100"}
+:: Interrogation End [end] {"position":"2300,1800","size":"100,100"}
 $name fell into Ivex's hands.
 
 <<if $interrogationEndingUnlock>>\
@@ -1794,47 +1730,47 @@ To change the adventurer's fate, you can...
 
 <div class="action-box">\
   <ul class="actions">\  
-  	<li>[[Attempt to escape again.|Escape Options]]</li>
-  	<li>[[Return to the beginning of the game.|Title Screen]]</li>
+      <li>[[Attempt to escape again.|Escape Options]]</li>
+      <li>[[Return to the beginning of the game.|Title Screen]]</li>
   </ul>\
 </div>
 
 
-:: Easy Way {"position":"64,1480","size":"100,100"}
+:: Easy Way {"position":"1375,1975","size":"100,100"}
 <<include "Easy Way (Text)">>
 
 <div class="action-box">\
   <ul class="actions">\
-	<li>[[Stay silent and growl.|Resistance]]</li>
-	<li>[[Spit towards Ivex to show his distaste.|Defiance]]</li>	
+    <li>[[Stay silent and growl.|Resistance]]</li>
+    <li>[[Spit towards Ivex to show his distaste.|Defiance]]</li>	
   </ul>\
 </div>
 
 
-:: Hard Way {"position":"342,1481","size":"100,100"}
+:: Hard Way {"position":"1375,2100","size":"100,100"}
 <<include "Hard Way (Text)">>
 <<set $defiance += 1>>\
 
 <div class="action-box">\
   <ul class="actions">\
-	<li>[[Stay silent and growl.|Resistance]]</li>
-	<li>[[Spit towards Ivex to show his distaste.|Defiance]]</li>	
+    <li>[[Stay silent and growl.|Resistance]]</li>
+    <li>[[Spit towards Ivex to show his distaste.|Defiance]]</li>	
   </ul>\
 </div>
 
 
-:: Ivex Torture 2 {"position":"204,1342","size":"100,100"}
+:: Ivex Torture 2 {"position":"1225,2025","size":"100,100"}
 <<include "Ivex Torture 2 (Text)">>
 
 <div class="action-box">\
   <ul class="actions">\
     <li>[[Splay ears in submission.|Easy Way]]</li>
-	<li>[[Growl in defiance.|Hard Way]]</li>
+    <li>[[Growl in defiance.|Hard Way]]</li>
   </ul>\
 </div>
 
 
-:: Arousal Relief {"position":"727,1316","size":"100,100"}
+:: Arousal Relief {"position":"300,2800","size":"100,100"}
 Fuck it. It will be quick and it will feel great! With a glance towards the door and a growl coming from his throat, $name wraps his paw around his cock and that alone brings a groan of relief.
 
 Closing his eyes, he starts pumping it. In fast, quick motions, the wolf lets his hand glide over the surface of his cock, stimulating it, pleasuring it. Nobody knows his own dick better than his own hand, so with dexterity, his paw strokes his cock up and down. It teases the tip, then when it reaches the base, the wolf opens his grip just lightly to give his knot a squeeze before it keeps going...
@@ -1856,31 +1792,31 @@ With a growl of frustration, all $name can do is try to ignore his erection agai
 [[Continue|The Upper Office]]
 
 
-:: Resistance {"position":"118,1616","size":"100,100"}
+:: Resistance {"position":"1525,2100","size":"100,100"}
 <<include "Resistance (Text)">>
 
 <div class="action-box">\
   <ul class="actions">\
     <li>[['"Yes, I come from the far north, so what?"'|Ice]]</li>
-	<li>[['"No, I come from the south, so what?"'|Shock]]</li>
-	<li>[["Stay silent."|Random Punishment]]</li>
+    <li>[['"No, I come from the south, so what?"'|Shock]]</li>
+    <li>[["Stay silent."|Random Punishment]]</li>
   </ul>\
 </div>
 
 
-:: Ice {"position":"48,1789","size":"100,100"}
+:: Ice {"position":"1675,2200","size":"100,100"}
 <<include "Ice (Text)">>
 
 [[Continue|Ice 2]]
 
 
-:: Shock {"position":"446,1789","size":"100,100"}
+:: Shock {"position":"1675,1900","size":"100,100"}
 <<include "Shock (Text)">>
 
 [[Continue|Shock 2]]
 
 
-:: Random Punishment {"position":"294,1790","size":"100,100"}
+:: Random Punishment {"position":"1675,2050","size":"100,100"}
 <<silently>>
 <<set $defiance += 2>>\
 <<set $punishment to random(1, 2)>>
@@ -1904,7 +1840,7 @@ The mage grins.
 <</if>>\
 
 
-:: Ice 2 {"position":"100,1936","size":"100,100"}
+:: Ice 2 {"position":"1800,2200","size":"100,100"}
 <<include "Ice 2 (Text)">>
 
 <div class="action-box">\
@@ -1914,7 +1850,7 @@ The mage grins.
 </div>
 
 
-:: Ice 3 {"position":"139,2087","size":"100,100"}
+:: Ice 3 {"position":"1925,2200","size":"100,100"}
 <<if !$interrogationEndingFreeze>>\
 <<set $interrogationEndingFreezeUnlock = true>>\
 <</if>>\
@@ -1923,7 +1859,7 @@ The mage grins.
 [[Continue|Extra Torture]]
 
 
-:: Extra Torture {"position":"257,2232","size":"100,100"}
+:: Extra Torture {"position":"2050,2025","size":"100,100"}
 <<include "Extra Torture (Text)">>
 
 <<if $defiance > 3>>\
@@ -1937,7 +1873,7 @@ The mage grins.
 <</if>>\
 
 
-:: Defiant End {"position":"377,2375","size":"100,100"}
+:: Defiant End {"position":"2225,2025","size":"100,100"}
 <<if !$interrogationEnding>>\
 <<set $interrogationEndingUnlock = true>>\
 <</if>>\
@@ -1951,7 +1887,7 @@ The mage grins.
 [[Continue|Interrogation End]]
 
 
-:: Compliant End {"position":"132,2376","size":"100,100"}
+:: Compliant End {"position":"2125,1900","size":"100,100"}
 <<if !$interrogationEnding>>\
 <<set $interrogationEndingUnlock = true>>\
 <</if>>\
@@ -1965,20 +1901,20 @@ The mage grins.
 [[Continue|Interrogation End]]
 
 
-:: Defiance {"position":"386,1618","size":"100,100"}
+:: Defiance {"position":"1525,1975","size":"100,100"}
 <<include "Defiance (Text)">>
 <<set $defiance += 1>>\
 
 <div class="action-box">\
   <ul class="actions">\
     <li>[['"Yes, I come from the far north, so what?"'|Ice]]</li>
-	<li>[['"No, I come from the south, so what?"'|Shock]]</li>
-	<li>[["Stay silent."|Random Punishment]]</li>
+    <li>[['"No, I come from the south, so what?"'|Shock]]</li>
+    <li>[["Stay silent."|Random Punishment]]</li>
   </ul>\
 </div>
 
 
-:: Shock 2 {"position":"394,1934","size":"100,100"}
+:: Shock 2 {"position":"1800,1900","size":"100,100"}
 <<include "Shock 2 (Text)">>
 
 <div class="action-box">\
@@ -1988,7 +1924,7 @@ The mage grins.
 </div>
 
 
-:: Shock 3 {"position":"367,2087","size":"100,100"}
+:: Shock 3 {"position":"1925,1900","size":"100,100"}
 <<if !$interrogationEndingShock>>\
 <<set $interrogationEndingShockUnlock = true>>\
 <</if>>\
@@ -1997,7 +1933,7 @@ The mage grins.
 [[Continue|Extra Torture]]
 
 
-:: Second Floor [hub] {"position":"1186,928","size":"200,200"}
+:: Second Floor {"position":"675,3100","size":"200,200"}
 <<if $end07>>\
   <<goto "To Be Continued 2">>
 <</if>>\
@@ -2029,22 +1965,22 @@ Now the question is... where to go?
 <div class="action-box">\
   <ul class="actions">\
     <<if !$extractionRoom>>\
-  	  <li>[[Try the closed door.|Extraction Room Intro]]</li>
-	<<else>>\
-	  <li>[[Try the large hall.|Extraction Room]]</li>
-	<</if>>\
-	<<if !$lionGemstoneKnowledge>>\
-	  <<if $lionWatch>>\
-	    <li>[[Try the door with the lion inside.|Lion Watch]]</li>
-	  <<else>>\
-	    <li>[[Pry open the door with someone inside.|Lion Room Intro]]</li>	
-	  <</if>>\
-	<</if>>\
+        <li>[[Try the closed door.|Extraction Room Intro]]</li>
+    <<else>>\
+      <li>[[Try the large hall.|Extraction Room]]</li>
+    <</if>>\
+    <<if !$lionGemstoneKnowledge>>\
+      <<if $lionWatch>>\
+        <li>[[Try the door with the lion inside.|Lion Watch]]</li>
+      <<else>>\
+        <li>[[Pry open the door with someone inside.|Lion Room Intro]]</li>	
+      <</if>>\
+    <</if>>\
   </ul>\
 </div>
 
 
-:: Extraction Room Intro {"position":"1254,792","size":"100,100"}
+:: Extraction Room Intro {"position":"725,3775","size":"100,100"}
 <<if !$extractionDoor>>\
 With care, the wolf approaches the closed door. Taking a couple of reflexive sniffs towards it, the smells coming from it seem... varied, but also stale. With his ears perked up, $name tries to listen in to see if there's movement inside, but not a sound comes from it.
 
@@ -2061,8 +1997,8 @@ Maybe it would be good to go in and take a closer look... or maybe trying someth
 
 <div class="action-box">\
   <ul class="actions">\
-  	<li>[[Pry further and investigate the room.|Extraction Room]]</li>
-	<li>[[Return to the hallway.|Second Floor]]</li>
+      <li>[[Pry further and investigate the room.|Extraction Room]]</li>
+    <li>[[Return to the hallway.|Second Floor]]</li>
   </ul>\
 </div>\
 <<else>>\
@@ -2072,14 +2008,14 @@ Maybe it would be good to go in and take a closer look... or maybe trying someth
 
 <div class="action-box">\
   <ul class="actions">\
-  	<li>[[Pry further and investigate the room.|Extraction Room]]</li>
-	<li>[[Return to the hallway.|Second Floor]]</li>
+      <li>[[Pry further and investigate the room.|Extraction Room]]</li>
+    <li>[[Return to the hallway.|Second Floor]]</li>
   </ul>\
 </div>\
 <</if>>\
 
 
-:: Lion Room Intro {"position":"1235,1181","size":"100,100"}
+:: Lion Room Intro {"position":"950,3100","size":"100,100"}
 <<if !$lionDoor>>\
 Silently approaching the half-open door, the wolf carefully places his paw upon it and slides it open just a tad bit more so that he can peer inside.
 
@@ -2094,8 +2030,8 @@ Perhaps observing him for a little while longer could be useful. Getting discove
 
 <div class="action-box">\
   <ul class="actions">\
-  	<li>[[Pry further and watch the lion.|Lion Watch]]</li>
-	<li>[[Return to the hallway.|Second Floor]]</li>
+      <li>[[Pry further and watch the lion.|Lion Watch]]</li>
+    <li>[[Return to the hallway.|Second Floor]]</li>
   </ul>\
 </div>\
 <<else>>\
@@ -2109,29 +2045,14 @@ Approaching him for more information could be useful, even if risky...
 
 <div class="action-box">\
   <ul class="actions">\
-  	<li>[[Pry further and watch the lion.|Lion Watch]]</li>
-	<li>[[Return to the hallway.|Second Floor]]</li>
+      <li>[[Pry further and watch the lion.|Lion Watch]]</li>
+    <li>[[Return to the hallway.|Second Floor]]</li>
   </ul>\
 </div>\
 <</if>>\
 
 
-:: Blocked Exit {"position":"1447,965","size":"100,100"}
-Silently making his way past the other doors, the wolf quickly reaches the end of the hallway, where he is greeted by the black door he had seen before.
-
-From up close it looks even thicker. If it wasn't made of a different material, it might as well be part of a solid wall. Placing his hand on it, the wolf can feel that the black stone is smooth, but there doesn't seem to be any way to open it. Judging by the hallways' layout and the indications on the floor, it seems like it would be fair to guess that there are more stairs leading down to the next floor behind this sealed door.
-
-$name frowns. Tackling it would certainly not help and it would draw attention. Even a powerful wolf such as him cannot force this door open. Still, it can't be there for nothing. There has to be a way to open it and the wolf hopes that the answer is not just magic.
-
-After spending a few more moments feeling up the door in different places, the wolf is forced to sigh and give up. There is no moving further down the tower without finding a way to open this door.
-
-All $name can do is turn back and look into his other options.
-<<set $stoneDoor = true>>\
-
-[[Continue|Second Floor]]
-
-
-:: Lion Watch {"position":"1342,1292","size":"100,100"}
+:: Lion Watch {"position":"950,3225","size":"100,100"}
 <<set $lionWatch = true>>\
 <<set $lionwatchFinal = ($lionwatch1 + $lionwatch2 + $lionwatch3 + $lionwatch4+ $lionwatch5 + $lionwatch6 + $lionwatch7)>>
 With care, the wolf pries the door open just a little more so that he can slide his head inside to watch. <<print $name>>'s erection grinds uncomfortably against the wooden door, reminding him of its presence, but he does his best to ignore it.
@@ -2241,19 +2162,19 @@ It doesn't seem like he's going to be going anywhere or doing anything different
 \
 <div class="action-box">\
   <ul class="actions">\
-  	<li>[[Stop watching him and return to the hallway.|Second Floor]]</li>
-	<<if $lionCutscene>>\
-	  <li>[[Approach the lion.|Lion Start]]</li>
-	<<else>>\
-	  <<timed `$lionwatchFinal + "s"` t8n>>\
-	    <li>[[Approach the lion.|Lion Start]]</li>
-	  <</timed>>\
-	<</if>>\
+      <li>[[Stop watching him and return to the hallway.|Second Floor]]</li>
+    <<if $lionCutscene>>\
+      <li>[[Approach the lion.|Lion Start]]</li>
+    <<else>>\
+      <<timed `$lionwatchFinal + "s"` t8n>>\
+        <li>[[Approach the lion.|Lion Start]]</li>
+      <</timed>>\
+    <</if>>\
   </ul>\
 </div>\
 
 
-:: Extraction Room {"position":"1410,788","size":"100,100"}
+:: Extraction Room {"position":"525,3900","size":"200,200"}
 <<if $extractionRoom>>\
 There isn't much to see despite the room's size. The mysterious, numbered alcoves line up along the tall walls around the wolf, with most of them being closed.
 
@@ -2273,14 +2194,14 @@ A careful, more thorough investigation of the strange room could be helpful.
 
 <div class="action-box">\
   <ul class="actions">\
-  	<li>[[Examine the desk.|The Desk]]</li>
-	<li>[[Examine the altar.|The Altar]]</li>
+      <li>[[Examine the desk.|The Desk]]</li>
+    <li>[[Examine the altar.|The Altar]]</li>
     <li>[[Go back to the hallway.|Second Floor]]</li>
   </ul>\
 </div>
 
 
-:: Lion Start {"position":"1266,1450","size":"100,100"}
+:: Lion Start {"position":"1075,3225","size":"100,100"}
 Frowning and taking a deep breath, the wolf has had enough observing and decides to approach the lion. One of his paws goes down to cover his hard cock as best as it can, but the wolf's ears remain up and his stance a wary one. The lion has the appearance of a warrior himself, and he's definitely not normal, so he doesn't know what to expect.
 
 Abandoning subtlety, the wolf opens the door and steps in. The sounds do cause the lion to turn his head towards the lupine, although his hands continue to grind herbs and his expression does not change, even as he sets his eyes on $name.
@@ -2293,13 +2214,13 @@ The question makes the wolf blink. At least the lion isn't showing any signs of 
 
 <div class="action-box">\
   <ul class="actions">\
-  	<li>[['"Uhh... Yes?"'|Lion Conversation]]</li>
-	<li>[['"I'm looking for a way out..."'|Lion Conversation]]</li>
+      <li>[['"Uhh... Yes?"'|Lion Conversation]]</li>
+    <li>[['"I'm looking for a way out..."'|Lion Conversation]]</li>
   </ul>\
 </div>\
 
 
-:: Lion Conversation {"position":"1219,1599","size":"100,100"}
+:: Lion Conversation {"position":"1200,3225","size":"100,100"}
 Before the wolf can even properly finish speaking, however, the lion interrupts him.
 
 "I am directed to provide the means for one to take their place. Wait here."
@@ -2344,13 +2265,13 @@ Apparently tired of waiting, the lion starts stepping forward, raising the penda
 
 <div class="action-box">\
   <ul class="actions">\
-  	<li>[[Let the lion put the pendant on.|Mind Capture]]</li>
-	<li>[[Refuse the pendant.|Lion Refusal]]</li>
+      <li>[[Let the lion put the pendant on.|Mind Capture]]</li>
+    <li>[[Refuse the pendant.|Lion Refusal]]</li>
   </ul>\
 </div>\
 
 
-:: Mind Capture {"position":"883,1849","size":"100,100"}
+:: Mind Capture [end] {"position":"1325,3225","size":"100,100"}
 <<include "Mind Capture (Text)">>
 
 <span class="bad-ending">Bad Ending: <i>Enthrallment</i></span>
@@ -2358,7 +2279,7 @@ Apparently tired of waiting, the lion starts stepping forward, raising the penda
 [[Continue|Mind Capture 2]]
 
 
-:: Lion Refusal {"position":"1294,1749","size":"100,100"}
+:: Lion Refusal {"position":"1200,3350","size":"100,100"}
 There's no way $name is letting this lion put some magic gadget on him without him knowing what it is, especially coming from someone like that panther.
 
 With a growl, $name takes a step back and slaps the lion's hands to the side.
@@ -2384,13 +2305,13 @@ After all, Ivex could still return at any minute or hear something if things get
 [[Continue|Lion Fight]]
 
 
-:: Lion Fight {"position":"1320,1905","size":"100,100"}
+:: Lion Fight {"position":"1200,3475","size":"100,100"}
 <<include "Lion Fight (Text)">>
 
 [[Continue|Lion Pindown]]
 
 
-:: Lion Pindown {"position":"1352,2057","size":"100,100"}
+:: Lion Pindown {"position":"1200,3600","size":"100,100"}
 <<include "Lion Pindown (Text)">>
 <<if $arousalLevel == 1>>\
 
@@ -2402,13 +2323,13 @@ The candle's lingering influence... it drives the wolf crazy, It's so hard to re
 
 <div class="action-box">\
   <ul class="actions">\
-  	<li>[[Fight the urge. Tie the lion up and be done with it.|Lion Bondage]]</li>
-	<li>[[The lion is a defeated thrall. Just a quick fuck to help relieve the urges...|Lion Fucking]]</li>
+      <li>[[Fight the urge. Tie the lion up and be done with it.|Lion Bondage]]</li>
+    <li>[[The lion is a defeated thrall. Just a quick fuck to help relieve the urges...|Lion Fucking]]</li>
   </ul>\
 </div>\
 
 
-:: Lion Bondage [key] {"position":"1602,1810","size":"100,100"}
+:: Lion Bondage [key] {"position":"1000,3800","size":"100,100"}
 <<set $end07 = false>>\
 Reaching for the rope, it is only a matter of holding the lion down while forcing his arms back to tie them behind his back. Once that is done, the wolf plays it safe by doing the same to his legs and finishing with the lion in a tight hogtie.
 
@@ -2447,7 +2368,7 @@ He is ready to try and craft the key to his escape.
 
 <div class="action-box">\
   <ul class="actions">\
-  	[[Try and craft the red gemstone.|Gemstone Crafting]]
+      [[Try and craft the red gemstone.|Gemstone Crafting]]
   </ul>\
 </div>
 <<else>>\
@@ -2464,7 +2385,7 @@ All the wolf can do for now is return to the hallway and explore the rest of thi
 <</if>>\
 
 
-:: Lion Fucking {"position":"1346,2260","size":"100,100"}
+:: Lion Fucking {"position":"1350,3600","size":"100,100"}
 <<include "Lion Fucking (Text)">>
 <<if $arousalLevel >= 2>>\
 
@@ -2474,15 +2395,15 @@ But there's no decision to be made. After being exposed to that candle for so lo
 <div class="action-box">\
   <ul class="actions">\
     <<if $arousalLevel < 2>>\
-  	<li>[[Resist knotting him.|Lion Finish]]</li>
-	<<else>>\
-	<li>[[Knot him!|Lion Knotting]]</li>
-	<</if>>\
+      <li>[[Resist knotting him.|Lion Finish]]</li>
+    <<else>>\
+    <li>[[Knot him!|Lion Knotting]]</li>
+    <</if>>\
   </ul>\
 </div>\
 
 
-:: Lion Finish {"position":"1630,2180","size":"100,100"}
+:: Lion Finish {"position":"1250,3750","size":"100,100"}
 Gritting his teeth, it takes every ounce of effort from the wolf to, instead of shoving his knot into that damned lion hard as he wants to, reach down to his knot with his own paw and give it a hard squeeze.
 
 $name moans out loud. That's what he needs, that's what any wolf needs, to drive him crazy and past the point of no return. With pleasure overcoming him, the wolf's cock throbs, shoved deep inside the lion save for the knot, to start depositing the wolf's mark deep into the other male.
@@ -2497,12 +2418,12 @@ But, no! He's wasted enough time as it is! Ivex could return at any time. Lookin
 
 <div class="action-box">\
   <ul class="actions">\
-  	<li>[[Tie the lion up and be done with it.|Lion Bondage]]</li>
+      <li>[[Tie the lion up and be done with it.|Lion Bondage]]</li>
   </ul>\
 </div>\
 
 
-:: Lion Knotting {"position":"1116,2199","size":"100,100"}
+:: Lion Knotting {"position":"1475,3600","size":"100,100"}
 <<if !$enthrallmentLion>>\
 <<set $enthrallmentLionUnlock = true>>\
 <</if>>\
@@ -2511,7 +2432,7 @@ But, no! He's wasted enough time as it is! Ivex could return at any time. Lookin
 [[Continue|Mind Capture (Knot)]]
 
 
-:: Mind Capture (Knot) {"position":"1109,1912","size":"100,100"}
+:: Mind Capture (Knot) {"position":"1600,3600","size":"100,100"}
 <<include "Mind Capture (Knot) (Text)">>
 
 <span class="bad-ending">Bad Ending: <i>Enthrallment</i></span>
@@ -2519,19 +2440,19 @@ But, no! He's wasted enough time as it is! Ivex could return at any time. Lookin
 [[Continue|Mind Capture 2]]
 
 
-:: Mind Capture 2 {"position":"986,2045","size":"100,100"}
+:: Mind Capture 2 {"position":"1450,3225","size":"100,100"}
 <<include "Mind Capture 2 (Text)">>
 
 [[Continue|Enthrallment 1]]
 
 
-:: Enthrallment 1 {"position":"886,2199","size":"100,100"}
+:: Enthrallment 1 {"position":"1575,3225","size":"100,100"}
 <<include "Enthrallment 1 (Text)">>
 
 [[Continue|Enthrallment 2]]
 
 
-:: Enthrallment 2 {"position":"749,2028","size":"100,100"}
+:: Enthrallment 2 {"position":"1700,3225","size":"100,100"}
 <<if !$enthrallmentEnding>>\
 <<set $enthrallmentEndingUnlock = true>>\
 <</if>>\
@@ -2542,7 +2463,7 @@ But, no! He's wasted enough time as it is! Ivex could return at any time. Lookin
 [[Continue|Enthrallment End]]
 
 
-:: Enthrallment End {"position":"697,1731","size":"100,100"}
+:: Enthrallment End [end] {"position":"1800,2875","size":"100,100"}
 $name became Ivex's thrall.
 
 <<if $enthrallmentEndingUnlock>>\
@@ -2560,38 +2481,14 @@ To change the adventurer's fate, you can...
 
 <div class="action-box">\
   <ul class="actions">\  
-  	<li>[[Return to the point of escaping the first floor.|Escape Start]]</li>
-  	<li>[[Return to the beginning of the game.|Title Screen]]</li>
+      <li>[[Return to the point of escaping the first floor.|Escape Start]]</li>
+      <li>[[Return to the beginning of the game.|Title Screen]]</li>
   </ul>\
 </div>
 
 
-:: To Be Continued 2 {"position":"1104,1252","size":"100,100"}
-<b>Aaaand... that's it, again!</b>
-
-You've reached the end of this version! Unfortunately, in order to see what lies beyond the other door and finally escape this tower once and for all, you'll need to wait a bit longer. The next version will get you closer to the end!
-
-For now, however, just as before, I encourage you to try some new things if you haven't yet. Choose different options, see what happens...
-
-Starting from this enhanced build, you can check out the [[Archives]] (also always available in the sidebar menu) and see what you have unlocked and what's still left to be unlocked! Not only that, but in there, you'll have the ability to easily read through any endings you have already unlocked as many times as you want without having to go through the entire game to reach them. I hope you enjoy it!
-
-Overall, though, thank you so much for playing this prototype interactive story. If you wanna see more ASAP, my <a target="_blank" href="https://www.patreon.com/sleth">patreon</a> is one build ahead of the public release with more content! They'll also get a poll that will influence one of the endings... ;)
-
-It's thanks to their awesome support that I can keep working on my passion for writing!
-
-Regardless of supporting me with $$ or not, thank you so much for playing! If you'd like, leave a comment about the game or something and I'll gladly read it and take it to heart as well.
-
-From here, you can...
-
-[[Return to the start of the second floor|Escape Start]]
-
-OR!
-
-[[Return all the way to the beginning|Bound]]
-
-
-:: Archives [noreturn] {"position":"331,2607","size":"100,100"}
-[[Return to the game|$return]]
+:: Archives [noreturn] {"position":"2400,700","size":"100,100"}
+<<link "Return to the game" $return>><</link>>\
 
 <h1>Archives</h1>
 Welcome to the Mage's Tower Archives.
@@ -2603,20 +2500,20 @@ Grayed out endings are paths that have not yet been found, although there are hi
 
 <hr>
 <h2>Endings unlocked:</h2>
-<<include "Interrogation Archive Display">>
+<<include [[Interrogation Archive Display]]>>
 
-<<include "Enthrallment Archive Display">>
+<<include [[Enthrallment Archive Display]]>>
 
-<<include "Extraction Archive Display">>
+<<include [[Extraction Archive Display]]>>
 
-<<include "Ivex Punishment Archive Display">>
+<<include [[Ivex Punishment Archive Display]]>>
 
-<<include "Ivex Enthrallment Archive Display">>
+<<include [[Ivex Enthrallment Archive Display]]>>
 
-<<include "Ivex Extraction Archive Display">>
+<<include [[Ivex Extraction Archive Display]]>>
 
 
-:: The Desk {"position":"1535,637","size":"100,100"}
+:: The Desk {"position":"900,4350","size":"100,100"}
 <<if $theDesk>>\
 The only interesting things the wolf can see on the desk are the <span class="imp-info">thick book</span> and the <span class="imp-info">journal</span>.
 <<else>>\
@@ -2636,20 +2533,20 @@ If they belong to Ivex, they might be worth checking out.
 
 <div class="action-box">\
   <ul class="actions">\
-	<<if !$theJournal>>\
-	<li>[[Examine the journal.|The Journal]]</li>
-	<<else>>\
-	<li>[[Examine the journal again.|Journal Notes]]</li>
-	<</if>>\
+    <<if !$theJournal>>\
+    <li>[[Examine the journal.|The Journal]]</li>
+    <<else>>\
+    <li>[[Examine the journal again.|Journal Notes]]</li>
+    <</if>>\
     <<if !$spellbookKnowledge>>\
-  	<li>[[Examine the large book.|The Spellbook]]</li>
-	<</if>>\	
-	<li>[[Go try something else.|Extraction Room]]</li>
+      <li>[[Examine the large book.|The Spellbook]]</li>
+    <</if>>\	
+    <li>[[Go try something else.|Extraction Room]]</li>
   </ul>\
 </div>
 
 
-:: The Altar {"position":"1307,618","size":"100,100"}
+:: The Altar {"position":"800,4000","size":"100,100"}
 <<if $thePlatform>>\
 $name approaches the altar at the center of the room to take a closer look once more.
 
@@ -2682,19 +2579,19 @@ Still, it looks absolutely harmless.
 
 <div class="action-box">\
   <ul class="actions">\
-  	<li>[[Touch the substance.|Pulled In]]</li>
-	<li>[[Go back to try something else.|Extraction Room]]</li>
+      <li>[[Touch the substance.|Pulled In]]</li>
+    <li>[[Go back to try something else.|Extraction Room]]</li>
   </ul>\
 </div>
 
 
-:: Pulled In {"position":"1208,491","size":"100,100"}
+:: Pulled In {"position":"925,4000","size":"100,100"}
 <<include "Pulled In (Text)">>
 
 [[Continue|Pulled Further]]
 
 
-:: Pulled Further {"position":"1455,465","size":"100,100"}
+:: Pulled Further [end] {"position":"1050,4000","size":"100,100"}
 <<include "Pulled Further (Text)">>
 
 <span class="bad-ending">Bad Ending: <i>Extraction</i></span>
@@ -2702,75 +2599,75 @@ Still, it looks absolutely harmless.
 [[Continue|Extraction 1]]
 
 
-:: Extraction 1 {"position":"1321,235","size":"100,100"}
+:: Extraction 1 {"position":"1175,4000","size":"100,100"}
 <<include "Extraction 1 (Text)">>
 
 <div class="action-box">\
   <ul class="actions">\
-  	<li>[["Hmmfgh!!"|Extraction 2]]</li>
-	<li>[["Hmmfffhhg?!"|Extraction 2]]</li>
+      <li>[["Hmmfgh!!"|Extraction 2]]</li>
+    <li>[["Hmmfffhhg?!"|Extraction 2]]</li>
   </ul>\
 </div>
 
 
-:: Extraction 2 {"position":"1187,146","size":"100,100"}
+:: Extraction 2 {"position":"1300,4000","size":"100,100"}
 <<include "Extraction 2 (Text)">>
 
 [[Continue|Extraction 3]]
 
 
-:: Extraction 3 {"position":"1361,32","size":"100,100"}
+:: Extraction 3 {"position":"1425,4000","size":"100,100"}
 <<include "Extraction 3 (Text)">>
 
 <div class="action-box">\
   <ul class="actions">\
-  	<li>[["Hmmrrrrhfgh!!!"|Forceful Extraction 1]]</li>
-	<li>[["Hmmmffh..."|Gentle Extraction 1]]</li>
+      <li>[["Hmmrrrrhfgh!!!"|Forceful Extraction 1]]</li>
+    <li>[["Hmmmffh..."|Gentle Extraction 1]]</li>
   </ul>\
 </div>
 
 
-:: Forceful Extraction 1 {"position":"1535,219","size":"100,100"}
+:: Forceful Extraction 1 {"position":"1550,4050","size":"100,100"}
 <<set $forcefulExtraction = true>>\
 <<include "Forceful Extraction 1 (Text)">>
 
 <div class="action-box">\
   <ul class="actions">\
-  	<li>[["HMMRFGH!!!"|Forceful Extraction 2]]</li>
+      <li>[["HMMRFGH!!!"|Forceful Extraction 2]]</li>
   </ul>\
 </div>
 
 
-:: Gentle Extraction 1 {"position":"1534,0","size":"100,100"}
+:: Gentle Extraction 1 {"position":"1550,3925","size":"100,100"}
 <<set $forcefulExtraction = false>>\
 <<include "Gentle Extraction 1 (Text)">>
 
 <div class="action-box">\
   <ul class="actions">\
-  	<li>[["Hmmmmfffgghh...!"|Gentle Extraction 2]]</li>
+      <li>[["Hmmmmfffgghh...!"|Gentle Extraction 2]]</li>
   </ul>\
 </div>
 
 
-:: Forceful Extraction 2 {"position":"1672,220","size":"100,100"}
+:: Forceful Extraction 2 {"position":"1675,4050","size":"100,100"}
 <<include "Forceful Extraction 2 (Text)">>
 
 [[Continue|Forceful Extraction 3]]
 
 
-:: Forceful Extraction 3 {"position":"1797,222","size":"100,100"}
+:: Forceful Extraction 3 {"position":"1800,4050","size":"100,100"}
 <<include "Forceful Extraction 3 (Text)">>
 
 [[Continue|Forceful Extraction End]]
 
 
-:: Forceful Extraction End {"position":"1922,222","size":"100,100"}
+:: Forceful Extraction End {"position":"1925,4050","size":"100,100"}
 <<include "Forceful Extraction End (Text)">>
 
 [[Continue|Extraction End 1]]
 
 
-:: Extraction End 1 {"position":"2058,76","size":"100,100"}
+:: Extraction End 1 {"position":"2050,3975","size":"100,100"}
 <<include "Extraction End 1 (Text)">>
 
 <<if $forcefulExtraction>>\
@@ -2780,7 +2677,7 @@ Still, it looks absolutely harmless.
 <</if>>\
 
 
-:: Forceful Extraction End 2 {"position":"2195,239","size":"100,100"}
+:: Forceful Extraction End 2 {"position":"2175,4050","size":"100,100"}
 <<if !$extractionEnding>>\
 <<set $extractionEndingUnlock = true>>\
 <</if>>\
@@ -2793,7 +2690,7 @@ Still, it looks absolutely harmless.
 [[Continue|Extraction End 2]]
 
 
-:: Extraction End 2 {"position":"2342,85","size":"100,100"}
+:: Extraction End 2 [end] {"position":"2525,3575","size":"100,100"}
 $name remained trapped serving as fuel for Ivex's magic.
 
 <<if $extractionEndingUnlock>>\
@@ -2816,13 +2713,13 @@ To change the adventurer's fate, you can...
 
 <div class="action-box">\
   <ul class="actions">\  
-  	<li>[[Return to the point of escaping the first floor.|Escape Start]]</li>
-  	<li>[[Return to the beginning of the game.|Title Screen]]</li>
+      <li>[[Return to the point of escaping the first floor.|Escape Start]]</li>
+      <li>[[Return to the beginning of the game.|Title Screen]]</li>
   </ul>\
 </div>
 
 
-:: Gentle Extraction End 2 {"position":"2197,1","size":"100,100"}
+:: Gentle Extraction End 2 {"position":"2175,3925","size":"100,100"}
 <<if !$extractionEnding>>\
 <<set $extractionEndingUnlock = true>>\
 <</if>>\
@@ -2835,25 +2732,25 @@ To change the adventurer's fate, you can...
 [[Continue|Extraction End 2]]
 
 
-:: Gentle Extraction 2 {"position":"1674,0","size":"100,100"}
+:: Gentle Extraction 2 {"position":"1675,3925","size":"100,100"}
 <<include "Gentle Extraction 2 (Text)">>
 
 [[Continue|Gentle Extraction 3]]
 
 
-:: Gentle Extraction 3 {"position":"1801,0","size":"100,100"}
+:: Gentle Extraction 3 {"position":"1800,3925","size":"100,100"}
 <<include "Gentle Extraction 3 (Text)">>
 
 [[Continue|Gentle Extraction End]]
 
 
-:: Gentle Extraction End {"position":"1926,1","size":"100,100"}
+:: Gentle Extraction End {"position":"1925,3925","size":"100,100"}
 <<include "Gentle Extraction End (Text)">>
 
 [[Continue|Extraction End 1]]
 
 
-:: Interrogation Archive [noreturn] {"position":"471,2696","size":"100,100"}
+:: Interrogation Archive [noreturn] {"position":"1700,1100","size":"100,100"}
 <<include "Ivex Torture 1 (Text)">>
 
 <<include "Ivex Torture 2 (Text)">>
@@ -2911,7 +2808,7 @@ The wolf chooses to remain silent with nothing but a low growl towards the mage.
 [[Return to the Archives|Archives]]
 
 
-:: Ivex Torture 1 (Text) [text] {"position":"311,1198","size":"100,100"}
+:: Ivex Torture 1 (Text) [text] {"position":"1100,1925","size":"100,100"}
 The mage hums to himself as he takes the time to casually walk around the wolf, observing him from all sides. $name can't help but keep desperately pulling against the restraints. The wolf's cock flexes, dripping pre-cum almost constantly now from the overwhelming arousal he's subjected to.
 
 "Look at you... barely more than a feral beast now, slave to your baser instincts..." the mage mocked. "What would your fellow adventurers say if they could see you now? Bound, drooling, wanting to get out just so that you can pleasure yourself relentlessly..."
@@ -2933,7 +2830,7 @@ Ivex pulls the cloth covering his nose down as well to reveal his large grin.
 "Now that you're back with me... shall we begin?"
 
 
-:: Ivex Torture 2 (Text) [text] {"position":"310,1342","size":"100,100"}
+:: Ivex Torture 2 (Text) [text] {"position":"1225,1925","size":"100,100"}
 The mage brings both his hands up. A few precise movements are made and $name can see the panther's eyes glow for a moment. Ivex mutters some words under his breath and then the creaking sound of a chest opening comes from behind the bound wolf. From there, a small crystal comes floating to Ivex with remarkable speed, which he promptly catches with ease and holds up.
 
 "This is a gravity crystal. Handy things, those are. You can bind their energy and attach them to anything. They have many practical uses, but I'm going to show you one of my favorites." Ivex took a step forward.
@@ -2961,7 +2858,7 @@ Ivex chuckles in a way of mocking. "See how utterly helpless you are before me? 
 The weight on the wolf's balls feels heavy. It tugs at them uncomfortably and, even though it has only been a few seconds, it already starts to feel a little painful to hold the crystal with his nuts alone. Ivex stares at the wolf with a cocky smile of superiority waiting for his answer.
 
 
-:: Easy Way (Text) [text] {"position":"168,1482","size":"100,100"}
+:: Easy Way (Text) [text] {"position":"1375,1875","size":"100,100"}
 "Learning your place I see..." the mage smiles. Even though the wolf says nothing, Ivex seems smart enough to pick up the hesitation in body language.
 
 The panther leans in close, his hand coming to the wolf's leg to caress it. $name can't help but draw in a sharp breath as just the caressing near his needy cock is enough to make the wolf's heartbeat accelerate.
@@ -2979,7 +2876,7 @@ It gets even worse when Ivex starts massaging it ever so lightly with his finger
 A vague question. The wolf's knowledge is limited, but any details he tells Ivex could put the Adventurer's guild or whoever else they send after Ivex in the same danger he is facing. Betraying his comrades is something the wolf would never do, and just the fact that Ivex believes he would is an offense in itself.
 
 
-:: Hard Way (Text) [text] {"position":"446,1481","size":"100,100"}
+:: Hard Way (Text) [text] {"position":"1375,2200","size":"100,100"}
 "Aahh... still so full of fire, aren't you? Even knowing how small you are next to me?" Ivex says with his usual lingering smile of amusement. "I suppose it's only fair. I haven't even begun to show you what I can do to you."
 
 <<print $name>>'s growling continues. "You wouldn't stand a fucking chance against a warrior like me if it weren't for your magic tricks!"
@@ -3005,7 +2902,7 @@ It gets even worse when Ivex starts massaging it ever so lightly with his finger
 A vague question. The wolf's knowledge is limited, but any details he tells Ivex could put the Adventurer's guild or whoever else they send after Ivex in the same danger he is facing. Betraying his comrades is something the wolf would never do.
 
 
-:: Resistance (Text) [text] {"position":"222,1615","size":"100,100"}
+:: Resistance (Text) [text] {"position":"1525,2200","size":"100,100"}
 "Not willing to tell me, hmm? A shame... such a shame..." Ivex speaks with obviously fake disappointment. In fact, he smiles, the panther's tail swishing back and forth lazily as a sign of worrying satisfaction and amusement.
 
 $name decides to remain quiet. It is hard enough to endure the weight on his balls on one side and the urge to let out sounds of pleasure as Ivex's fingers still continue to tease his oversensitive cock. If only that cursed arousal would go away! Looking down at his member, hard as a rock and leaking, a small wave of shame comes over the wolf, but this is all the sick mage's doing, $name tells himself. Only his doing...
@@ -3027,7 +2924,7 @@ The light touch is not enough to satisfy the wolf's urges, not nearly enough, bu
 "So? Do you like the cold or not? Answer me or I'll make my own assumptions..." he grins once more.
 
 
-:: Defiance (Text) [text] {"position":"490,1617","size":"100,100"}
+:: Defiance (Text) [text] {"position":"1525,1875","size":"100,100"}
 $name spits at the mage to give his response. The panther is fast enough to take a quick step back so that the spit, at best, splashes at his footpaws.
 
 The mage's smile fades immediately.
@@ -3065,7 +2962,7 @@ The light touch is not enough to satisfy the wolf, not nearly enough, but it doe
 "So? Do you like the cold or not? Answer me or I'll make my own assumptions..." he grins once more.
 
 
-:: Shock (Text) [text] {"position":"549,1788","size":"100,100"}
+:: Shock (Text) [text] {"position":"1675,1800","size":"100,100"}
 With a chuckle, the panther comes even closer. $name grows stiff and growls seeing the panther leaning against him. With the wolf bound and spread as he is, Ivex has full freedom to press his side against the wolf's, going as far as leaning his head to rest it against <<print $name>>'s broad chest. The panther's hand never leaves the wolf's cock, continuing to stroke and tease it in its way too slow manner, but the mage's other hand comes to caress the exposed fur of the wolf's chest.
 
 "Such a big specimen... the big ones are my favorite. Wolves, even more. I wonder what sounds you'll make..."
@@ -3093,7 +2990,7 @@ $name breathes a small sigh of relief.
 Yet Ivex grins again. "Time to have fun with you."
 
 
-:: Shock 2 (Text) [text] {"position":"499,1933","size":"100,100"}
+:: Shock 2 (Text) [text] {"position":"1800,1800","size":"100,100"}
 The panther's eyes move back to the wolf's cock. That hand never stopped teasing it, much to the wolf's dismay, and the weight on his balls never went away either. Yet, still, as Ivex chuckles again, his hand speeds up. The stroking gets faster. The panther's hand skillfully strokes and teases the whole of the wolf's exposed length, going all the way down to the knot, toying with it to make him gasp, then moving back to the dripping tip. He does it a few times, furthering the wolf's pleasure, and soon $name is panting. The candle did too much. His balls churn and the weight feels more uncomfortable than ever. $name feels like he could cum ten times in a row and one of them is already coming with just that bit of stimulation... until Ivex grins.
 
 <<print $name>>'s eyes start going wide.
@@ -3123,7 +3020,7 @@ It feels like far, far too long before he lets go, and the tingling sensation re
 "Now, are you willing to tell me <b>everything</b> I want to know?" the mage asks with three fingers playing around the wolf's knot, threatening to touch it. It takes effort to even form words to muster a response, but when $name finally manages to...
 
 
-:: Shock 3 (Text) [text] {"position":"473,2087","size":"100,100"}
+:: Shock 3 (Text) [text] {"position":"1925,1800","size":"100,100"}
 Before the wolf can finish saying anything at all, a movement from Ivex's finger has some kind of belt come flying from behind to wrap itself around the wolf's muzzle with lightning speed. It buckles itself and tightens <b>hard</b>, making the wolf flinch and causing him to be unable to open his muzzle at all.
 
 "Hmmmhgghm!" the wolf complains. It's impossible to form proper words with his muzzle shut tight.
@@ -3143,7 +3040,7 @@ Ivex spends a little time pleasuring the wolf, but unfortunately, it is all too 
 $name shakes his hand, letting out muffled pleas and complaints against it, but it is to no avail. The wolf howls through his shut muzzle as Ivex envelops his cock in lightning once more and starts stroking it with that hand instead...
 
 
-:: Extra Torture (Text) [text] {"position":"361,2232","size":"100,100"}
+:: Extra Torture (Text) [text] {"position":"2050,2125","size":"100,100"}
 It's hard to tell for how long the mage plays with the wolf. Unable to even say anything, all $name can do is stay there, bound and exposed, as he endures the whims of the sadistic mage. With his magic-engulfed hand, he alternates between torturing and pleasuring the wolf's exposed cock a few more times before he moves on to different methods.
 
 Ivex seems to take immense pleasure in shifting the weight of the crystal hanging from the wolf's balls back and forth. Sometimes it grows light to give his nuts some relief, and sometimes the mage makes it so heavy that $name feels like his balls are supporting the weight of a person by themselves.
@@ -3161,7 +3058,7 @@ To the wolf, it feels like hours pass by. His cock feels sore, his balls even mo
 Ivex approaches the wolf again, leaning against his chest, his hand caressing the wolf's tortured knot and bringing a whine of need from the bound adventurer.
 
 
-:: Defiant End (Text) [text] {"position":"482,2374","size":"100,100"}
+:: Defiant End (Text) [text] {"position":"2325,2025","size":"100,100"}
 Ivex's painful squeezing thankfully does not last long. The panther soon lets go of it, stepping back, but as he does, he motions with his hands again and...
 
 Four small metal rings come to him, all flying between the mage and the wolf. With a smile, the panther motions more delicately, and much to the wolf's dismay, all four rings fly in order towards his cock and carefully slide around it. One rests right above his knot, the other three a little spaced out around the wolf's throbbing length.
@@ -3215,7 +3112,7 @@ The mage turns and starts walking away. $name grunts and yells through his shut 
 $name shakes his head. Ivex, however, just laughs and walks away. The large wolf is left alone in the room, bound, with the candle burning and clouded in unending pleasure for who knows how long. Overwhelmed by everything inflicted upon him, $name can't even wonder what Ivex has in store for him in the future now that he's in the mage's hands.
 
 
-:: Compliant End (Text) [text] {"position":"236,2375","size":"100,100"}
+:: Compliant End (Text) [text] {"position":"2125,1800","size":"100,100"}
 Ivex's pleasurable stroking does not last long. The panther soon lets go of it, stepping back, but as he does, he motions with his hands again and...
 
 Four small metal rings come to him, all flying between the mage and the wolf. With a smile, the panther motions more delicately, and much to the wolf's dismay, all four rings fly in order towards his cock and carefully slide around it. One rests right above his knot, the other three a little spaced out around the wolf's throbbing length.
@@ -3251,7 +3148,7 @@ Ivex lets go of all he is holding and, as usual, everything floats up instead of
 $name shakes his head. Ivex, however, just laughs and motions with his hand again. The gear approaches the bound wolf... and there is nothing he can do to stop it.
 
 
-:: Ice (Text) [text] {"position":"150,1788","size":"100,100"}
+:: Ice (Text) [text] {"position":"1675,2300","size":"100,100"}
 With a chuckle, the panther comes even closer. $name grows stiff and growls seeing the panther leaning against him. With the wolf bound and spread as he is, Ivex has full freedom to press his side against the wolf's, going as far as leaning his head to rest it against <<print $name>>'s broad chest. The panther's hand never leaves the wolf's cock, continuing to stroke and tease it in its way too slow manner, but the mage's other hand comes to caress the exposed fur of the wolf's chest.
 
 "Such a big specimen... the big ones are my favorite. Wolves, even more. I wonder what sounds you'll make..."
@@ -3279,7 +3176,7 @@ He breathes a sigh of relief.
 Yet Ivex grins again. "Time to have fun with you."
 
 
-:: Ice 2 (Text) [text] {"position":"203,1935","size":"100,100"}
+:: Ice 2 (Text) [text] {"position":"1800,2300","size":"100,100"}
 The panther's eyes move back to the wolf's cock. That hand never stopped teasing it, much to the wolf's dismay, and the weight on his balls never went away either. Yet, still, as Ivex chuckles again, his hand speeds up. The stroking gets faster. The panther's hand skillfully strokes and teases the whole of the wolf's exposed length, going all the way down to the knot, toying with it to make him gasp, then moving back to the dripping tip. He does it a few times, furthering the wolf's pleasure, and soon $name is panting. The candle did too much. His balls churn and the weight feels more uncomfortable than ever. $name feels like he could cum ten times in a row and one of them is already coming with just that bit of stimulation... until Ivex grins.
 
 <<print $name>>'s eyes start going wide.
@@ -3305,7 +3202,7 @@ $name can't help it. The wolf lets out what is almost a howl as the ice envelops
 "Now, are you willing to tell me <b>everything</b> I want to know?" the mage asks without letting go of the wolf's knot. It takes effort to even form words to muster a response, but when $name finally manages to...
 
 
-:: Ice 3 (Text) [text] {"position":"241,2086","size":"100,100"}
+:: Ice 3 (Text) [text] {"position":"1925,2300","size":"100,100"}
 Before the wolf can finish saying anything at all, a movement from Ivex's finger has some kind of belt come flying from behind to wrap itself around the wolf's muzzle with lightning speed. It buckles itself and tightens <b>hard</b>, making the wolf flinch and causing him to be unable to open his muzzle at all.
 
 "Hmmmhgghm!" the wolf complains. It's impossible to form proper words with his muzzle shut tight.
@@ -3321,7 +3218,7 @@ It feels like a long time goes by before Ivex's hand finally retreats. The wolf'
 $name shakes his hand, letting out muffled pleas and complaints against it, but it is to no avail. The wolf howls through his shut muzzle as Ivex envelops his cock in ice once more and starts stroking all over again.
 
 
-:: Mind Capture (Knot) (Text) [text] {"position":"1212,1912","size":"100,100"}
+:: Mind Capture (Knot) (Text) [text] {"position":"1700,3600","size":"100,100"}
 For a moment, $name feels his adrenaline shoot up. His first reflex is to bring his paw up to remove the pendant from his neck, but as he tries to do so he realizes... it doesn't work. His arm won't move, no matter how much he wills it to. Neither will the other one, or his legs, or... anything!
 
 The wolf finds himself stuck there, on all fours above the lion with his knot stuck to the feline. His mind races for a moment, his heart speeding up, but then...
@@ -3349,7 +3246,7 @@ His body starts grinding herbs next to the lion and there's nothing he can do ab
 $name is trapped.
 
 
-:: Mind Capture (Text) [text] {"position":"989,1848","size":"100,100"}
+:: Mind Capture (Text) [text] {"position":"1325,3125","size":"100,100"}
 The lion stands chest to chest with the wolf and brings the pendant up. $name reluctantly allows the feline to put it over his head and around his neck.
 
 Looking down at it, the wolf can see the blue gemstone glowing brighter. It is as if there is a mist inside it that glows and whirls. At first, nothing happens.
@@ -3371,7 +3268,7 @@ His body starts grinding herbs next to the lion and there's nothing he can do ab
 $name is trapped.
 
 
-:: Mind Capture 2 (Text) [text] {"position":"1090,2045","size":"100,100"}
+:: Mind Capture 2 (Text) [text] {"position":"1450,3125","size":"100,100"}
 It doesn't matter how much the wolf shouts and yells inside his thoughts or how much willpower he puts into defying his body's movements. It won't obey. Whatever that pendant is, it's strong enough to overcome him entirely.
 
 $name is forced to remain there next to the lion in the exact same state the leonine warrior is in. Blank expression and mindlessly grinding herbs for Ivex's nefarious purposes. Like... like some sort of slave. Like a mindless fucking thrall! The thought alone is enough to drive the wolf mad with anger, but his heart does not even speed up. It feels so unnatural to feel these things without really feeling them!
@@ -3383,7 +3280,7 @@ For some reason, that smell feels incredibly <b>arousing</b>. If he could look a
 No matter how much he tries, $name cannot find a way out. He's trapped there grinding herbs and getting aroused by it until who knows how long after that, Ivex himself opens the door.
 
 
-:: Interrogation Archive Display {"position":"182,2696","size":"100,100"}
+:: Interrogation Archive Display [noreturn] {"position":"1700,1000","size":"100,100"}
 <<silently>>\
   <<if $interrogationEndingFreeze && $interrogationEndingShock>>
     <<set $interrogationSpell = 'freeze'>>
@@ -3402,73 +3299,73 @@ No matter how much he tries, $name cannot find a way out. He's trapped there gri
     <<set $interrogationEnd = 'rough'>>
   <<else>>
     <<set $interrogationEnd = ''>>
-  <</if>>  
+  <</if>>
 <</silently>>\
 \
 <<if $interrogationEnding>>\
   <b>[[Bad Ending: Interrogation|Interrogation Archive]]</b>
   Variation 1: <<nobr>>
   <<if $interrogationEndingFreeze>>
-	<label><<radiobutton "$interrogationSpell" "freeze" autocheck>> Freeze</label>
+    <label><<radiobutton "$interrogationSpell" "freeze" autocheck>> Freeze</label>
   <<else>>
     <span class="helper-container">
-	  <span><label><<radiobutton "$interrogationSpell" "">> <span class="disabled">Freeze</span></label></span>
-	  <small class="helper-text">Ivex has a special treatment for northern wolves that like the cold...</small>
-	</span>
-	<<done>><<script>>
-	document.getElementById("radiobutton-interrogationspell-0").disabled = true;
-	<</script>><</done>>
+      <span><label><<radiobutton "$interrogationSpell" "">> <span class="disabled">Freeze</span></label></span>
+      <small class="helper-text">Ivex has a special treatment for northern wolves that like the cold...</small>
+    </span>
+    <<done>><<script>>
+    document.getElementById("radiobutton-interrogationspell-0").disabled = true;
+    <</script>><</done>>
   <</if>>
   <</nobr>>\
    | <<nobr>>
-	<<if $interrogationEndingShock>>
-		<label><<radiobutton "$interrogationSpell" "shock" autocheck>> Shock</label>
-	  <<else>>
-		<span class="helper-container">
-		  <span><label><<radiobutton "$interrogationSpell" "">> <span class="disabled">Shock</span></label></span>
-		  <small class="helper-text">Ivex has a special treatment for southern wolves that hate the cold...</small>
-		</span>
-		<<done>><<script>>
-			document.getElementById("radiobutton-interrogationspell-1").disabled = true;
-		<</script>><</done>>
+    <<if $interrogationEndingShock>>
+        <label><<radiobutton "$interrogationSpell" "shock" autocheck>> Shock</label>
+      <<else>>
+        <span class="helper-container">
+          <span><label><<radiobutton "$interrogationSpell" "">> <span class="disabled">Shock</span></label></span>
+          <small class="helper-text">Ivex has a special treatment for southern wolves that hate the cold...</small>
+        </span>
+        <<done>><<script>>
+            document.getElementById("radiobutton-interrogationspell-1").disabled = true;
+        <</script>><</done>>
     <</if>>
   <</nobr>>
 
   Variation 2: <<nobr>>
   <<if $interrogationEndingMild>>
-	<label><label><<radiobutton "$interrogationEnd" "mild" autocheck>> Mild</label>
+    <label><label><<radiobutton "$interrogationEnd" "mild" autocheck>> Mild</label>
   <<else>>
     <span class="helper-container">
-	  <span><label><<radiobutton "$interrogationEnd" "">> <span class="disabled">Mild</span></label></span>
-	  <small class="helper-text">Ivex treats those that choose collaboration over defiance with "kindness"...</small>
-	</span>
-	<<done>><<script>>
-	document.getElementById("radiobutton-interrogationend-0").disabled = true;
-	<</script>><</done>>
+      <span><label><<radiobutton "$interrogationEnd" "">> <span class="disabled">Mild</span></label></span>
+      <small class="helper-text">Ivex treats those that choose collaboration over defiance with "kindness"...</small>
+    </span>
+    <<done>><<script>>
+    document.getElementById("radiobutton-interrogationend-0").disabled = true;
+    <</script>><</done>>
   <</if>>
   <</nobr>>\
    | <<nobr>>
-	<<if $interrogationEndingRough>>
-	  <label><<radiobutton "$interrogationEnd" "rough" autocheck>> Harsh</label>
-	<<else>>
-	  <span class="helper-container">
-	  <span><label><<radiobutton "$interrogationEnd" "">> <span class="disabled">Rough</span></label></span>
-	  <small class="helper-text">Ivex has a special disdain for those that dare defy his wishes...</small>
-	  </span>
-	  <<done>><<script>>
-	  document.getElementById("radiobutton-interrogationend-1").disabled = true;
-	  <</script>><</done>>
+    <<if $interrogationEndingRough>>
+      <label><<radiobutton "$interrogationEnd" "rough" autocheck>> Harsh</label>
+    <<else>>
+      <span class="helper-container">
+      <span><label><<radiobutton "$interrogationEnd" "">> <span class="disabled">Rough</span></label></span>
+      <small class="helper-text">Ivex has a special disdain for those that dare defy his wishes...</small>
+      </span>
+      <<done>><<script>>
+      document.getElementById("radiobutton-interrogationend-1").disabled = true;
+      <</script>><</done>>
     <</if>>
   <</nobr>>
 <<else>>\
   <span class="helper-container">
-  	<b><span class="disabled">Bad Ending: Interrogation</span></b>
-	<small class="helper-text">Interrogation by the hands of the wizard is the first step that awaits those that cannot escape his contraptions...</small>
+      <b><span class="disabled">Bad Ending: Interrogation</span></b>
+    <small class="helper-text">Interrogation by the hands of the wizard is the first step that awaits those that cannot escape his contraptions...</small>
   </span>
 <</if>>\
 
 
-:: Enthrallment 1 (Text) [text] {"position":"990,2199","size":"100,100"}
+:: Enthrallment 1 (Text) [text] {"position":"1575,3125","size":"100,100"}
 The wolf can't even turn his head to look at the damned mage, but the panther is incredibly happy and amused to find him there with a gemstone around his neck and working next to the lion.
 
 There is nothing $name can do. Ivex compliments the lion for capturing him with a slap to the feline's bare ass. The wolf is forced to remain there, grinding herbs while Ivex's hands explore his helpless body, stroke and play with his forcefully aroused cock and even go as far as shoving a finger up his ass.
@@ -3482,7 +3379,7 @@ Much to <<print $name>>'s dismay, whatever order Ivex issues, the parasitic mind
 After that, there is nothing else the wolf can do. Removing the pendant is impossible by himself and Ivex surely won't do it. $name finds himself doomed to serve as the perverted mage's thrall against his will.
 
 
-:: Enthrallment 2 (Text) [text] {"position":"851,2028","size":"100,100"}
+:: Enthrallment 2 (Text) [text] {"position":"1700,3125","size":"100,100"}
 Time loses all meaning to the wolf. Inside Ivex's tower, it's impossible to tell day from night. His body sleeps sometimes, but the intervals at which he does seem random and, sometimes, get interrupted by Ivex's orders if they are particularly lengthy.
 
 Little by little, the unwilling wolf learns more about the mage, but every new thing he learns just makes him hate him more. $name gets by telling himself that, as soon as he's free, he's gonna get his revenge on the mage, except that the days keep going by and freedom never comes.
@@ -3500,13 +3397,13 @@ Activities with the lion end up being quite common as well. The mage takes pleas
 Time keeps passing, each day a new set of orders with some being worse and some being better. Still, <<print $name>>'s own mind waits. His current system is counting the number of punches he's gonna give Ivex when he gets free, but as of right now he's beaten a thousand and is still going. Still, someday... someday freedom will come and he'll be able to settle the score. Someday, somehow.
 
 
-:: Lion Description {"position":"1420,1161","size":"100,100"}
+:: Lion Description {"position":"1025,2950","size":"100,100"}
 The lion is large with shiny golden fur and an impressive mane. He is also quite muscular, with thick arms and a broad chest, as made plain by the fact that he does not wear much in terms of clothing. What seems to be some kind of harness made of leather has some straps going across his chest and back, and below? Nothing. The lion does not wear anything to cover his rear that is plain for the wolf to see from where he stands.
 
 [[Return|Lion Room Intro]]
 
 
-:: Lion Fucking (Text) [text] {"position":"1448,2259","size":"100,100"}
+:: Lion Fucking (Text) [text] {"position":"1350,3500","size":"100,100"}
 It's too hard to resist. Besides, the lion is clearly a thrall fighting for Ivex. The wolf has beaten him fair and square, and now...
 
 With a lustful growl, $name pulls his hips back so that he can line himself up with the struggling lion's hole. His cock is already coated in his own pre-cum from all the fighting, the damned lingering arousal from that blasted candle. The thought of it, the memories, the humiliation he went through because of Ivex's pervertedness makes the wolf angry. All he went through... Yeah, it's time to let it out on something.
@@ -3526,7 +3423,7 @@ His knot is the only thing that still remains outside of the lion. It begs to fe
 Despite his eagerness and need, however, the wolf glances at the rope. Knotting the lion would mean being stuck to him for a long time, which is a luxury he definitely does not have. His rational mind tells him that, but as $name keeps fucking, his body begs him to knot the damned bastard. As he fucks faster, his pleasure reaching its peak...
 
 
-:: Lion Knotting (Text) [text] {"position":"1219,2198","size":"100,100"}
+:: Lion Knotting (Text) [text] {"position":"1475,3500","size":"100,100"}
 Gritting his teeth, the wolf puts even more force behind his fucking. It feels good, great even, to give in to the overwhelming lust. Drool runs down the wolf's muzzle to fall down on the lion's exposed back at the mere thought of how that tight ass is going to feel around his knot.
 
 It takes effort. A lot of effort. With a lot of grunting from both parties and a lot of insistence from the wolf, his knot finally spreads the lion's ass, the large bulb forcing its way in until finally...
@@ -3550,7 +3447,7 @@ With one sudden move, the lion's hand reaches over his head. The wolf feels some
 $name blinks. Through his fucking, he didn't realize the lion had freed his other hand, reached out for the pendant and now managed to place it over his neck.
 
 
-:: Enthrallment Archive [noreturn] {"position":"475,2806","size":"100,100"}
+:: Enthrallment Archive [noreturn] {"position":"1825,1100","size":"100,100"}
 <<if $lionFuck>>\
 <<include "Lion Fight (Text)">>
 
@@ -3582,7 +3479,7 @@ But there's no decision to be made. After being exposed to that candle for so lo
 [[Return to the Archives|Archives]]
 
 
-:: Enthrallment Archive Display {"position":"180,2804","size":"100,100"}
+:: Enthrallment Archive Display [noreturn] {"position":"1825,1000","size":"100,100"}
 <<silently>>\
   <<set $lionFuck = false>>
 <</silently>>\
@@ -3590,30 +3487,30 @@ But there's no decision to be made. After being exposed to that candle for so lo
 <<if $enthrallmentEnding>>\
   <b>[[Bad Ending: Enthrallment|Enthrallment Archive]]</b>
   Variation: <<nobr>>
-	<label><<radiobutton "$lionFuck" false checked>> None</label>
+    <label><<radiobutton "$lionFuck" false checked>> None</label>
   <</nobr>>\
    | <<nobr>>
-	<<if $enthrallmentLion>>
-		<label><<radiobutton "$lionFuck" true>> Lion</label>
-	  <<else>>
-		<span class="helper-container">
-		  <span><label><<radiobutton "$lionFuck" "">> <span class="disabled">Lion</span></label></span>
-		  <small class="helper-text">Engaging in arousing activities while overtaken by previous magical lust makes some things impossible to resist...</small>
-		</span>
-		<<done>><<script>>
-			document.getElementById("radiobutton-lionfuck-1").disabled = true;
-		<</script>><</done>>
+    <<if $enthrallmentLion>>
+        <label><<radiobutton "$lionFuck" true>> Lion</label>
+      <<else>>
+        <span class="helper-container">
+          <span><label><<radiobutton "$lionFuck" "">> <span class="disabled">Lion</span></label></span>
+          <small class="helper-text">Engaging in arousing activities while overtaken by previous magical lust makes some things impossible to resist...</small>
+        </span>
+        <<done>><<script>>
+            document.getElementById("radiobutton-lionfuck-1").disabled = true;
+        <</script>><</done>>
     <</if>>
   <</nobr>>
 <<else>>\
   <span class="helper-container">
-  	<b><span class="disabled">Bad Ending: Enthrallment</span></b>
-	<small class="helper-text">Sometimes a magical accessory is for more than just the looks...</small>
+      <b><span class="disabled">Bad Ending: Enthrallment</span></b>
+    <small class="helper-text">Sometimes a magical accessory is for more than just the looks...</small>
   </span>
 <</if>>\
 
 
-:: Lion Pindown (Text) [text] {"position":"1455,2057","size":"100,100"}
+:: Lion Pindown (Text) [text] {"position":"1100,3600","size":"100,100"}
 The feline is good. Very good. How can someone this strong end up grinding herbs in some psycho mage's tower?! The wolf's wondering has to wait, however, because as the lion uses his legs to trap his own, things start getting ugly. Much to the wolf's dismay, the lion grips him closer than ever and, in that position, the wolf's cock finds itself hard-pressed against the lion's own member. It feels warm against the wolf's sensitive length, tingles of pleasure distracting $name from the urgency of the situation. The lion forces him back, climbing on top of him, dangerously close to pinning him down...
 
 "NO!" the wolf yells at the lion's face. With a surge of anger, the wolf lets out a loud snarl and bends his knee, hitting the exposed lion straight on the nuts.
@@ -3635,7 +3532,7 @@ As he does so, the lion keeps squirming. When he does, the wolf looks down to se
 The lion's rear is toned and round. The feline's tail swishes back and forth in distress, but with his squirming, his cheeks move and up and down, back and forth... right against the wolf's cock. His erection sits right there, between the beautiful molds of the lion's ass, and his squirming just makes it grind against it. Tingles of pleasure shoot up at the wolf and, as he looks down with more attention, he can see everything. The lion's exposed ass. Bare. Vulnerable. It looks really tight...
 
 
-:: Lion Fight (Text) [text] {"position":"1422,1905","size":"100,100"}
+:: Lion Fight (Text) [text] {"position":"1100,3475","size":"100,100"}
 The lion rushes forward. The wolf growls, bracing to meet the large warrior chest to chest. $name has fought many strong men before and, while many couldn't match the large wolf's strength and size, giving him an advantage, that is not the case with this lion. When the feline tackles him and pushes forward, the wolf finds himself losing his footing.
 
 Before he can fall, however, $name spins, paws pushing back against the lion trying to grip and hold him so that they both fall side by side rather than letting the lion be on top. The wolf then props his knee up to try and get the upper hand and force the lion to roll with him to pin the feline down, but despite the lion's apparent mindless status, $name can tell that his fighting reflexes are still sharp.
@@ -3651,7 +3548,7 @@ The lion grabs hold of <<print $name>>'s wrist and tries to twist it. The wolf h
 The two roll on the ground, muscle against muscle, each trying to end up on top.
 
 
-:: The Spellbook [key] {"position":"1759,674","size":"100,100"}
+:: The Spellbook [key] {"position":"1575,4725","size":"100,100"}
 Opening the large tome, it's plain to see that it is something of importance.
 
 On one of its pages, a very intricate circle that even $name can identify as some sort of arcane incantation symbol takes all the space. On the page beside it, there is what seems to be the name and instructions on words to say for the incantation itself. The random page the wolf opens the book on only says 'Levitate'. It's definitely some sort of <span class="imp-info">spellbook</span>.
@@ -3674,7 +3571,7 @@ He is ready to try and craft the key to his escape.
 
 <div class="action-box">\
   <ul class="actions">\
-  	<li>[[Try and craft the red gemstone.|Gemstone Crafting]]</li>
+      <li>[[Try and craft the red gemstone.|Gemstone Crafting]]</li>
   </ul>\
 </div>
 <<else>>\
@@ -3683,7 +3580,7 @@ Now, to craft a gemstone, all he would need is to find an empty gemstone somewhe
 
 <div class="action-box">\
   <ul class="actions">\
-  	<li>[[Leave the spellbook as it is for now.|The Desk]]</li>
+      <li>[[Leave the spellbook as it is for now.|The Desk]]</li>
   </ul>\
 </div>
 <</if>>\
@@ -3693,13 +3590,13 @@ After leafing through a bunch of them, the wolf just grunts. It doesn't seem lik
 
 <div class="action-box">\
   <ul class="actions">\
-  	<li>[[Leave the spellbook as it is.|The Desk]]</li>
+      <li>[[Leave the spellbook as it is.|The Desk]]</li>
   </ul>\
 </div>
 <</if>>\
 
 
-:: The Journal {"position":"1677,476","size":"100,100"}
+:: The Journal {"position":"1000,4475","size":"100,100"}
 <<set $theJournal = true>>\
 Pulling the journal close to himself, the wolf sits down to take a look. His bare rear against the chair reminds him of his forced nudity, but he forces himself to ignore it and focus on the contents of the journal instead.
 
@@ -3710,7 +3607,7 @@ As $name goes through it, there are a few parts that catch his attention...
 [[Continue|Journal Notes]]
 
 
-:: Journal Notes {"position":"1795,524","size":"100,100"}
+:: Journal Notes {"position":"900,4600","size":"100,100"}
 Among the many, many pages of passages, some stand out...
 
 Near the beginning of the journal...
@@ -3743,12 +3640,12 @@ The rest of the journal is still blank and unwritten.
 
 <div class="action-box">\
   <ul class="actions">\
-  	<li>[[Leave the journal as it is.|The Desk]]</li>
+      <li>[[Leave the journal as it is.|The Desk]]</li>
   </ul>\
 </div>
 
 
-:: Memory Book Notes {"position":"1933,439","size":"100,100"}
+:: Memory Book Notes {"position":"1050,4600","size":"100,100"}
 This is the first entry in the journal. The calligraphy is neat and done with care, but the ink is already starting to fade, signaling that it might have been written a long time ago. It reads:
 
 <span class="handwriting">
@@ -3765,12 +3662,12 @@ This part continues on to some far too detailed notes of what seems to be Ivex's
 
 <div class="action-box">\
   <ul class="actions">\
-  	<li>[[Read something else.|Journal Notes]]</li>
+      <li>[[Read something else.|Journal Notes]]</li>
   </ul>\
 </div>
 
 
-:: School Notes {"position":"2046,440","size":"100,100"}
+:: School Notes {"position":"1150,4600","size":"100,100"}
 These notes are smeared and poorly written, unlike most that surround them. They read:
 
 <span class="handwriting">
@@ -3802,12 +3699,12 @@ After that, the next routine writing seems to take place several days later and 
 
 <div class="action-box">\
   <ul class="actions">\
-  	<li>[[Read something else.|Journal Notes]]</li>
+      <li>[[Read something else.|Journal Notes]]</li>
   </ul>\
 </div>
 
 
-:: Tower Notes {"position":"1933,552","size":"100,100"}
+:: Tower Notes {"position":"1050,4700","size":"100,100"}
 This note stands out amidst a bunch of unorganized notes. The writing at this point is more sporadic and rough. It speaks of concerning matters. It reads:
 
 <span class="mild-handwriting">
@@ -3828,12 +3725,12 @@ The rest of the notes on this page are crude drawings of both things that look a
 
 <div class="action-box">\
   <ul class="actions">\
-  	<li>[[Read something else.|Journal Notes]]</li>
+      <li>[[Read something else.|Journal Notes]]</li>
   </ul>\
 </div>
 
 
-:: Gem Notes {"position":"2046,552","size":"100,100"}
+:: Gem Notes {"position":"1150,4700","size":"100,100"}
 These notes stand out amidst a bunch of unorganized notes. The writing at this point is sporadic and rough. They seem to talk about <span class="imp-info">gemstones</span> though. It reads:
 
 <span class="mild-handwriting">
@@ -3854,12 +3751,12 @@ The notes that follow this get far too into magical terms for the wolf to proper
 
 <div class="action-box">\
   <ul class="actions">\
-  	<li>[[Read something else.|Journal Notes]]</li>
+      <li>[[Read something else.|Journal Notes]]</li>
   </ul>\
 </div>
 
 
-:: Extraction Notes {"position":"2155,553","size":"100,100"}
+:: Extraction Notes {"position":"1250,4700","size":"100,100"}
 These notes stand out amidst a bunch of unorganized notes. The writing at this point is sporadic and rough. Ivex seems to write about his plans but in a confusing manner. It reads:
 
 <span class="mild-handwriting">
@@ -3884,12 +3781,12 @@ There are drawings and sketches beneath more strange notes. The drawings are lit
 
 <div class="action-box">\
   <ul class="actions">\
-  	<li>[[Read something else.|Journal Notes]]</li>
+      <li>[[Read something else.|Journal Notes]]</li>
   </ul>\
 </div>
 
 
-:: Lion Notes {"position":"1932,672","size":"100,100"}
+:: Lion Notes {"position":"1050,4800","size":"100,100"}
 These notes are written in a brasher way with much less care for the handwriting. They seem to mention a lion, which reminds the wolf of the one he's seen in the tower, making them possibly worth reading. It reads:
 
 <span class="crude-handwriting">
@@ -3924,12 +3821,12 @@ This seems to be where the notes about the lion end. The topic of the notes chan
 
 <div class="action-box">\
   <ul class="actions">\
-  	<li>[[Read something else.|Journal Notes]]</li>
+      <li>[[Read something else.|Journal Notes]]</li>
   </ul>\
 </div>
 
 
-:: Kink Notes {"position":"2045,672","size":"100,100"}
+:: Kink Notes {"position":"1150,4800","size":"100,100"}
 These notes are written in a brasher way with much less care for the handwriting. Around the page, there are marks left by some kind of dry liquid and, when the wolf touches them, they feel a tad sticky. It reads:
 
 <span class="crude-handwriting">
@@ -3971,12 +3868,12 @@ There are dozens of other ideas written here, but the anger inside the wolf make
 
 <div class="action-box">\
   <ul class="actions">\
-  	<li>[[Read something else.|Journal Notes]]</li>
+      <li>[[Read something else.|Journal Notes]]</li>
   </ul>\
 </div>
 
 
-:: Thief Notes {"position":"2156,671","size":"100,100"}
+:: Thief Notes {"position":"600,4775","size":"100,100"}
 These notes are written in a brasher way with much less care for the handwriting. The ink in these notes is dry but still strong, signaling that they might be recent. It reads:
 
 <span class="crude-handwriting">
@@ -4008,7 +3905,7 @@ This is the last entry on the journal so far and, thankfully, it has already pro
 [[Continue|Notes Knowledge]]
 
 
-:: Notes Knowledge [key] {"position":"1945,814","size":"100,100"}
+:: Notes Knowledge [key] {"position":"400,4825","size":"100,100"}
 <<if !$journalKnowledge>>\
 Re-reading the journal entry one more time, the naked wolf's tail wags back and forth. That poor fox, wherever he is, left very useful information in these records! If that fox adventurer could have escaped the tower, then so can <<print $name>>.
 
@@ -4037,22 +3934,22 @@ The wolf's ears twitch and his smile widens. He, in fact, already has some knowl
 
 <div class="action-box">\
   <ul class="actions">\
-  	<li>[[Assess his knowledge...|Knowledge Assessment]]</li>
+      <li>[[Assess his knowledge...|Knowledge Assessment]]</li>
   </ul>\
 </div>
 <<else>>\
 
 <div class="action-box">\
   <ul class="actions">\
-  	<li>[[Read something else on the journal.|Journal Notes]]</li>
-  	<li>[[Sift through the other contents of the desk.|The Desk]]</li>	
-  	<li>[[Get away from the desk and look somewhere else.|Extraction Room]]</li>	
+      <li>[[Read something else on the journal.|Journal Notes]]</li>
+      <li>[[Sift through the other contents of the desk.|The Desk]]</li>	
+      <li>[[Get away from the desk and look somewhere else.|Extraction Room]]</li>	
   </ul>\
 </div>
 <</if>>\
 
 
-:: Gemstone Crafting [key] {"position":"1781,1136","size":"100,100"}
+:: Gemstone Crafting [key] {"position":"825,5200","size":"100,100"}
 The naked wolf pulls the desk's chair and sits on it properly. He sets a gray gemstone from the lion's room on the table and pulls the spellbook closer to himself.
 
 With a frown, he begins looking for the right spell. Luckily, it doesn't take long for him to smile as he finds what has to be the right one.
@@ -4072,7 +3969,7 @@ And then, just like that, the glow goes away. When the wolf looks at it again, h
 [[Continue|The Exit]]
 
 
-:: Knowledge Assessment [key] {"position":"1641,849","size":"100,100"}
+:: Knowledge Assessment [key] {"position":"200,4850","size":"100,100"}
 According to Ivex's journal, the wolf needs a <span class="imp-info">red teleportation gemstone</span> to get out of the tower.
 
 Ivex's journal mentions two ways to get those...
@@ -4103,19 +4000,19 @@ Crafting a gemstone could be possible if only the wolf could find all of the req
 <div class="action-box">\
   <ul class="actions">\
     <<if $spellbookKnowledge && $lionGemstoneKnowledge>>\
-  	<li>[[Try and craft the red gemstone.|Gemstone Crafting]]</li>
-	<<else>>\
-	<li>[[Read something else on the journal.|Journal Notes]]</li>
-	<li>[[Go back to the main hallway to explore more...|Second Floor]]</li>
-	<</if>>\
-	<<if $blobGemstoneKnowledge>>\
-	<li>[[Try and get the red gemstone left by the fox.|The Altar]]</li>
-	<</if>>\
+      <li>[[Try and craft the red gemstone.|Gemstone Crafting]]</li>
+    <<else>>\
+    <li>[[Read something else on the journal.|Journal Notes]]</li>
+    <li>[[Go back to the main hallway to explore more...|Second Floor]]</li>
+    <</if>>\
+    <<if $blobGemstoneKnowledge>>\
+    <li>[[Try and get the red gemstone left by the fox.|The Altar]]</li>
+    <</if>>\
   </ul>\
 </div>
 
 
-:: The Exit {"position":"1933,1137","size":"100,100"}
+:: The Exit {"position":"825,5325","size":"100,100"}
 With care, $name grabs the gemstone. He holds it in his paw. It feels warm to the touch. The wolf looks at it, takes a sniff at it, then holds it up with two fingers to inspect it properly. It's a beautiful gemstone, but... how to use it?
 
 Even though he has it, $name frowns. Does he need to go to a certain place? Speak certain words? Ivex didn't when he left, but the panther mage could do a whole lot of impressive and downright impossible things.
@@ -4131,7 +4028,7 @@ The whole world around him starts shifting into a blur.
 [[Continue|Outside]]
 
 
-:: Outside {"position":"2079,1139","size":"100,100"}
+:: Outside [restart] {"position":"950,5325","size":"100,100"}
 The big wolf stumbles forward. A sense of vertigo overwhelms him for a moment as everything spins and loses its shape. However, as quickly as it comes, the feeling goes away. The wolf suddenly feels his feet touching the ground again. His hands find a table behind him to hold onto to keep himself steady and, when he blinks... everything feels different.
 
 The air on his bare fur feels colder than before. The floor under his feet is simple wood rather than stone. As the wolf looks around, he realizes he is no longer in the large hallway he was before, but rather somewhere else entirely.
@@ -4149,7 +4046,7 @@ Before $name can ponder more over the implications of that, the sound of steps c
 [[Continue|Ivex's Fall]]
 
 
-:: Ivex's Fall {"position":"2228,1141","size":"100,100"}
+:: Ivex's Fall {"position":"950,5450","size":"100,100"}
 Not knowing what to expect, the wolf prepares himself as best as he can in his naked, unarmed state. The door opens casually without rush, but the person coming in...
 
 Is none other than Ivex himself.
@@ -4195,29 +4092,7 @@ He looks around. All those gemstones scattered across the floor are the source o
 [[Continue|Tying up]]
 
 
-:: To Be Continued 3 {"position":"1911,1343","size":"100,100"}
-<b>Aaaand... that's it, once more!</b>
-
-The final escape and Ivex's downfall signal the end of this month's build. The next build will be the last... and it will include nothing but the endings and all the interesting ways you can choose to make the arrogant mage pay for what he's done.
-
-I have a few things in mind, but I intend on putting up a Patreon vote to let my faithful patrons decide on one of the possibilities we might see here. What kinks will it include? What should our very, very angry wolf put the panther through? We'll see what people decide!
-
-For now, this is it! As always, I encourage you to go back and try some new things if you haven't yet. Have you seen all the ways things can go wrong before you reach this point? Their variations? Have you tried doing things in a different order?
-
-Starting from this build, you can check out the [[Archives]] (also always available in the sidebar menu) and see what you have unlocked and what's still left to be unlocked! Not only that, but in there, you'll have the ability to easily read through any endings you have already unlocked as many times as you want without having to go through the entire game to reach them. I hope you enjoy it!
-
-As always, thank you so much for playing this prototype interactive story. I really hope it's been an enjoyable ride so far!
-
-From here, you also can...
-
-[[Return to the start of the second floor|Escape Start]]
-
-OR!
-
-[[Return all the way to the beginning|Bound]]
-
-
-:: Pulled In (Text) [text] {"position":"1311,491","size":"100,100"}
+:: Pulled In (Text) [text] {"position":"925,4100","size":"100,100"}
 Intent on getting that gemstone, the wolf brings his paw up to the blob. Slowly and carefully, he approaches it to test it with a clawed finger until...
 
 He pokes at it. The whole surface ripples when he does, but the blob remains firm in place. It feels... strange. Definitely viscous and more 'wet' than he thought. Odd. Nothing in particular happens, however, and the wolf pokes it a few more times, seeing it bounce and ripple in response to it. With a small chuckle, the wolf just shakes his head and pulls his paw away.
@@ -4231,7 +4106,7 @@ With a small growl and a frown, the wolf pulls harder. The large warrior puts th
 Stopping his pulling for a moment, the wolf stops to catch his breath. Looking at the blob, $name tries to think of a solution for a moment, when all of a sudden...
 
 
-:: Pulled Further (Text) [text] {"position":"1558,464","size":"100,100"}
+:: Pulled Further (Text) [text] {"position":"1050,4100","size":"100,100"}
 The wolf's ears twitch when he feels his wrist getting engulfed in one swift motion. The blob protrudes itself forward to grab more of his paw, and before the wolf can even properly react, <b>it</b> pulls him.
 
 "Whoa!" The wolf stumbles forward, the entirety of his arm pulled into the viscous blob before he can plant his feet on the ground and use his other hand to grab onto the platform's edge and keep it from pulling him further in. With a growl, the wolf tries to pull his arm out but meets the same resistance that his finger had met before.
@@ -4249,7 +4124,7 @@ $name fights bravely, but soon his hand slips and the blob pulls him in so that 
 In one sudden, even more surprising move, the blob suddenly sucks him in with such strength that the wolf as a whole gets taken into its form.
 
 
-:: Extraction 1 (Text) [text] {"position":"1426,235","size":"100,100"}
+:: Extraction 1 (Text) [text] {"position":"1175,4100","size":"100,100"}
 <<print $name>>'s first instinct is to hold his breath as he gets pulled into the viscous blob. Keeping his muzzle well shut, the wolf thrashes as best as he can inside it. It all feels... sticky, wet and warm. It feels like being underwater, but its texture is thicker and moving inside it is hard. It takes a lot of strength from the wolf to be able to wave his arms in a feeble attempt to 'swim' out of the thing, but the blob keeps him engulfed.
 
 Before long, it starts hardening too. Moving becomes harder and harder. The wolf is left in an awkward 'floating' position with his limbs half-spread. Grunting, $name's muscles bulge with effort as he tries to keep moving, but the liquid hardens all around him, stopping the wolf altogether and keeping him well inside it.
@@ -4269,7 +4144,7 @@ As $name is busy regaining his breath, though, the wolf's eyes widen once more. 
 $name can't even frown when he feels it starts focusing on his forcefully erect cock.
 
 
-:: Extraction 2 (Text) [text] {"position":"1084,145","size":"100,100"}
+:: Extraction 2 (Text) [text] {"position":"1300,4100","size":"100,100"}
 No matter how much the wolf tries to struggle or move, it feels as if he might as well be encased in solid rock. The slime around him does not budge even a little. His arms, legs, paws, everything remains completely immobile and yet, at the same time, the slime's texture can be felt over it. Always moving, always working.
 
 Thankfully for $name, his muzzle ended up slightly tilted so that, directing his eyes downwards, he can look down at his own cock. It stands there just as erect as it was when he fell into the slime. The red spire protruding from his sheath with its veiny, dark red surface remains still as well, and yet...
@@ -4283,7 +4158,7 @@ Before the wolf can ponder on it further, the movement around his cock changes. 
 Though the slime seems solid as rock everywhere else, around his cock it moves. It flexes, its surface shifting ever so slightly around his member and, as it does, the wolf can feel... a stroke over his sensitive shaft.
 
 
-:: Extraction 3 (Text) [text] {"position":"1258,31","size":"100,100"}
+:: Extraction 3 (Text) [text] {"position":"1425,4100","size":"100,100"}
 The slime does it again. And again, and again. It starts a slow, rhythmic set of movements around the wolf's cock, kneading it at the same time as it strokes it. At first, the strokes are loose and wild, but as the slime moves up and down, it seems to adapt to his length. The strokes become wider, reaching all the way to the wolf's tapered tip and then going downwards all the way to the top of his knot, which in turn throbs and pulses, growing more engorged for the stimulation.
 
 From within the slime, $name growls again, but he also can't help but moan. Completely immobilized, the wolf can't even frown as the weird magical slime starts masturbating him without his consent.
@@ -4295,7 +4170,7 @@ At the moment, it's hard to think. As the slime keeps stroking the wolf's cock w
 There's little the wolf can do. Inside him, his rage swells. He can try harder to fight against this thing. Ivex won't get him that easily! On the other hand, it's much, much easier to just give in to the pleasure. It feels so heavenly good. It's not like there's anyone watching. Maybe giving in to it just for a little while would be beneficial as well...
 
 
-:: Forceful Extraction 1 (Text) [text] {"position":"1535,323","size":"100,100"}
+:: Forceful Extraction 1 (Text) [text] {"position":"1550,4150","size":"100,100"}
 No! The wolf lets out another muffled growl. A powerful warrior such as him will never, ever give in to this mage's perverted machinations!
 
 Huffing in outrage, the wolf redoubles his efforts to fight against the slime encasing him. His biceps, his chest, all of his muscles bulge out with effort as the wolf does his best to ignore the pleasure forcefully enveloping his cock and, instead, puts all of his might into forcing himself against the slime.
@@ -4317,7 +4192,7 @@ And the wolf is left panting from all of his efforts with a lingering ache on hi
 It can't be!
 
 
-:: Forceful Extraction 2 (Text) [text] {"position":"1672,321","size":"100,100"}
+:: Forceful Extraction 2 (Text) [text] {"position":"1675,4150","size":"100,100"}
 With even more outrage, the wolf is determined to fight again. Once more, his muscles bulge as he summons his strength. The outrage swells within him. His eyes focus down on his cock, abused by the slime moving around it, pleasuring its surface...
 
 The wolf does his best to try and ignore it. He huffs from the effort while, at the same time, he groans from the pleasure. The slime goes up and down the smooth surface of his cock, assaulting it from all sides. It feels like the softest of hands is stroking him, like a group of smooth tongues is licking it, from top to bottom, over and over again. The wolf can see its surface displacing itself as it moves from the tip of his cock to the base and back, and then, as it goes down his shaft just like all the other times...
@@ -4337,7 +4212,7 @@ The slime keeps pleasuring his cock, but as the wolf tries and tries to fight ag
 It gives the wolf hope! The slime starts speeding up the treatment of his member, maybe trying to distract him with pleasure? He won't fall for it, though! The wolf is determined to keep fighting no matter what! Just as he thinks he might get some movement done inside the slime again, however...
 
 
-:: Forceful Extraction 3 (Text) [text] {"position":"1797,324","size":"100,100"}
+:: Forceful Extraction 3 (Text) [text] {"position":"1800,4150","size":"100,100"}
 The slime hardens again. This time, however, it does not feel the same as last time.
 
 All around his body, that pressure comes from the viscous liquid again, yet around his cock, the stroking doesn't stop. If anything, it increases. While before the wolf could feel a single displacement in the slime's surface going up and down his length, a second one now appears. Then a third, then a fourth. All of them assault his cock, kneading it from different sides to the point where his cock even bobs back and forth inside the liquid as the different surfaces start masturbating it. The feeling of them around his shaft, around his <b>knot</b>, makes the wolf let out a drawn-out groan as the pleasure enforced on him increases tenfold.
@@ -4353,7 +4228,7 @@ The slime starts softening around his sheath. Then around his balls. The same to
 And then, things get even worse for the captured adventurer.
 
 
-:: Forceful Extraction End (Text) [text] {"position":"1921,324","size":"100,100"}
+:: Forceful Extraction End (Text) [text] {"position":"1925,4150","size":"100,100"}
 As if the stimulation on his cock and balls wasn't enough, the wolf feels the slime start to soften around the underside of his tail as well.
 
 Frantically, the wolf's eyes grow even wider.
@@ -4373,7 +4248,7 @@ With a drawn-out muffled moan, the wolf's exposed cock starts pulsing inside the
 It doesn't stop there, and neither does the slime. All the stimulation keeps going as the wolf's orgasm hits, shooting jet after jet of cum into the slime. His seed seems to be 'caught' by the blob. The white, pearly substance is gathered just above his cock, melding together as the wolf is forced to shoot more and more. The slime keeps milking him, kneading his cock, his knot, and pressing hard inside his ass until the wolf's cock is reduced to quick throbs, spurting the last remnants of his orgasm. Only then does the slime start slowing down, although the stimulation doesn't truly stop. It allows the wolf to catch his breath, though. And as he looks down...
 
 
-:: Extraction End 1 (Text) [text] {"position":"2058,178","size":"100,100"}
+:: Extraction End 1 (Text) [text] {"position":"2050,4075","size":"100,100"}
 The seed the wolf expelled is taken by the slime. It travels through its surface around the wolf's body and then it goes down. The wolf remembers the small hole he had seen in the altar beneath the slime and, seeing no more traces of his seed, he can only assume it was taken there.
 
 Before $name can ponder on what might happen next, it simply starts over again.
@@ -4393,7 +4268,7 @@ And then, as always, it does.
 As the wolf is being forcefully milked by the slime, a flicker of light suddenly appears above him.
 
 
-:: Forceful Extraction End 2 (Text) [text] {"position":"2194,342","size":"100,100"}
+:: Forceful Extraction End 2 (Text) [text] {"position":"2175,4150","size":"100,100"}
 The wolf's eyes grow wide as his eyes and nose recognize what the light is at the same time. 
 
 It's a candle. It burns on a special candleholder built inside the closed alcove. A bright red, large candle that looks exactly the same as the one he's seen before.
@@ -4429,7 +4304,7 @@ At one point, $name is barely aware that Ivex opens his alcove to look at him. T
 The pleasure feels unending.
 
 
-:: Gentle Extraction End 2 (Text) [text] {"position":"2198,103","size":"100,100"}
+:: Gentle Extraction End 2 (Text) [text] {"position":"2175,3825","size":"100,100"}
 The wolf's eyes grow wide as his eyes and nose recognize what the light is at the same time. 
 
 It's a candle. It burns on a special candleholder built inside the closed alcove. A bright red, large candle that looks exactly the same as the one he's seen before.
@@ -4465,7 +4340,7 @@ At one point, $name is barely aware that Ivex opens his alcove to look at him. T
 The pleasure feels unending.
 
 
-:: Gentle Extraction 1 (Text) [text] {"position":"1533,102","size":"100,100"}
+:: Gentle Extraction 1 (Text) [text] {"position":"1550,3825","size":"100,100"}
 Yeah. The wolf lets out a muffled groan. Just for a moment, $name lets himself relax inside the slime as it continues to treat his cock.
 
 Resting for just a moment feels wise. The wolf is gathering his strength, he tells himself, as he feels pleasure emanating from his loins all over his body because of what the slime does. His face and ears grow red for letting it happen, but what can he do?
@@ -4479,7 +4354,7 @@ His hips try to move reflexively to do that, but they can't. Of course, they can
 As if reading his thoughts, the wolf can swear the slime starts speeding up. Its strokes, up and down the wolf's smooth, red length, become a little tighter. The pleasure is... almost too much.
 
 
-:: Gentle Extraction 2 (Text) [text] {"position":"1673,101","size":"100,100"}
+:: Gentle Extraction 2 (Text) [text] {"position":"1675,3825","size":"100,100"}
 Despite all the pleasure, the wolf clings to his willpower. He can't let it overcome him, he has to fight it! With effort, his muscles bulge as he summons his strength. The outrage swells within him. His eyes focus down on his cock, abused by the slime moving around it, pleasuring its surface...
 
 The wolf does his best to try and ignore it. He huffs from the effort while, at the same time, he groans from the pleasure. The slime goes up and down the smooth surface of his cock, assaulting it from all sides. It feels like the softest of hands is stroking him, like a group of smooth tongues is licking it, from top to bottom, over and over again. The wolf can see its surface displacing itself as it moves from the tip of his cock to the base and back, and then, as it goes down his shaft just like all the other times...
@@ -4495,7 +4370,7 @@ The pleasure is overwhelming. The slime keeps pleasuring his cock. It's impossib
 The slime starts speeding up the treatment of his member, and then...
 
 
-:: Gentle Extraction 3 (Text) [text] {"position":"1801,101","size":"100,100"}
+:: Gentle Extraction 3 (Text) [text] {"position":"1800,3825","size":"100,100"}
 The slime softens itself even more around the wolf. It starts to feel like floating in water and, though the pleasure is almost overwhelming, even in his relaxed state, $name realizes he can move his head. Thoughts of trying to get away pop up in his head and try to fight the lust he's feeling, but before he can move at all, the slime itself does.
 
 When the wolf feels everything shifting around his body, his reflex is to move his arms or his legs to keep himself balanced. He quickly finds that that's not possible, though. Though the blob around him feels softer, it still feels sticky and impossible to push through for his limbs.
@@ -4513,7 +4388,7 @@ The slime starts softening around his sheath. Then around his balls. The same to
 And then, things grow even more intense for the captured adventurer.
 
 
-:: Gentle Extraction End (Text) [text] {"position":"1926,102","size":"100,100"}
+:: Gentle Extraction End (Text) [text] {"position":"1925,3825","size":"100,100"}
 As if the stimulation on his cock and balls wasn't enough, the wolf feels the soft slime all around his body start to move and twitch as well.
 
 The wolf's eyes grow wide.
@@ -4537,7 +4412,7 @@ With a drawn-out moan, the wolf's exposed cock starts pulsing inside the slime a
 It doesn't stop there, and neither does the slime. All the stimulation keeps going as the wolf's orgasm hits, shooting jet after jet of cum into the slime. His seed seems to be 'caught' by the blob. The white, pearly substance is gathered just above his cock, melding together as the wolf is encouraged to shoot more and more. The slime keeps milking him, kneading his cock, his knot, and inflicting pleasure all around his body until the wolf's cock is reduced to quick throbs, spurting the last remnants of his orgasm. Only then does the slime start slowing down, although the stimulation doesn't truly stop. It allows the wolf to catch his breath, though. And as he looks down…
 
 
-:: Extraction Archive Display {"position":"180,2911","size":"100,100"}
+:: Extraction Archive Display [noreturn] {"position":"1950,1000","size":"100,100"}
 <<silently>>\
   <<if $extractionGentleEnd && $extractionForcefulEnd>>
     <<set $extractionVariant = 'gentle'>>
@@ -4554,39 +4429,39 @@ It doesn't stop there, and neither does the slime. All the stimulation keeps goi
   <b>[[Bad Ending: Extraction|Extraction Archive]]</b>
   Variation: <<nobr>>
   <<if $extractionGentleEnd>>
-	<label><<radiobutton "$extractionVariant" "gentle" autocheck>> Gentle</label>
+    <label><<radiobutton "$extractionVariant" "gentle" autocheck>> Gentle</label>
   <<else>>
     <span class="helper-container">
-	  <span><label><<radiobutton "$extractionVariant" "">> <span class="disabled">Gentle</span></label></span>
-	  <small class="helper-text">The slime is fine-tuned to reward those that let it do its work...</small>
-	</span>
-	<<done>><<script>>
-	document.getElementById("radiobutton-extractionvariant-0").disabled = true;
-	<</script>><</done>>
+      <span><label><<radiobutton "$extractionVariant" "">> <span class="disabled">Gentle</span></label></span>
+      <small class="helper-text">The slime is fine-tuned to reward those that let it do its work...</small>
+    </span>
+    <<done>><<script>>
+    document.getElementById("radiobutton-extractionvariant-0").disabled = true;
+    <</script>><</done>>
   <</if>>
   <</nobr>>\
    | <<nobr>>
-	<<if $extractionForcefulEnd>>
-		<label><<radiobutton "$extractionVariant" "forceful" autocheck>> Forceful</label>
-	  <<else>>
-		<span class="helper-container">
-		  <span><label><<radiobutton "$extractionVariant" "">> <span class="disabled">Forceful</span></label></span>
-		  <small class="helper-text">The slime is fine-tuned to go rougher on those that insist on fighting it...</small>
-		</span>
-		<<done>><<script>>
-			document.getElementById("radiobutton-extractionvariant-1").disabled = true;
-		<</script>><</done>>
+    <<if $extractionForcefulEnd>>
+        <label><<radiobutton "$extractionVariant" "forceful" autocheck>> Forceful</label>
+      <<else>>
+        <span class="helper-container">
+          <span><label><<radiobutton "$extractionVariant" "">> <span class="disabled">Forceful</span></label></span>
+          <small class="helper-text">The slime is fine-tuned to go rougher on those that insist on fighting it...</small>
+        </span>
+        <<done>><<script>>
+            document.getElementById("radiobutton-extractionvariant-1").disabled = true;
+        <</script>><</done>>
     <</if>>
   <</nobr>>
 <<else>>\
   <span class="helper-container">
-  	<b><span class="disabled">Bad Ending: Extraction</span></b>
-	<small class="helper-text">Touching unknown magical things always ends badly...</small>
+      <b><span class="disabled">Bad Ending: Extraction</span></b>
+    <small class="helper-text">Touching unknown magical things always ends badly...</small>
   </span>
 <</if>>\
 
 
-:: Extraction Archive [noreturn] {"position":"475,2917","size":"100,100"}
+:: Extraction Archive [noreturn] {"position":"1950,1100","size":"100,100"}
 <<include "Pulled In (Text)">>
 
 <<include "Pulled Further (Text)">>
@@ -4632,21 +4507,13 @@ It doesn't stop there, and neither does the slime. All the stimulation keeps goi
 [[Return to the Archives|Archives]]
 
 
-:: Coming Soon {"position":"2709,1029","size":"100,100"}
-<div class="action-box">\
-  <ul class="actions">\
-	<li>[[Return to the hallway.|Chastity]]</li>
-  </ul>\
-</div>\
-
-
-:: Title Screen {"position":"879,45","size":"100,100"}
+:: Title Screen [restart] {"position":"2500,25","size":"100,100"}
 <div class="title-screen">\
-<<include "Title Screen 1">>
+<<include [[Title Screen 1]]>>
 </div>\
 
 
-:: Tying up {"position":"2374,1143","size":"100,100"}
+:: Tying up {"position":"1075,5450","size":"100,100"}
 Holding the unconscious panther up, he almost looks harmless. $name keeps growling, though. After all that time wandering around naked and erect, it doesn't bother the wolf as much anymore, but that thought alone is enough for the wolf's anger to feel bolstered. Who knows what the damned mage has done with his gear? With his trusty sword, even? Punishment of the same level should be inflicted upon him so that he can learn how it feels. But... what, exactly?
 
 Carelessly letting the panther fall down, $name looks around. Ivex's gems are scattered all over the floor. It is wise to gather them up and make sure he can't get ahold of them, but before anything, he has to make sure the mage is secure. Going around the house, $name quickly sees that he is in some kind of farmhouse. The tower was stored in the attic, but after going down a crude set of stairs, the windows reveal that there is nothing but fields and a poorly kept road surrounding it. Ivex keeps his hideout well-hidden. Luckily for the wolf, a farmhouse is well-equipped for many things, so he has no trouble finding a good bunch of thick rope in the main room, which he promptly takes upstairs to use.
@@ -4658,7 +4525,7 @@ As he shoves each of the many colored gems back into the small sack, he can't he
 [[Continue|Gemstones]]
 
 
-:: SFW Finish {"position":"2882,1284","size":"100,100"}
+:: SFW Finish {"position":"2400,5200","size":"100,100"}
 Yeah. It's not his place to punish Ivex. A long time in prison ought to be enough to make him re-think his actions. With aching loins, the wolf moves out of the room with the feline in tow. Despite everything, however, $name can't help but smile. A lot has happened, but luckily, no one will need to know about it, and his reputation is safe. Not only that, but the criminal is taken and the wolf is victorious.
 
 There is a lot of satisfaction in the thought that a large sack of gold awaits him for all this effort. In his head, the wolf already makes plans for a night of heavy drinking... and perhaps a few escorts in a tavern to make up for all the built-up need he never got to satisfy.
@@ -4666,7 +4533,7 @@ There is a lot of satisfaction in the thought that a large sack of gold awaits h
 [[Continue|Bounty Collection]]
 
 
-:: Gemstones {"position":"2514,1139","size":"100,100"}
+:: Gemstones {"position":"1200,5450","size":"100,100"}
 Frowning, the wolf hesitates, but curiosity takes over and, carefully, the wolf lets the gemstone rest on his paw... before closing it around to grip it.
 
 The gemstone starts glowing with a faint blue light.
@@ -4692,7 +4559,7 @@ $name shoves each and every one of them into the pouch until there are only four
 [[Continue|Chastity]]
 
 
-:: Punishments {"position":"2532,1403","size":"100,100"}
+:: Punishments {"position":"1425,5575","size":"100,100"}
 The wolf's hands curl into tight fists. He can barely control his growling, looking down at Ivex. Will getting locked up in some mage's containment chamber, or whatever else the guild decides to do to him, be enough to make him pay for what he's done? Of course not. They don't know half of what he's done, and even if he tells them, it won't have the same impact as seeing it.
 
 With the sack of gemstones in hand, the wolf stomps over to the tied-up feline and lifts him up by the scruff. Ivex shifts and grunts in his sleep, but doesn't wake up quite yet.
@@ -4711,18 +4578,18 @@ Thinking back to his experience in the tower and Ivex's journal, his report on w
 
 <div class="action-box">\
   <ul class="actions">\
-  	<li>[[Wake him up. He needs to be awake to experience this.|Personal Vengeance]]</li>
-	<<if $enthrallmentEnding>>\
-  	  <li>[[ [Unlocked: Enthrallment] Put a pendant around his neck.|Enthrallment Vengeance]]</li>
-	<</if>>\
-	<<if $extractionEnding>>\
-  	  <li>[[ [Unlocked: Extraction] Throw him into that blob.|Extraction Vengeance]]</li>
-	<</if>>\
+      <li>[[Wake him up. He needs to be awake to experience this.|Personal Vengeance]]</li>
+    <<if $enthrallmentEnding>>\
+        <li>[[ [Unlocked: Enthrallment] Put a pendant around his neck.|Enthrallment Vengeance]]</li>
+    <</if>>\
+    <<if $extractionEnding>>\
+        <li>[[ [Unlocked: Extraction] Throw him into that blob.|Extraction Vengeance]]</li>
+    <</if>>\
   </ul>\
 </div>
 
 
-:: Personal Vengeance {"position":"2596,1533","size":"100,100"}
+:: Personal Vengeance [end] {"position":"1375,5975","size":"100,100"}
 <<silently>>
 <<set $gagged = false>>
 <<set $randomGag to random(1, 2)>>
@@ -4780,12 +4647,12 @@ What to do to him first?
 
 <div class="action-box">\
   <ul class="actions">\
-  	<li>[[Strip him.|Strip]]</li>
+      <li>[[Strip him.|Strip]]</li>
   </ul>\
 </div>
 
 
-:: Enthrallment Vengeance {"position":"2088,1518","size":"100,100"}
+:: Enthrallment Vengeance [end] {"position":"1600,5575","size":"100,100"}
 <<include "Enthrallment Vengeance (Text)">>
 
 <span class="good-ending">Ending: <i>Ivex's Enthrallment</i></span>
@@ -4793,7 +4660,7 @@ What to do to him first?
 [[Continue|Ivex Enthrallment 1]]
 
 
-:: Extraction Vengeance {"position":"3126,1535","size":"100,100"}
+:: Extraction Vengeance [end] {"position":"1650,5750","size":"100,100"}
 <<include "Extraction Vengeance (Text)">>
 
 <span class="good-ending">Ending: <i>Ivex's Extraction</i></span>
@@ -4801,13 +4668,13 @@ What to do to him first?
 [[Continue|Ivex Extraction 1]]
 
 
-:: Ivex Extraction 1 {"position":"3126,1685","size":"100,100"}
+:: Ivex Extraction 1 {"position":"1775,5750","size":"100,100"}
 <<include "Ivex Extraction 1 (Text)">>
 
 [[Continue|Ivex Extraction 2]]
 
 
-:: Chastity {"position":"2524,1277","size":"100,100"}
+:: Chastity {"position":"1325,5450","size":"100,100"}
 It is just as perverted as some of the other ones he found, yet even though its effects make the wolf's eyes grow wide, it also makes his tail wag enthusiastically.
 
 It's perfect.
@@ -4840,84 +4707,84 @@ The wolf's member throbs in excitement at the thought. Now he can't wait for the
 
 <div class="action-box">\
   <ul class="actions">\
-  	<li>[[Punish Ivex for his misdeeds.|Punishments]]</li>
-  	<li>[[Turn Ivex in and be done with it.|Turn In]]</li>
+      <li>[[Punish Ivex for his misdeeds.|Punishments]]</li>
+      <li>[[Turn Ivex in and be done with it.|Turn In]]</li>
   </ul>\
 </div>
 
 
-:: Ivex Extraction 2 {"position":"3126,1835","size":"100,100"}
+:: Ivex Extraction 2 {"position":"1900,5750","size":"100,100"}
 <<include "Ivex Extraction 2 (Text)">>
 
 [[Continue|Ivex Extraction 3]]
 
 
-:: Ivex Extraction 3 {"position":"3126,1985","size":"100,100"}
+:: Ivex Extraction 3 {"position":"2025,5750","size":"100,100"}
 <<include "Ivex Extraction 3 (Text)">>
 
 [[Continue|Ivex Extraction Final]]
 
 
-:: Ivex Extraction Final {"position":"3126,2135","size":"100,100"}
+:: Ivex Extraction Final {"position":"2150,5750","size":"100,100"}
 <<include "Ivex Extraction Final (Text)">>
 
 [[Continue|Ivex Extraction End]]
 
 
-:: Ivex Extraction End {"position":"3126,2285","size":"100,100"}
+:: Ivex Extraction End {"position":"2275,5750","size":"100,100"}
 <<include "Ivex Extraction End (Text)">>
 
 [[To the end|Extraction Finish]]
 
 
-:: Ivex Enthrallment 1 {"position":"2089,1671","size":"100,100"}
+:: Ivex Enthrallment 1 {"position":"1725,5575","size":"100,100"}
 <<include "Ivex Enthrallment 1 (Text)">>
 
 [[Continue|Ivex Enthrallment 2]]
 
 
-:: Ivex Enthrallment 2 {"position":"2089,1821","size":"100,100"}
+:: Ivex Enthrallment 2 {"position":"1850,5575","size":"100,100"}
 <<include "Ivex Enthrallment 2 (Text)">>
 
 [[Continue|Ivex Enthrallment 3]]
 
 
-:: Ivex Enthrallment 3 {"position":"2089,1971","size":"100,100"}
+:: Ivex Enthrallment 3 {"position":"1975,5575","size":"100,100"}
 <<include "Ivex Enthrallment 3 (Text)">>
 
 [[Continue|Ivex Enthrallment 4]]
 
 
-:: Ivex Enthrallment 4 {"position":"2087,2119","size":"100,100"}
+:: Ivex Enthrallment 4 {"position":"2100,5575","size":"100,100"}
 <<include "Ivex Enthrallment 4 (Text)">>
 
 [[Continue|Ivex Enthrallment 5]]
 
 
-:: Ivex Enthrallment 5 {"position":"2087,2269","size":"100,100"}
+:: Ivex Enthrallment 5 {"position":"2225,5575","size":"100,100"}
 <<include "Ivex Enthrallment 5 (Text)">>
 
 [[Continue|Ivex Enthrallment Final]]
 
 
-:: Ivex Enthrallment Final {"position":"2087,2419","size":"100,100"}
+:: Ivex Enthrallment Final {"position":"2350,5575","size":"100,100"}
 <<include "Ivex Enthrallment Final (Text)">>
 
 [[Continue|Ivex Enthrallment End]]
 
 
-:: Ivex Enthrallment End {"position":"2089,2663","size":"100,100"}
+:: Ivex Enthrallment End {"position":"2475,5575","size":"100,100"}
 <<include "Ivex Enthrallment End (Text)">>
 
 <div class="action-box">\
   <ul class="actions">\
-  	<li>[[Keep Ivex as a personal thrall.|Enthrallment Finish]]</li>
-  	<li>[[Take him back as he is and collect the bounty.|Bounty Collection]]</li>
+      <li>[[Keep Ivex as a personal thrall.|Enthrallment Finish]]</li>
+      <li>[[Take him back as he is and collect the bounty.|Bounty Collection]]</li>
   </ul>\
 </div>
 
 
-:: Gag {"position":"2827,1814","size":"100,100"}
+:: Gag {"position":"1225,6425","size":"100,100"}
 <<set $gagged = true>>\
 Yeah, silencing him might be a good idea. Given the place Ivex has chosen to hide, it is unlikely that anyone would hear him, but his prattling is growing annoying pretty quickly.
 
@@ -4927,14 +4794,14 @@ The wolf looks around. There's a few options on how to silence him. What to gag 
 
 <div class="action-box">\
   <ul class="actions">\
-  	<li>[[With a piece of rope.|Gag with Rope]]</li>
-  	<li>[[With a silence spell.|Gag with Spell]]</li>
-  	<li>[[With his own undergarments.|Gag with Underwear]]</li>	
+      <li>[[With a piece of rope.|Gag with Rope]]</li>
+      <li>[[With a silence spell.|Gag with Spell]]</li>
+      <li>[[With his own undergarments.|Gag with Underwear]]</li>	
   </ul>\
 </div>
 
 
-:: Strip {"position":"2481,1665","size":"100,100"}
+:: Strip {"position":"1375,6175","size":"100,100"}
 <<if !$stage0Clear>>\
 Memories of the perverted panther getting rid of his clothes back in the tower come to the wolf's mind. Narrowing his eyes towards the feline, he reaches up to him.
 
@@ -4978,15 +4845,15 @@ Still, the show must go on. Kneeling next to the panther, the wolf drags him clo
 
 <div class="action-box">\
   <ul class="actions">\
-  	<li>[[Show him.|Fondle]]</li>
-	<<if !$gagged>>\
-  	<li>[[Gag him.|Gag]]</li>
-	<</if>>\
+      <li>[[Show him.|Fondle]]</li>
+    <<if !$gagged>>\
+      <li>[[Gag him.|Gag]]</li>
+    <</if>>\
   </ul>\
 </div>
 
 
-:: Gag with Rope {"position":"2939,1710","size":"100,100"}
+:: Gag with Rope {"position":"1475,6500","size":"100,100"}
 Better to go with the classics.
 
 Cutting a spare piece of rope with his teeth, the wolf then ties it into a thick, single piece and, nonchalantly, shoves it into the maw of the complaining panther.
@@ -5008,7 +4875,7 @@ Sweet, sweet silence.
 <</if>>\
 
 
-:: Gag with Spell {"position":"2940,1812","size":"100,100"}
+:: Gag with Spell {"position":"1375,6500","size":"100,100"}
 Why not use Ivex's own tools against him?
 
 Shoving his paw into the pouch of gemstones, the wolf pulls out a gray-ish one that he remembers was a spell of silence. Clutching it into his paw, the wolf activates it and sees how to use it.
@@ -5032,7 +4899,7 @@ Sweet, sweet silence.
 <</if>>\
 
 
-:: Gag with Underwear {"position":"2940,1915","size":"100,100"}
+:: Gag with Underwear {"position":"1575,6500","size":"100,100"}
 The wolf smirks. It's time to get creative.
 
 Reaching out for Ivex's cut and discarded clothes, it's easy to find the stained piece of cloth he had wrapped around his crotch. 
@@ -5058,7 +4925,7 @@ Sweet, sweet silence.
 <</if>>\
 
 
-:: Fondle {"position":"2481,1815","size":"100,100"}
+:: Fondle {"position":"1500,6175","size":"100,100"}
 <<set $revengeStage = 1>>\
 The wolf takes a few heavy steps toward the panther. Seeing $name approaching is enough to make Ivex look fearful again. He tries to wiggle away, but a simple pull on his tail is enough to drag him back closer. Then, the wolf gets down on all fours over the bound mage.
 
@@ -5104,16 +4971,16 @@ $name continues to hold the panther down and forcefully stimulate him. What to d
 
 <div class="action-box">\
   <ul class="actions">\
-  	<li>[[Use one of his spells on him.|Spell]]</li>
-  	<li>[[Continue stimulating him.|Edge]]</li>	
-	<<if !$gagged>>\
-  	<li>[[Gag him.|Gag]]</li>
-	<</if>>\
+      <li>[[Use one of his spells on him.|Spell]]</li>
+      <li>[[Continue stimulating him.|Edge]]</li>	
+    <<if !$gagged>>\
+      <li>[[Gag him.|Gag]]</li>
+    <</if>>\
   </ul>\
 </div>
 
 
-:: Spell {"position":"2717,2091","size":"100,100"}
+:: Spell {"position":"1875,6375","size":"100,100"}
 <<if !$spellOptions>>\
 Yes. Ivex has made so many spells with the sole intent of using them on people for his own perversion. Why not use some of these against him?
 
@@ -5139,27 +5006,27 @@ Which spell would be best to use right now?
 
 <div class="action-box">\
   <ul class="actions">\
-  	<li>[[Use a Lust spell on him.|Lust Spell]]</li>  
-	<<if $interrogationEndingFreeze>>\
-  	  <li>[[ [Unlocked: Freeze] Use an ice spell on him.|Ice Spell]]</li>
-	<<else>>\
-	  <li><span class="disabled">[Locked: Interrogation - ???] ???</span></li>
-	<</if>>\
-	<<if $interrogationEndingShock>>\
-  	  <li>[[ [Unlocked: Shock] Use an lightning spell on him.|Lightning Spell]]</li>
-	<<else>>\
-	  <li><span class="disabled">[Locked: Interrogation - ???] ???</span></li>
-	<</if>>\	
-	<<if $revengeStage == 2 || $revengeStage == 1>>\
-	<li>[[On second thought, maybe no spells just yet...|Hold]]</li>
-	<<elseif $revengeStage == 3>>\
-	<li>[[On second thought, maybe no spells just yet...|Fucking]]</li>
-	<</if>>\
+      <li>[[Use a Lust spell on him.|Lust Spell]]</li>  
+    <<if $interrogationEndingFreeze>>\
+        <li>[[ [Unlocked: Freeze] Use an ice spell on him.|Ice Spell]]</li>
+    <<else>>\
+      <li><span class="disabled">[Locked: Interrogation - ???] ???</span></li>
+    <</if>>\
+    <<if $interrogationEndingShock>>\
+        <li>[[ [Unlocked: Shock] Use an lightning spell on him.|Lightning Spell]]</li>
+    <<else>>\
+      <li><span class="disabled">[Locked: Interrogation - ???] ???</span></li>
+    <</if>>\	
+    <<if $revengeStage == 2 || $revengeStage == 1>>\
+    <li>[[On second thought, maybe no spells just yet...|Hold]]</li>
+    <<elseif $revengeStage == 3>>\
+    <li>[[On second thought, maybe no spells just yet...|Fucking]]</li>
+    <</if>>\
   </ul>\
 </div>
 
 
-:: Edge {"position":"2280,2318","size":"100,100"}
+:: Edge {"position":"1675,6025","size":"100,100"}
 <<if !$ivexEdging>>
 $name is fond of the good, old methods, and this seems to be extra effective on the mage.
 
@@ -5211,7 +5078,7 @@ After he's satisfied, $name wipes his hand on the panther's already matted fur a
 <</if>>\
 
 
-:: Ice Spell {"position":"2905,2218","size":"100,100"}
+:: Ice Spell {"position":"1775,6500","size":"100,100"}
 Pulling out the light blue gemstone, the wolf clutches it in his hand and looks down at Ivex.
 
 <<if !$freezeSpell>>\
@@ -5269,7 +5136,7 @@ After he's satisfied, Ivex's member is left shy and cold inside his sheath, read
 <</if>>\
 
 
-:: Lightning Spell {"position":"2906,2103","size":"100,100"}
+:: Lightning Spell {"position":"1875,6500","size":"100,100"}
 Pulling out the purple gemstone, the wolf clutches it in his hand and looks down at Ivex.
 
 <<if !$shockSpell>>\
@@ -5331,7 +5198,7 @@ Before long, he gets bored of it. Ivex's member seems to have shirked away a lit
 <</if>>\
 
 
-:: Hold {"position":"2484,1991","size":"100,100"}
+:: Hold {"position":"1675,6175","size":"100,100"}
 <<set $revengeStage = 2>>\
 <<if !$stage1Clear>>\
   <<if !$gagged>>\
@@ -5359,17 +5226,17 @@ Before long, he gets bored of it. Ivex's member seems to have shirked away a lit
     <<set $ivexEdges = 0>>\
   <</if>>\
   <<if $ivexEdges <= 2>>\
-	The wolf roughly grabs the bound mage's caged sheath to feel it up.
-	The panther's arousal feels... <span style="color:#e7d778">gripping</span>.
+    The wolf roughly grabs the bound mage's caged sheath to feel it up.
+    The panther's arousal feels... <span style="color:#e7d778">gripping</span>.
   <<elseif $ivexEdges > 2 && $ivexEdges <= 3>>\
-	The wolf roughly grabs the bound mage's caged sheath to feel it up.
-	The panther's arousal feels... <span style="color:#bb5e39">powerful</span>.
+    The wolf roughly grabs the bound mage's caged sheath to feel it up.
+    The panther's arousal feels... <span style="color:#bb5e39">powerful</span>.
   <<elseif $ivexEdges > 3 && $ivexEdges <= 5>>\
   The wolf roughly grabs the bound mage's caged sheath to feel it up.
   The panther's arousal feels... <span style="color:#bf5150">overpowering</span>.
   <<elseif $ivexEdges > 5>>\
-	The wolf roughly grabs the bound mage's caged sheath to feel it up.
-	The panther's arousal feels... <span style="color:#e92940">overwhelming</span>.
+    The wolf roughly grabs the bound mage's caged sheath to feel it up.
+    The panther's arousal feels... <span style="color:#e92940">overwhelming</span>.
   <<else>>\
   <</if>>\
 
@@ -5380,17 +5247,17 @@ Before long, he gets bored of it. Ivex's member seems to have shirked away a lit
 
 <div class="action-box">\
   <ul class="actions">\
-  	<li>[[Use one of his spells on him.|Spell]]</li>
-  	<li>[[Stimulate and tease him by hand.|Edge]]</li>
-	<li>[[Fuck him.|Fuck]]</li>
-	<<if !$gagged>>\
-  	<li>[[Gag him.|Gag]]</li>
-	<</if>>\
+      <li>[[Use one of his spells on him.|Spell]]</li>
+      <li>[[Stimulate and tease him by hand.|Edge]]</li>
+    <li>[[Fuck him.|Fuck]]</li>
+    <<if !$gagged>>\
+      <li>[[Gag him.|Gag]]</li>
+    <</if>>\
   </ul>\
 </div>
 
 
-:: Lust Spell {"position":"2788,2337","size":"100,100"}
+:: Lust Spell {"position":"1975,6500","size":"100,100"}
 Pulling out the pink gemstone, the wolf clutches it in his hand and looks down at Ivex.
 
 <<if !$lustSpell>>\
@@ -5454,7 +5321,7 @@ Hearing Ivex panting in desperate frustration like he made him pant in the past 
 <</if>>\
 
 
-:: Fuck {"position":"2484,2141","size":"100,100"}
+:: Fuck {"position":"1800,6175","size":"100,100"}
 It's high time Ivex deals with the consequences of what he has caused.
 
 The wolf's member throbs in excitement. $name keeps one paw firmly on Ivex's shoulder, holding him down on his back, but the other? The wolf's eyes lock with the panther's and he brings it down to his own cock. The wolf gives it a stroke, from top to bottom. The bright red, veiny spire has been aching for this for hours and hours. Ever since he was forced to breathe in that candle. This fire inside him has been burning for too long.
@@ -5507,7 +5374,7 @@ Ivex is simply forced to take the wolf's pounding.
 [[Continue|Fucking]]
 
 
-:: Fucking {"position":"2484,2291","size":"100,100"}
+:: Fucking {"position":"1975,6175","size":"100,100"}
 <<if !$stage2Clear>>\
 <<set $revengeStage = 3>>\
 "Fuck..." the wolf groans. His lusty growling is constant as he continues to fuck the panther hard. In and out, the smaller feline's ass already taking his size with more ease, yet still feeling delightfully tight around his cock.
@@ -5573,17 +5440,17 @@ Holding himself like that, the wolf wonders, what to do to him next?
 
 <div class="action-box">\
   <ul class="actions">\
-  	<li>[[Use one of his spells on him.|Spell]]</li>
-  	<li>[[Stimulate and tease him by hand.|Edge]]</li>
-	<li>[[Knot him.|Knot]]</li>
-	<<if !$gagged>>\
-  	<li>[[Gag him.|Gag]]</li>
-	<</if>>\
+      <li>[[Use one of his spells on him.|Spell]]</li>
+      <li>[[Stimulate and tease him by hand.|Edge]]</li>
+    <li>[[Knot him.|Knot]]</li>
+    <<if !$gagged>>\
+      <li>[[Gag him.|Gag]]</li>
+    <</if>>\
   </ul>\
 </div>
 
 
-:: Knot {"position":"2484,2441","size":"100,100"}
+:: Knot {"position":"2150,6175","size":"100,100"}
 No holding back. The wolf's lust is too strong and his instincts start speaking louder. There has been enough messing with the panther. It's time to finish it.
 
 Ivex just yelps and mewls when the wolf pulls him up and grips him hard against his chest again. The smaller feline squirms, certainly knowing what's coming, but the wolf stops it with nothing but one threatening growl.
@@ -5613,7 +5480,7 @@ Putting more strength into his hips, $name pushes in one last time and, this tim
 [[Continue|Knotted Mage]]
 
 
-:: Knotted Mage {"position":"2484,2591","size":"100,100"}
+:: Knotted Mage {"position":"2275,6175","size":"100,100"}
 <<if !$gagged>>\
 "AAAH!!" Ivex yells.
 <<else>>\
@@ -5660,7 +5527,7 @@ It will take some time for the wolf's knot to come down, but $name is not in a h
 [[Continue|Pull Out Finish]]
 
 
-:: Pull Out Finish {"position":"2573,2733","size":"100,100"}
+:: Pull Out Finish {"position":"2400,6175","size":"100,100"}
 The wolf spends his time locked with the feline to play with him some more. Watching him squirm and whine turns out to be extremely therapeutic. To <<print $name>>, it's almost as if all the humiliation he went through in the tower didn't happen. Almost.
 <<if $ivexClimax>>\
 
@@ -5688,13 +5555,13 @@ The wolf does. He wonders if Ivex has had enough punishment or if he should add 
 
 <div class="action-box">\
   <ul class="actions">\
-  	<li>[[Add a punishing touch for the journey.|Pull Out Punishment Finish]]</li>
-  	<li>[[Take him back as he is and collect the bounty.|Bounty Collection]]</li>
+      <li>[[Add a punishing touch for the journey.|Pull Out Punishment Finish]]</li>
+      <li>[[Take him back as he is and collect the bounty.|Bounty Collection]]</li>
   </ul>\
 </div>
 
 
-:: Enthrallment Finish {"position":"2394,3056","size":"100,100"}
+:: Enthrallment Finish {"position":"2600,5500","size":"100,100"}
 <<if !$enthralmentIvexEnding>>\
 <<set $enthralmentIvexEndingUnlock = true>>\
 <</if>>\
@@ -5705,7 +5572,7 @@ The wolf does. He wonders if Ivex has had enough punishment or if he should add 
 [[The End|The End]]
 
 
-:: Extraction Finish {"position":"2810,3060","size":"100,100"}
+:: Extraction Finish {"position":"2400,5750","size":"100,100"}
 <<if !$extractionIvexEnding>>\
 <<set $extractionIvexEndingUnlock = true>>\
 <</if>>\
@@ -5716,7 +5583,7 @@ The wolf does. He wonders if Ivex has had enough punishment or if he should add 
 [[The End|The End]]
 
 
-:: Turn In {"position":"2704,1282","size":"100,100"}
+:: Turn In {"position":"1450,5450","size":"100,100"}
 Before Ivex can wake up, $name approaches him. He grunts looking down at the mage, but picks him up and places the unconscious, bound mage over his shoulder to get ready to take him back.
 
 Looking down, however, the wolf sees his member still aching. Surely Ivex's candle effect must wear off at some point, but it's still uncomfortable. Even the large wolf can't help but blush remembering his time bound on that cross. The way Ivex taunted and touched him, the threats the feline made...
@@ -5729,13 +5596,13 @@ $name takes a deep breath. Should he really just take Ivex to be arrested and no
 
 <div class="action-box">\
   <ul class="actions">\
-  	<li>[[Yes. Turn Ivex in and be done with it.|SFW Finish]]</li>  
-  	<li>[[No... he deserves some punishment. Punish Ivex for his misdeeds.|Punishments]]</li>
+      <li>[[Yes. Turn Ivex in and be done with it.|SFW Finish]]</li>  
+      <li>[[No... he deserves some punishment. Punish Ivex for his misdeeds.|Punishments]]</li>
   </ul>\
 </div>
 
 
-:: Pull Out Punishment Finish {"position":"2512,2883","size":"100,100"}
+:: Pull Out Punishment Finish {"position":"2525,6175","size":"100,100"}
 $name decides that, since Ivex's arrogance seems to know no bounds, he can deal with a little extra punishment during the trip back.
 
 With a smirk, the wolf looks down at Ivex, who in turn glares daggers up at him, but is unable to say anything gagged as he is. Not breaking eye contact, the wolf shoves his paw into the gem pouch again and... pulls out the pink, lust spell gemstone.
@@ -5759,7 +5626,7 @@ $name just smiles. He has something he can fuck on the way if he needs to.
 [[Continue|Bounty Collection]]
 
 
-:: Bounty Collection {"position":"2606,3062","size":"100,100"}
+:: Bounty Collection {"position":"2950,5650","size":"100,100"}
 Lucky for the wolf, he manages to find a worn, old pair of pants in the farmhouse Ivex had made his base. They are far too short for him, but they will do, so that at least he's not naked.
 
 Gathering what supplies he can, the wolf sets off with everything in hand: Ivex's tower inside the large gemstone, the pouch of magic gems and, most importantly, Ivex.
@@ -5777,7 +5644,7 @@ Or, at least, he will try to.
 [[The End|The End]]
 
 
-:: The End {"position":"2603,3330","size":"100,100"}
+:: The End [end] {"position":"2775,5050","size":"100,100"}
 The End.
 <<if $personalEndingUnlock>>\
 <<set $personalEnding = true>>\
@@ -5814,14 +5681,14 @@ From here on, you can...
 
 <div class="action-box">\
   <ul class="actions">\  
-  	<li>[[Return to the point of escaping the tower.|Outside]]</li>
-  	<li>[[Return to the point of escaping the first floor.|Escape Start]]</li>	
-  	<li>[[Return to the beginning of the game.|Title Screen]]</li>
+      <li>[[Return to the point of escaping the tower.|Outside]]</li>
+      <li>[[Return to the point of escaping the first floor.|Escape Start]]</li>	
+      <li>[[Return to the beginning of the game.|Title Screen]]</li>
   </ul>\
 </div>
 
 
-:: Enthrallment Vengeance (Text) [text] {"position":"1986,1518","size":"100,100"}
+:: Enthrallment Vengeance (Text) [text] {"position":"1600,5475","size":"100,100"}
 Deciding on his vengeance, the wolf smirks. While the panther is still unconscious on the floor, the wolf turns towards the tower inside the gemstone, picks the red teleportation stone up and clutches it again.
 
 $name finds the transportation easier this time. Perhaps because he was ready for it? Regardless, the wolf turns up at the exact same spot he left. From there, it is a simple matter to return to the lion's room where the large feline still squirms on the ground.
@@ -5849,7 +5716,7 @@ Recognition flares up in Ivex's eyes right away.
 The wolf doesn't stop.
 
 
-:: Ivex Enthrallment 1 (Text) [text] {"position":"1985,1671","size":"100,100"}
+:: Ivex Enthrallment 1 (Text) [text] {"position":"1725,5475","size":"100,100"}
 "YOU FOOL!" Ivex yells as the pendant is brought up to his head. "When I get out of this, I will make you regret all of this a thousand times ov-"
 
 $name lowers the pendant, placing it around his neck. The gemstone emits a glow for a moment and, as soon as it does, Ivex's eyes grow wide for just a moment and his words get interrupted. Then, soon after, his expression of outrage and anger fades into a neutral one. The same one the lion holds all the time.
@@ -5877,7 +5744,7 @@ Watching the bound feline standing still and without expression, the wolf smirks
 Maybe it's time to do something about that, too.
 
 
-:: Ivex Enthrallment 2 (Text) [text] {"position":"1986,1821","size":"100,100"}
+:: Ivex Enthrallment 2 (Text) [text] {"position":"1850,5475","size":"100,100"}
 Deciding to test things out before pushing anything further, the wolf grabs Ivex by his scruff and pulls him up to his knees. The panther stands firm on them, but says nothing and does not change his expression. He does seem to be completely at the wolf's mercy.
 
 Placing the bound captive properly in front of him, the wolf keeps one hand on his head holding his fur, but with the other... he points his hard, red member down towards Ivex.
@@ -5893,7 +5760,7 @@ The red, tapered member throbs in response to Ivex's continuous licking. The pan
 There is little to do but take advantage of it.
 
 
-:: Ivex Enthrallment 3 (Text) [text] {"position":"1987,1972","size":"100,100"}
+:: Ivex Enthrallment 3 (Text) [text] {"position":"1975,5475","size":"100,100"}
 "Stop," the wolf orders, and the panther ceases his licking right away.
 
 With a pleased smile, the wolf grips his cock at the base again and, taking another step forward, presses his member coated with saliva against Ivex's muzzle. The feline does not react as the wolf grinds and wipes his member against his face, smearing it with both drool and pre-cum.
@@ -5919,7 +5786,7 @@ $name smirks. The wolf's hand on his own cock starts stroking it properly. The w
 The wolf's smile widens. He does not stop stroking his cock as he walks toward the door. "Then follow me."
 
 
-:: Ivex Enthrallment 4 (Text) [text] {"position":"1983,2119","size":"100,100"}
+:: Ivex Enthrallment 4 (Text) [text] {"position":"2100,5475","size":"100,100"}
 It doesn't take long for $name to find the bedroom. It looks neat, but a layer of dust on most furniture indicates it likely hasn't been used in a while. Ivex probably sleeps inside his magical tower of nonsense. The wolf points at it, though.
 
 "Get on the bed, panther. On all fours."
@@ -5943,7 +5810,7 @@ Spitting on his paw, the wolf then smears it around his cock, lubricating it a l
 Why should he do all the work?
 
 
-:: Ivex Enthrallment 5 (Text) [text] {"position":"1985,2269","size":"100,100"}
+:: Ivex Enthrallment 5 (Text) [text] {"position":"2225,5475","size":"100,100"}
 Pushing the feline to the side, $name himself lies on the bed on his back. The panther looks at him with no emotion, remaining on all fours at the corner of the bed as the wolf spreads his legs and brings his hand down to give his knot a small squeeze. Then, he looks at the panther and smiles.
 
 "Climb up and line your rear with my cock," he orders.
@@ -5967,7 +5834,7 @@ Inch by inch, the feline takes his cock, and the wolf gets a front-row seat watc
 "Now... ride it. Fuck yourself with my cock."
 
 
-:: Ivex Enthrallment Final (Text) [text] {"position":"1986,2419","size":"100,100"}
+:: Ivex Enthrallment Final (Text) [text] {"position":"2350,5475","size":"100,100"}
 The sensations of the panther going back up on his cock are amazing for the lust-filled wolf. $name lets himself moan in pleasure as the panther moves up... and then comes down again, impaling himself on his cock all over again. Ivex's expression does not change, but the little grunts of effort coming from him are like music to the wolf's ear. The blue gemstone on the feline's pendant continues glowing as the enthralled mage is forced to obey his every command.
 
 "Faster... fuck..." $name growls, and the panther obeys.
@@ -5995,7 +5862,7 @@ Only the sound of Ivex's small grunts can be heard as the panther keeps jerking 
 The wolf is happy and content in laying down like that for a while, with the mage that fucked him over stuck to his cock and forced to pleasure himself in the most frustrating of ways.
 
 
-:: Ivex Enthrallment End (Text) [text] {"position":"1987,2661","size":"100,100"}
+:: Ivex Enthrallment End (Text) [text] {"position":"2475,5475","size":"100,100"}
 $name takes his sweet time. He is definitely not in a hurry anymore. The wolf enjoys the feeling of the panther's ass around his cock, the way it grips his grown knot, and the way it clenches while Ivex continues to try and try to jerk off to no avail.
 
 While waiting for his knot to recede, he looks at the feline. Ivex stares at nothing in particular while his hand continues to tease and work his sheath. His cock, stuck inside it, looks absolutely desperate to grow, but the magic barrier keeping his sheath sealed is strong. The barrier, however, does not seem to apply to liquids, as a steady flow of pre-cum keeps coming from Ivex's sheath to run down towards Ivex's balls and, much to his annoyance, mat the fur of his crotch as well.
@@ -6027,7 +5894,7 @@ What would it be like to have a thrall himself? Would a large bag of gold really
 No, that wouldn't be right. ...Would it? Ivex has made thralls of others and he had no intention of letting them go. It is poetic justice that he ends up meeting the same fate. Besides, slaves are common in most cities. Wouldn't that be a fitting punishment for the mage after all he's done?
 
 
-:: Enthrallment Finish (Text) [text] {"position":"2291,3056","size":"100,100"}
+:: Enthrallment Finish (Text) [text] {"position":"2600,5400","size":"100,100"}
 A smile grows across the wolf's muzzle. Yeah, there is no reason to waste such a good thrall by delivering him in for gold. Thinking back on all Ivex did to him in the tower and, even more so, what Ivex planned to do to him still, fills the wolf with certainty that this is the right way to go about it.
 
 "This is a pretty look for you," $name comments. "You don't mind staying naked, do you? I think I might just keep you naked all the time. It's not like you will mind all the stares, right?"
@@ -6057,7 +5924,7 @@ With a new 'companion' by his side, the wolf moves on. The life of an adventurer
 Or, at least, he will try to.
 
 
-:: Extraction Vengeance (Text) [text] {"position":"3230,1535","size":"100,100"}
+:: Extraction Vengeance (Text) [text] {"position":"1650,5850","size":"100,100"}
 Deciding on his vengeance, the wolf smirks. He picks Ivex up. Taking him inside the tower is risky, as he seemed to be more powerful there, therefore it has to be done before he wakes up. It'll be worth it, hopefully.
 
 With ease, the large wolf lifts the unconscious panther up to carry him over his shoulder. He then takes the red gemstone he made to get out of the tower, looks at it, and grips it again, hoping it'll work...
@@ -6075,7 +5942,7 @@ It softens his impact. The wolf takes a step back, not sure what to expect. Much
 It is at that moment that Ivex's droopy eyes start to open. The blob continues to engulf him, moving the feline to its center. Ivex looks confused for a moment, but then... his eyes grow wide. They meet the wolf's, then dart all around him, and his expression shifts to one of rage... and panic.
 
 
-:: Ivex Extraction 1 (Text) [text] {"position":"3231,1684","size":"100,100"}
+:: Ivex Extraction 1 (Text) [text] {"position":"1775,5850","size":"100,100"}
 The panther's muzzle moves, but if he makes any sound, it doesn't make it past the thick, viscous substance of the blob. Ivex's bound arms and legs move for a moment, but as soon as they start, they immediately slow down, and the wolf can see that the thing is hardening around them to keep the panther still. Frozen in place, Ivex's eyes dart back and forth until they meet the wolf's. $name can see him frown, his expression shifting to one of anger, but his face too freezes inside the thing. Whatever this blob is, it doesn't seem keen on letting the feline move. Good. It works even better than the wolf expected.
 
 $name wipes his paws and smiles triumphantly. Seeing Ivex trapped inside his own device is extremely pleasant. For a few moments, he watches the feline as he clearly struggles to move. His small muscles contract here or there, showing he's trying to put effort into moving his limbs, but none of it amounts to anything. What a weakling! After a while, it is clear that the feline is trapped and cannot get out. The wolf is ready to leave him there, for in fact, he doesn't even know how he would go about getting Ivex out of it. The mages in the adventurer's guild will surely figure something out when he delivers the panther and his tower to them in a few days. Taking a step back, the wolf is about to leave, but then something else catches his eye.
@@ -6089,7 +5956,7 @@ The thing moves around it as if massaging his sheath, except...
 The yellow glow surrounding it stops it. The blob seems keen on continuing to stimulate it for some reason, but the yellow glow blocks it. The wolf raises an eyebrow watching it all unfold. Is this thing another one of Ivex's perverted machinations?
 
 
-:: Ivex Extraction 2 (Text) [text] {"position":"3231,1834","size":"100,100"}
+:: Ivex Extraction 2 (Text) [text] {"position":"1900,5850","size":"100,100"}
 The panther seems angrier and more distressed as time goes on. The blob moving around his sheath grows more active. Even from outside, it looks as if it is actively stroking it, trying to stimulate it for some reason.
 
 In response to that, $name can see how Ivex's body reacts. Since the magic's chastity cage is transparent, the way the panther's sheath grows thicker is clear. The pink member nestled within reaches the opening of his sheath and bulges it, but because of the spell, it is unable to properly grow hard. It sure seems keen on trying to, though.
@@ -6105,7 +5972,7 @@ Ivex makes effort after effort to move, to get away from the thing assaulting hi
 The wolf smirks with satisfaction. Ivex is finally paying for all he has done.
 
 
-:: Ivex Extraction 3 (Text) [text] {"position":"3230,1986","size":"100,100"}
+:: Ivex Extraction 3 (Text) [text] {"position":"2025,5850","size":"100,100"}
 <<print $name>> can't help but move his own hand down to his cock as he watches the struggling panther get assaulted inside his own device. The karmic justice in it feels weirdly erotic. Or maybe it's just the effects of the candle still burning hot within him? Either way, it feels great for the wolf to have the freedom to wrap his paw around his member and stroke it.
 
 It feels even better to see Ivex's eyes shifting downwards towards his cock. The panther is forced to watch the free wolf idly jerking off while, at the same time, the blob keeps working on his cock relentlessly while it is unable to even grow hard.
@@ -6121,7 +5988,7 @@ Ivex seems to definitely feel that. The feline's eyes grow wide, and his face ch
 And then things get even better.
 
 
-:: Ivex Extraction Final (Text) [text] {"position":"3230,2135","size":"100,100"}
+:: Ivex Extraction Final (Text) [text] {"position":"2150,5850","size":"100,100"}
 The wolf's paw speeds up even more on his cock and he laughs when the blob spreads Ivex's legs even wider. The movement under the panther's tail makes what's going to happen next obvious. It's unbelievable that Ivex made this thing to do that to someone, but it feels incredibly pleasant to see it done to him!
 
 The panther seems to be aware of what's going to happen as well. His struggling to move grows more frantic than ever, every muscle in the panther's body contracting as he tries to move, but it is as if he is encased in solid ice. The panther remains there, floating inside the blob, even as it moves under his tail...
@@ -6145,7 +6012,7 @@ The wolf, on the other hand, slows down his paw. His cock, just as before, remai
 Just as he wonders that, the altar where the blob with Ivex inside starts glowing. The wolf takes a step back, readying himself, unsure of what is happening...
 
 
-:: Ivex Extraction End (Text) [text] {"position":"3229,2285","size":"100,100"}
+:: Ivex Extraction End (Text) [text] {"position":"2275,5850","size":"100,100"}
 The glowing on the altar grows brighter. Ivex seems to grow more frantic inside it for a moment, and then...
 
 It disappears.
@@ -6167,7 +6034,7 @@ Yet, he smirks. If the panther has really inflicted that upon others, then it is
 The panther's eyes grow wide with fury when the wolf pushes the first of the alcove's stone doors closed. Then, $name can see him trying so very hard to move, to say something, all the while his eyes and face start losing themselves in an expression of drunken lust and need before the wolf closes the second door, trapping the crazed mage inside with nothing but his own candles... and his own weird blob-thing.
 
 
-:: Extraction Finish (Text) [text] {"position":"2914,3060","size":"100,100"}
+:: Extraction Finish (Text) [text] {"position":"2400,5850","size":"100,100"}
 The wolf gets out of the tower and takes pleasure in knowing that, inside this gemstone where the tower is, the target of his bounty is as well.
 
 Lucky for the wolf, he manages to find a worn, old pair of pants in the farmhouse Ivex had made his base. They are far too short for him, but they will do, so that at least he's not naked.
@@ -6187,18 +6054,18 @@ With a handsome amount of gold in his hands, the wolf moves on. The life of an a
 Or, at least, he will try to.
 
 
-:: Ivex Enthrallment Archive Display {"position":"177,3127","size":"100,100"}
+:: Ivex Enthrallment Archive Display [noreturn] {"position":"2200,1000","size":"100,100"}
 <<if $enthralmentIvexEnding>>\
   <b>[[Ending: A New Servant|Ivex Enthrallment Archive]]</b>
 <<else>>\
   <span class="helper-container">
-  	<b><span class="disabled">Ending: A New Servant</span></b>
-	<small class="helper-text">New punishment ideas might come to the adventurer if he has experienced terrible things in different timelines...</small>
+      <b><span class="disabled">Ending: A New Servant</span></b>
+    <small class="helper-text">New punishment ideas might come to the adventurer if he has experienced terrible things in different timelines...</small>
   </span>
 <</if>>\
 
 
-:: Ivex Enthrallment Archive [noreturn] {"position":"472,3130","size":"100,100"}
+:: Ivex Enthrallment Archive [noreturn] {"position":"2200,1100","size":"100,100"}
 <<include "Enthrallment Vengeance (Text)">>
 
 <<include "Ivex Enthrallment 1 (Text)">>
@@ -6222,18 +6089,18 @@ Or, at least, he will try to.
 [[Return to the Archives|Archives]]
 
 
-:: Ivex Extraction Archive Display {"position":"176,3235","size":"100,100"}
+:: Ivex Extraction Archive Display [noreturn] {"position":"2325,1000","size":"100,100"}
 <<if $extractionIvexEnding>>\
   <b>[[Ending: Energy Supply|Ivex Extraction Archive]]</b>
 <<else>>\
   <span class="helper-container">
-  	<b><span class="disabled">Ending: Energy Supply</span></b>
-	<small class="helper-text">New punishment ideas might come to the adventurer if he has experienced terrible things in different timelines...</small>
+      <b><span class="disabled">Ending: Energy Supply</span></b>
+    <small class="helper-text">New punishment ideas might come to the adventurer if he has experienced terrible things in different timelines...</small>
   </span>
 <</if>>\
 
 
-:: Ivex Extraction Archive [noreturn] {"position":"471,3235","size":"100,100"}
+:: Ivex Extraction Archive [noreturn] {"position":"2325,1100","size":"100,100"}
 <<include "Extraction Vengeance (Text)">>
 
 <<include "Ivex Extraction 1 (Text)">>
@@ -6253,18 +6120,18 @@ Or, at least, he will try to.
 [[Return to the Archives|Archives]]
 
 
-:: Ivex Punishment Archive Display {"position":"178,3020","size":"100,100"}
+:: Ivex Punishment Archive Display [noreturn] {"position":"2075,1000","size":"100,100"}
 <<if $personalEnding>>\
   <b>[[Ending: Punishment|Ivex Punishment Archive]]</b>
 <<else>>\
   <span class="helper-container">
-  	<b><span class="disabled">Ending: Punishment</span></b>
-	<small class="helper-text">The spoils of victory...</small>
+      <b><span class="disabled">Ending: Punishment</span></b>
+    <small class="helper-text">The spoils of victory...</small>
   </span>
 <</if>>\
 
 
-:: Ivex Punishment Archive [noreturn] {"position":"471,3023","size":"100,100"}
+:: Ivex Punishment Archive [noreturn] {"position":"2075,1100","size":"100,100"}
 The wolf, still holding Ivex up by the scruff, lifts him higher so that he can look at the unconscious feline's face. Then, without hesitation, $name brings a paw up and gives the panther's muzzle a hard slap.
 
 Ivex shakes, awakening with a grunt and a mewl. The feline blinks, his feet wiggling up in the air and he looks around confused for a moment before his eyes focus on the large wolf holding him up. The sight of him trying to do something about it, only to realize that his arms are bound behind his back and his bound feet can't even touch the floor makes for quite an amusing scene.
@@ -6644,8 +6511,8 @@ Or, at least, he will try to.
 [[Return to the Archives|Archives]]
 
 
-:: Credits [noreturn] {"position":"722,2741","size":"100,100"}
-[[Return to the game|$return]]
+:: Credits [noreturn] {"position":"2600,700","size":"100,100"}
+<<link "Return to the game" $return>><</link>>\
 
 The writing and development of this interactive story was made by me, [[Sleth|http://www.slethstories.com/]].
 
@@ -6657,50 +6524,50 @@ Not only that, but I'd also like to extend my deepest gratitude to my patrons, w
 
 First and foremost, my patrons that have supported me in these last 4 months it took for me to develop, learn and finish this project:
 
-<b><ul>\  
-	<li>John Harris</li>
-	<li>Timba Saber</li>
-	<li>Kevin Deiderich</li>
-	<li>Gd </li>
-	<li>Rise</li>
-	<li>Bingturong</li>
-	<li>Laswer5</li>
-	<li>Sándor Bajkai</li>
-	<li>Sameer </li>
-	<li>wssbxj </li>
-	<li>Ian Meyers</li>
-	<li>Daniel Choi</li>
-	<li>Lathbalrog</li>
-	<li>Argentcoyote</li>
-	<li>Rin Ookami</li>
-	<li>xiaokiroz </li>
-	<li>Nigel Leiterman</li>
-	<li>keinok82562 </li>
-	<li>MagicMinnett</li>
-	<li>Ishiah </li>
-	<li>Snow Tastes Great</li>
-	<li>nikokarro</li>
-	<li>Nimrax</li>
-	<li>Maxwell</li>
-	<li>SASO_PRO</li>
-	<li>Lykron </li>
-	<li>Chris </li>
-	<li>AshfurtheBroken </li>
-	<li>Hyenatime </li>
-	<li>Michael </li>
-	<li>Chris Gordon</li>
-	<li>Pinecone</li>
-	<li>Guri Linus</li>
-	<li>Hyao</li>
-	<li>fancyhat </li>
-	<li>llama</li>
-	<li>Abraxas </li>
-	<li>Hollud </li>
-	<li>Lykos Bane</li>
-	<li>Rex Aurum</li>
-	<li>Martin Farley</li>
-	<li>Knight of the Dragon</li>
-	<li>Raus</li>
+<b><ul>\
+    <li>John Harris</li>
+    <li>Timba Saber</li>
+    <li>Kevin Deiderich</li>
+    <li>Gd </li>
+    <li>Rise</li>
+    <li>Bingturong</li>
+    <li>Laswer5</li>
+    <li>Sándor Bajkai</li>
+    <li>Sameer </li>
+    <li>wssbxj </li>
+    <li>Ian Meyers</li>
+    <li>Daniel Choi</li>
+    <li>Lathbalrog</li>
+    <li>Argentcoyote</li>
+    <li>Rin Ookami</li>
+    <li>xiaokiroz </li>
+    <li>Nigel Leiterman</li>
+    <li>keinok82562 </li>
+    <li>MagicMinnett</li>
+    <li>Ishiah </li>
+    <li>Snow Tastes Great</li>
+    <li>nikokarro</li>
+    <li>Nimrax</li>
+    <li>Maxwell</li>
+    <li>SASO_PRO</li>
+    <li>Lykron </li>
+    <li>Chris </li>
+    <li>AshfurtheBroken </li>
+    <li>Hyenatime </li>
+    <li>Michael </li>
+    <li>Chris Gordon</li>
+    <li>Pinecone</li>
+    <li>Guri Linus</li>
+    <li>Hyao</li>
+    <li>fancyhat </li>
+    <li>llama</li>
+    <li>Abraxas </li>
+    <li>Hollud </li>
+    <li>Lykos Bane</li>
+    <li>Rex Aurum</li>
+    <li>Martin Farley</li>
+    <li>Knight of the Dragon</li>
+    <li>Raus</li>
 </ul></b>\
 
 And, of course, also an honorable mention to everyone that has supported me and my writing in the these last years I have had my patreon going:
@@ -6778,7 +6645,7 @@ And, of course, also an honorable mention to everyone that has supported me and 
 Thank you so much!
 
 
-:: Title Screen 1 {"position":"1016,2","size":"100,100"}
+:: Title Screen 1 {"position":"2625,25","size":"100,100"}
 <<silently>>
 <<if $personalEnding>>
 <<set $characterDisplay = "images/wolf.png">>
@@ -6795,6 +6662,7 @@ Thank you so much!
 <div class="title-options">\
 <<link "New Game">>
   <<script>>
+    // [[Bound]]
     Dialog.setup("Content Warning");
 	  Dialog.wiki("This interactive story contains content of an adult nature. If you are easily offended or are under the age of 18, please exit now.<br/><br/> Moreover, this story contains elements that depict dubious or lack of consent, as well as other fetish sexual topics such as mind control, CBT, chastity, and others. If these themes make you uncomfortable or are not enjoyable for you, proceed only at your own discretion.<br/><br/><span style= 'float: right;'><<"+"button Proceed>><<"+"goto 'Bound'>><<"+"script>>Dialog.close();<<"+"/script>><<"+"/button>></span>");
     Dialog.open();

--- a/story.tw
+++ b/story.tw
@@ -9,11 +9,16 @@ The Mage's Tower
 	"format-version": "2.36.1",
 	"start": "Title Screen",
 	"tag-colors": {
-		"hub": "purple",
+		"done": "purple",
+		"end": "red",
+		"has-hole": "yellow",
 		"incomplete": "red",
-		"key": "red",
-		"noreturn": "red",
-		"start": "green",
+		"init": "blue",
+		"key": "orange",
+		"maybe-password": "blue",
+		"must-fix": "orange",
+		"noreturn": "yellow",
+		"restart": "green",
 		"text": "blue"
 	},
 	"zoom": 0.6
@@ -95,6 +100,11 @@ The Mage's Tower
   background-color: #cb9b32;
 }
 
+#menu {
+  /* make some clear space, since footer is on top */
+  margin-bottom: 50px;
+}
+
 #menu ul {
   border-radius: 15px;
 }
@@ -148,6 +158,13 @@ The Mage's Tower
 
 #story-title {
   display: none;
+}
+
+#story-version {
+  color: rgb(90 90 90);
+  font-size: 12px;
+  font-weight: normal;
+  line-height: 1;
 }
 
 #story-caption {
@@ -250,7 +267,6 @@ ul.actions {
 }
 
 ul.actions li {
-  /*list-style-image: url('https://i.imgur.com/VdVEJPV.png');*/
   padding: 10px 0 10px 25px;
   list-style: none;
   background-image: url("images/quote.png");
@@ -258,6 +274,12 @@ ul.actions li {
   background-position: left center;
   background-size: 15px;
 }
+
+/* fixup for debug/test mode */
+.debugging ul.actions li {
+  background-image: url("https://magestower.slethstories.com/images/quote.png");
+}
+
 /* Action Box - End */
 
 
@@ -369,15 +391,35 @@ ul.actions li {
 
 :: Story JavaScript [script]
 Config.ui.stowBarInitially = true;
-Config.history.controls = false;
+
+if (!Config.debug) {
+  Config.history.controls = false;
+}
+
+if (Config.debug) {
+  // set flag for StoryMenu (can't use Config.debug; it's always false for StoryMenu)
+  setup.enableDebugMenu = true;
+
+  // set base url for html images (this happens too late for css images)
+  $('head').prepend('<base href="https://magestower.slethstories.com/">');
+
+  // add debugging class for css
+  $('html').addClass('debugging');
+
+  // start with debugview off
+  setTimeout(() => DebugView.disable());
+}
+
+l10nStrings.restartTitle = 'Reset';
+l10nStrings.restartPrompt = 'Archive unlocks and unsaved progress will be lost.<br><br>Are you sure you want to reset everything and start over?';
 
 $(document.head).append("<link rel='icon' href='images/mt_icon_tr.png'>");
 
-predisplay["Menu Return"] = function (taskName) {
-	if (! tags().contains("noreturn")) {
-		State.variables.return = passage();
+$(document).on(':passagestart', function (ev) {
+    if (! ev.passage.tags.contains("noreturn")) {
+        State.variables.return = ev.passage.title;
     }
-};
+});
 
 /* Health Bar code - Start */
 window.Health = function (CurHP, MaxHP, BarID, Horizontal, Container) {
@@ -414,6 +456,7 @@ macros.arousalbar = {
 
 
 :: Bound {"position":"2500,175","size":"100,100"}
+<<set $passedContentWarning = true>>\
 The sound of snapping fingers feels distant at first. As consciousness returns, it grows closer and closer until it starts becoming loud.
 
 The snapping comes from right beside his ear. The adventurer frowns, but consciousness has not returned in its entirety just yet. He feels as if... as if he had fallen down a well. At least that's all he can remember, sort of. It was bright, it was sudden, and now...
@@ -422,11 +465,14 @@ The snapping comes from right beside his ear. The adventurer frowns, but conscio
 
 The bound wolf only lets out a pained groan at first. Everything hurts. Slowly but surely, memories start to return. Memories of who he is...
 
-[[Continue|Wolf Warrior Chosen]]
+[[Continue|Drekkar Start]]
 
 
 :: StoryAuthor {"position":"1825,150","size":"100,100"}
-by <a href="http://www.slethstories.com/" target="_blank">Sleth</a>
+by <a href="http://www.slethstories.com/" target="_blank">Sleth</a>\
+<div id="story-version">
+  v1.2002910.0
+</div>
 
 
 :: StoryBanner {"position":"2075,150","size":"100,100"}
@@ -441,6 +487,9 @@ The Mage's Tower
 :: StoryMenu {"position":"2500,500","size":"100,100"}
 [[Archives]]
 [[Credits]]
+<<if setup.enableDebugMenu>>
+    [[Debug: Goto Title|Title Screen]]
+<</if>>
 
 
 :: Soft Awakening {"position":"900,625","size":"100,100"}
@@ -545,7 +594,7 @@ The panther opens a cocky grin.
 
 "The reward, however, is quite substantial. I do wonder who exactly hired you to find me, and how you managed to reach my location. I'd very much like to know that before I decide what to do with you."
 
-The wolf's narrow eyes focus on the panther. Bound in an unknown location and at the wizard's mercy, the lupine $class knows that the situation isn't good. Still, to just give out the name and location of the adventurer's guild that hired him to go after the mage would put all of them in danger, to say the least...
+The wolf's narrow eyes focus on the panther. Bound in an unknown location and at the wizard's mercy, the lupine $class knows that the situation isn't good. Still, to just give out the name and location of the Wayward Adventurer Guild would put all of them in danger, to say the least...
 
 The panther stares at the wolf expecting an answer.
 
@@ -557,13 +606,13 @@ The panther stares at the wolf expecting an answer.
 </div>
 
 
-:: Wolf Warrior Chosen {"position":"950,500","size":"100,100"}
+:: Drekkar Start {"position":"950,500","size":"100,100"}
 <<set $name = "Drekkar">>\
 <<set $class = "warrior">>\
 <<set $warrior = true>>\
 <<set $mage = false>>\
 <<set $rough_awakening = false>>\
-An adventurer, a fighter, a large wolf that takes pride in his strength. He goes by the name of Drekkar, with his older name being way more complex and difficult to pronounce. Hailing from the less advanced wolven tribes from the north, Drekkar left his kind early and adapted well to the world. With a sword in hand, there's little he cannot accomplish. Now, however...
+A seasoned fighter, a large wolf that takes pride in his strength. He goes by the name of Drekkar, with his older name being more complex and difficult to pronounce. Hailing from the less advanced wolven tribes from the north, Drekkar left his kind early and adapted well to the wider world. He's known among his friends at the Wayward Adventurers Guild as "that crazy bastard who took down the Mad Wizard of Carcenvellathrop by punching him in the face". With a sword in hand, there's little Drekkar cannot accomplish. Now, however...
 
 Drekkar's muscles, usually his most powerful weapon, ache. They feel stiff. An aching to stretch them comes upon the big wolf, but his body is only just recovering its proper responses. Drekkar lets out another tired groan. This feels worse than his last hangover...
 
@@ -608,62 +657,67 @@ With a spring to his step, the panther approaches, closing in the last distance 
 
 
 :: StoryInit {"position":"2200,150","size":"100,100"}
-<<set $name = "Drekkar">>\
-<<set $class = "warrior">>\
-<<set $warrior = true>>\
-<<set $mage = false>>\
+<<script>>
+const v = variables();
+v.name = "Drekkar";
+v.class = "warrior";
+v.warrior = true;
+v.mage = false;
 
-<<set $rough_awakening = true>>
-<<set $FurtherDefiance = false>>
+v.rough_awakening = true;
+v.FurtherDefiance = false;
 
-<<set $CurArousal = 10>>
-<<set $MaxArousal = 100>>
+v.CurArousal = 10;
+v.MaxArousal = 100;
 
-<<set $candleTimer = "2s">>
-<<set $window = false>>
-<<set $office = false>>
-<<set $door = false>>
+v.candleTimer = "2s";
+v.window = false;
+v.office = false;
+v.door = false;
 
-<<set $lionwatch1 = 40>>
-<<set $lionwatch2 = 20>>
-<<set $lionwatch3 = 20>>
-<<set $lionwatch4 = 40>>
-<<set $lionwatch5 = 50>>
-<<set $lionwatch6 = 60>>
-<<set $lionwatch7 = 90>>
-<<set $lionwatchFinal = ($lionwatch1 + $lionwatch2 + $lionwatch3 + $lionwatch4+ $lionwatch5 + $lionwatch6 + $lionwatch7)>>
+v.lionwatch1 = 40;
+v.lionwatch2 = 20;
+v.lionwatch3 = 20;
+v.lionwatch4 = 40;
+v.lionwatch5 = 50;
+v.lionwatch6 = 60;
+v.lionwatch7 = 90;
+v.lionwatchFinal = v.lionwatch1 + v.lionwatch2 + v.lionwatch3 +
+  v.lionwatch4 + v.lionwatch5 + v.lionwatch6 + v.lionwatch7;
 
-<<set $interrogationEndingUnlock = false>>
-<<set $interrogationEndingShockUnlock = false>>
-<<set $interrogationEndingFreezeUnlock = false>>
-<<set $interrogationEndingMildUnlock = false>>
-<<set $interrogationEndingRoughUnlock = false>>
-<<set $interrogationEnding = false>>
-<<set $interrogationEndingShock = false>>
-<<set $interrogationEndingFreeze = false>>
-<<set $interrogationEndingMild = false>>
-<<set $interrogationEndingRough = false>>
+v.interrogationEndingUnlock = false;
+v.interrogationEndingShockUnlock = false;
+v.interrogationEndingFreezeUnlock = false;
+v.interrogationEndingMildUnlock = false;
+v.interrogationEndingRoughUnlock = false;
+v.interrogationEnding = false;
+v.interrogationEndingShock = false;
+v.interrogationEndingFreeze = false;
+v.interrogationEndingMild = false;
+v.interrogationEndingRough = false;
 
-<<set $enthrallmentEndingUnlock = false>>
-<<set $enthrallmentLionUnlock = false>>
-<<set $enthrallmentEnding = false>>
-<<set $enthrallmentLion = false>>
+v.enthrallmentEndingUnlock = false;
+v.enthrallmentLionUnlock = false;
+v.enthrallmentEnding = false;
+v.enthrallmentLion = false;
 
-<<set $extractionEndingUnlock = false>>
-<<set $extractionForcefulEndUnlock = false>>
-<<set $extractionGentleEndUnlock = false>>
-<<set $extractionEnding = false>>
-<<set $extractionForcefulEnd = false>>
-<<set $extractionGentleEnd = false>>
+v.extractionEndingUnlock = false;
+v.extractionForcefulEndUnlock = false;
+v.extractionGentleEndUnlock = false;
+v.extractionEnding = false;
+v.extractionForcefulEnd = false;
+v.extractionGentleEnd = false;
 
-<<set $enthralmentIvexEndingUnlock = false>>
-<<set $enthralmentIvexEnding = false>>
-<<set $extractionIvexEndingUnlock = false>>
-<<set $extractionIvexEnding = false>>
-<<set $personalEndingUnlock = false>>
-<<set $personalEnding = false>>
-
+v.enthralmentIvexEndingUnlock = false;
+v.enthralmentIvexEnding = false;
+v.extractionIvexEndingUnlock = false;
+v.extractionIvexEnding = false;
+v.personalEndingUnlock = false;
+v.personalEnding = false;
+<</script>>\
+\
 <<nobr>>
+
 <<append "#ui-bar-body">>
   <div id="ui-bar-footer">
     <span>
@@ -677,7 +731,7 @@ With a spring to his step, the panther approaches, closing in the last distance 
     </span>
   </div>
 <</append>>
-<</nobr>>
+<</nobr>>\
 
 
 :: Molesting {"position":"950,1000","size":"100,100"}
@@ -766,7 +820,7 @@ The panther approaches again.
 
 <div class="action-box">\
   <ul class="actions">\
-	<li>[["Whatever you're trying to do, it won't work!" Keep holding your breath in defiance.|Hold Breath Defiantly]]</li>
+    <li>[["Whatever you're trying to do, it won't work!" Keep holding his breath in defiance.|Hold Breath Defiantly]]</li>
     <li>[[He has a point. Breathe out and at least give him a warning growl.|Growl Defiantly]]</li>
   </ul>\
 </div>
@@ -2489,28 +2543,31 @@ To change the adventurer's fate, you can...
 
 :: Archives [noreturn] {"position":"2400,700","size":"100,100"}
 <<link "Return to the game" $return>><</link>>\
-
-<h1>Archives</h1>
+\
+<h1>Archives</h1>\
 Welcome to the Mage's Tower Archives.
+
 Here you can revisit the different endings the adventurer has met in his time in the Mage's Tower. When the adventurer goes through an ending in the game for the first time, it will be unlocked here to be revisited at any time. If an ending has different variations due to the adventurer's choices during the game, these also can be set here, provided they have been seen before.
 
 Grayed out endings are paths that have not yet been found, although there are hints under them as to what path the adventurer should take to reach them. The same applies to different variations of endings.
 
 <i>Unlocked endings are only kept within a save. To keep all unlocked endings, make sure to always use and load the same save file.</i>
+\
+<hr>\
+<h2>Endings unlocked:</h2>\
+<<include [[Interrogation Archive Display]]>>\
+\
+<<include [[Enthrallment Archive Display]]>>\
+\
+<<include [[Extraction Archive Display]]>>\
+\
+<<include [[Ivex Punishment Archive Display]]>>\
+\
+<<include [[Ivex Enthrallment Archive Display]]>>\
+\
+<<include [[Ivex Extraction Archive Display]]>>\
 
-<hr>
-<h2>Endings unlocked:</h2>
-<<include [[Interrogation Archive Display]]>>
-
-<<include [[Enthrallment Archive Display]]>>
-
-<<include [[Extraction Archive Display]]>>
-
-<<include [[Ivex Punishment Archive Display]]>>
-
-<<include [[Ivex Enthrallment Archive Display]]>>
-
-<<include [[Ivex Extraction Archive Display]]>>
+<<link "Return to the game" $return>><</link>>\
 
 
 :: The Desk {"position":"900,4350","size":"100,100"}
@@ -2823,7 +2880,7 @@ Its arousing scent lingers for a few more moments, but soon enough the wolf's br
 
 Still panting, $name finally stops struggling and lets himself relax against his bonds for a moment. He realizes how sore all of his muscles are from the continuous desperate effort. Everything aches. Even as his mind clears up to some extent, however, the burning fire of arousal within him doesn't subside. It merely stops growing. His cock still remains fully hard, knot engorged and everything, and just looking at it makes his heart race with an urge to touch it.
 
-At least the wolf has enough awareness back to know he won't be able, to while bound as he is. And to worry about the panther standing in front of him.
+At least the wolf has enough awareness back to know he won't be able to, while bound as he is. And to worry about the panther standing in front of him.
 
 Ivex pulls the cloth covering his nose down as well to reveal his large grin.
 
@@ -2871,9 +2928,9 @@ The mage finally takes hold of the wolf's exposed cock with a paw. The feeling a
 
 It gets even worse when Ivex starts massaging it ever so lightly with his fingers. The pleasure contrasts with the pain of his balls being so mercilessly pulled by the crystal's weight.
 
-"I know the adventurer's guild sent you. What do they have on me?"
+"I know the Wayward Adventurers Guild sent you. What do they have on me?"
 
-A vague question. The wolf's knowledge is limited, but any details he tells Ivex could put the Adventurer's guild or whoever else they send after Ivex in the same danger he is facing. Betraying his comrades is something the wolf would never do, and just the fact that Ivex believes he would is an offense in itself.
+A vague question. The wolf's knowledge is limited, but any details he tells Ivex could put Guild or whoever else they send after Ivex in the same danger he is facing. Betraying his comrades is something the wolf would never do, and just the fact that Ivex believes he would is an offense in itself.
 
 
 :: Hard Way (Text) [text] {"position":"1375,2200","size":"100,100"}
@@ -2897,9 +2954,9 @@ The mage grabs the wolf's exposed cock with a paw. The feeling around it alone i
 
 It gets even worse when Ivex starts massaging it ever so lightly with his fingers. The pleasure is a terrible contrast to the pain of his balls being so mercifully pulled by the crystal's weight.
 
-"I know the adventurer's guild sent you. What do they have on me?"
+"I know the Wayward Adventurers Guild sent you. What do they have on me?"
 
-A vague question. The wolf's knowledge is limited, but any details he tells Ivex could put the Adventurer's guild or whoever else they send after Ivex in the same danger he is facing. Betraying his comrades is something the wolf would never do.
+A vague question. The wolf's knowledge is limited, but any details he tells Ivex could put the Guild or whoever else they send after Ivex in the same danger he is facing. Betraying his comrades is something the wolf would never do.
 
 
 :: Resistance (Text) [text] {"position":"1525,2200","size":"100,100"}
@@ -3281,7 +3338,7 @@ No matter how much he tries, $name cannot find a way out. He's trapped there gri
 
 
 :: Interrogation Archive Display [noreturn] {"position":"1700,1000","size":"100,100"}
-<<silently>>\
+<<silently>>
   <<if $interrogationEndingFreeze && $interrogationEndingShock>>
     <<set $interrogationSpell = 'freeze'>>
   <<elseif $interrogationEndingFreeze && !$interrogationEndingShock>>
@@ -4508,9 +4565,65 @@ It doesn't stop there, and neither does the slime. All the stimulation keeps goi
 
 
 :: Title Screen [restart] {"position":"2500,25","size":"100,100"}
+<<script>>
+    const v = variables();
+    if (v.personalEnding) {
+        v.characterDisplay = 'images/wolf.png';
+    } else {
+        v.characterDisplay = 'images/panther.png';
+    }
+    if (v.titleDelay1) {
+        // already seen title, speed it up.
+        v.titleDelay1 = '0.1s';
+        v.titleDelay2 = '1s';
+        v.titleDelay3 = '0.2s';
+    } else {
+        v.titleDelay1 = '1s';
+        v.titleDelay2 = '2s';
+        v.titleDelay3 = '3s';
+    }
+    if (v.passedContentWarning) {
+        // we're here without clearing data
+        v.startGameText = 'Try Again';
+    } else {
+        v.startGameText = 'New Game';
+    }
+<</script>>\
+\
 <div class="title-screen">\
-<<include [[Title Screen 1]]>>
-</div>\
+<div class="title-container">\
+\
+<<timed $titleDelay1 t8n>>\
+<img class="title-character" @src="$characterDisplay">\
+\
+<<next $titleDelay2>>\
+<img class="title-logo" src="images/logo_tr.png">\
+\
+<<next $titleDelay3>>
+<div class="title-options">\
+\
+<<link $startGameText>>
+    <<if $passedContentWarning>>
+        <<goto [[Bound]]>>
+    <<else>>
+        <<script>>
+            Dialog.setup("Content Warning");
+            Dialog.wiki("<<include [[Content Warning]]>>");
+            Dialog.open();
+        <</script>>
+    <</if>>
+<</link>>
+\
+<<link 'Load Game'>>
+    <<run UI.saves()>>
+<</link>>
+\
+[[Credits]]
+\
+</div> <!--title-options-->\
+<</timed>>\
+</div> <!--title-container-->\
+</div> <!--title-screen-->\
 
 
 :: Tying up {"position":"1075,5450","size":"100,100"}
@@ -4560,7 +4673,7 @@ $name shoves each and every one of them into the pouch until there are only four
 
 
 :: Punishments {"position":"1425,5575","size":"100,100"}
-The wolf's hands curl into tight fists. He can barely control his growling, looking down at Ivex. Will getting locked up in some mage's containment chamber, or whatever else the guild decides to do to him, be enough to make him pay for what he's done? Of course not. They don't know half of what he's done, and even if he tells them, it won't have the same impact as seeing it.
+The wolf's hands curl into tight fists. He can barely control his growling, looking down at Ivex. Will getting locked up in some mage's containment chamber, or whatever else the Guild decides to do to him, be enough to make him pay for what he's done? Of course not. They don't know half of what he's done, and even if he tells them, it won't have the same impact as seeing it.
 
 With the sack of gemstones in hand, the wolf stomps over to the tied-up feline and lifts him up by the scruff. Ivex shifts and grunts in his sleep, but doesn't wake up quite yet.
 
@@ -5142,7 +5255,11 @@ Pulling out the purple gemstone, the wolf clutches it in his hand and looks down
 <<if !$shockSpell>>\
 The panther catches a glimpse of which gemstone the wolf is pulling out and frowns.
 
+<<if !$gagged>>\
 "You idiot! Be careful what you touch! You don't even know what you're doing!" The panther hisses and wiggles trying to get away.
+<<else>>\
+"Ymm mmfgh! Mm gmfmf hmmgff gmfhgh!" The panther hisses and wiggles trying to get away.
+<</if>>\
 
 The wolf's grip on Ivex simply tightens while he clutches the gemstone with the other hand. The cackle of lightning around his paw creates a tingle. A funny one. It definitely seems like it does more than just tingle when his paw touches something, though.
 
@@ -5548,7 +5665,7 @@ Wiping his hands, the wolf looks down at Ivex. Bound, gagged and without his gem
 
 $name steps towards him to pick him up. Ivex still squirms and complains, obviously still angry over having lost. He no longer gets a choice, though.
 
-The wolf does. He wonders if Ivex has had enough punishment or if he should add a finishing touch to his reckoning. After all, it will be a few days' journey back to the adventurer's guild. Maybe adding something to... <b>entertain</b> Ivex in the meantime would be fun as well.
+The wolf does. He wonders if Ivex has had enough punishment or if he should add a finishing touch to his reckoning. After all, it will be a few days' journey back to the Wayward Adventurers Guild. Maybe adding something to... <b>entertain</b> Ivex in the meantime would be fun as well.
 <<if !$personalEnding>>\
 <<set $personalEndingUnlock = true>>\
 <</if>>\
@@ -5590,7 +5707,7 @@ Looking down, however, the wolf sees his member still aching. Surely Ivex's cand
 
 Not to mention the rest of his time trudging naked through his tower with a permanent hard-on. The wolf has captured many bounties before, some of them mages, but none of them had taken so much effort and humiliation to defeat.
 
-Glancing at the mage, he wonders. If he wants to give Ivex some reckoning for all he has done to him and to others, it has to be now. Once he's in the hands of the adventurer's guild officers, then another kind of justice will be served to him.
+Glancing at the mage, he wonders. If he wants to give Ivex some reckoning for all he has done to him and to others, it has to be now. Once he's in the hands of the Wayward Adventurers Guild officers, then another kind of justice will be served to him.
 
 $name takes a deep breath. Should he really just take Ivex to be arrested and nothing more?
 
@@ -5631,11 +5748,11 @@ Lucky for the wolf, he manages to find a worn, old pair of pants in the farmhous
 
 Gathering what supplies he can, the wolf sets off with everything in hand: Ivex's tower inside the large gemstone, the pouch of magic gems and, most importantly, Ivex.
 
-The journey back to the adventurer's guild takes a few days. It could go quicker, but after the deeply distressing effort to capture the mage, $name is not exactly in a hurry to get there anymore. The wolf takes his sweet time recovering from everything he went through inside the mage's crazy tower, and basking in his success.
+The journey back to the Wayward Adventurers Guild takes a few days. It could go quicker, but after the deeply distressing effort to capture the mage, $name is not exactly in a hurry to get there anymore. The wolf takes his sweet time recovering from everything he went through inside the mage's crazy tower, and basking in his success.
 
-When he gets to the guild, both the adventurers and officers there are deeply amused by the way $name delivers Ivex to them. After a thorough re-telling of what he went through and what he has in tow, the official mages in the adventurer's guild take Ivex to a prison where his magic will be kept in check.
+When he gets to the Guild, both the adventurers and officers there are deeply amused by the way $name delivers Ivex to them. After a thorough re-telling of what he went through and what he has in tow, the official mages in the Wayward Adventures Guild take Ivex to a prison where his magic will be kept in check.
 
-They also handle his tower. The wolf does not stick around to see it, but the rumors of the insane tower a mage possessed spread like wildfire. Apparently, the mages of the guild had to go through an arduous, delicate process to save the over fifty people Ivex had trapped inside his tower. All of them males.
+They also handle his tower. The wolf does not stick around to see it, but the rumors of the insane tower a mage possessed spread like wildfire. Apparently, the mages of the Guild had to go through an arduous, delicate process to save the over fifty people Ivex had trapped inside his tower. All of them males.
 
 With a handsome amount of gold in his pocket, the wolf moves on. The life of an adventurer is like that. Ivex wasn't the first mage he had to fight and it won't be the last. The events of the tower stick inside <<print $name>>'s mind, though, and they are enough to make him blush every now and then. He will make sure that such things never happen again.
 
@@ -5887,7 +6004,7 @@ The enthralled panther finally stops licking himself to sit up straight. Then, p
 
 Standing up himself, $name looks down at the mage. With the wolf's seed running down the back of his thighs, he smirks.
 
-It's time to take Ivex back to the adventurer's guild. Watching the blank-faced mage and knowing he's trapped like that, however, the wolf gets to thinking...
+It's time to take Ivex back to the Wayward Adventurers Guild. Watching the blank-faced mage and knowing he's trapped like that, however, the wolf gets to thinking...
 
 What would it be like to have a thrall himself? Would a large bag of gold really be enough to make up for something like that? What if...?
 
@@ -5913,11 +6030,11 @@ $name packs everything. The sack of gemstones with Ivex's spells and the large g
 
 Ivex, with the pendant around his neck, is made to walk behind the wolf the whole way. Never before had delivering a bounty been so easy. True to his word, the wolf leaves the panther completely naked. There is no point in wasting gold buying clothes for someone that does not deserve them.
 
-The journey back to the adventurer's guild is a few days long and the wolf is not in a hurry to return. In fact, $name makes a point to include as many towns as he can on the way back and, each time, he takes immense pleasure in watching the stares of folk as they see the naked panther parading around the city. In one of them, the wolf went as far as ordering the panther to clutch a gemstone containing a lust spell so he was mewling and dripping the whole time as well.
+The journey back to the Wayward Adventurers Guild is a few days long and the wolf is not in a hurry to return. In fact, $name makes a point to include as many towns as he can on the way back and, each time, he takes immense pleasure in watching the stares of folk as they see the naked panther parading around the city. In one of them, the wolf went as far as ordering the panther to clutch a gemstone containing a lust spell so he was mewling and dripping the whole time as well.
 
-When they arrive back in the adventurer's guild, the wolf delivers Ivex's tower and his gemstones to the official mages, but claims that he could not capture Ivex himself. It fills him with pleasure to know that he, in fact, left the panther jerking himself off in the alley behind the building.
+When they arrive back in the Guild, the wolf delivers Ivex's tower and his gemstones to the official mages, but claims that he could not capture Ivex himself. It fills him with pleasure to know that he, in fact, left the panther jerking himself off in the alley behind the building.
 
-The mages handle his tower. The wolf does not stick around to see it, but the rumors of the insane tower a mage possessed spread like wildfire. Apparently, the mages of the guild had to go through an arduous, delicate process to save the over fifty people Ivex had trapped inside his tower. All of them males. It makes $name feel all the better for having such a previously dangerous and deranged mage at his disposal, ready to lick his feet if he feels like it. Literally.
+The mages handle his tower. The wolf does not stick around to see it, but the rumors of the insane tower a mage possessed spread like wildfire. Apparently, the mages of the Wayward Adventurers Guild had to go through an arduous, delicate process to save the over fifty people Ivex had trapped inside his tower. All of them males. It makes $name feel all the better for having such a previously dangerous and deranged mage at his disposal, ready to lick his feet if he feels like it. Literally.
 
 With a new 'companion' by his side, the wolf moves on. The life of an adventurer is like that. Ivex wasn't the first mage he had to fight and it won't be the last. The events of the tower stick inside <<print $name>>'s mind, though, and they are enough to make him blush every now and then, but whenever that happens, his new panther servant is there to alleviate his rage. He will make sure that such things never happen again.
 
@@ -5945,7 +6062,7 @@ It is at that moment that Ivex's droopy eyes start to open. The blob continues t
 :: Ivex Extraction 1 (Text) [text] {"position":"1775,5850","size":"100,100"}
 The panther's muzzle moves, but if he makes any sound, it doesn't make it past the thick, viscous substance of the blob. Ivex's bound arms and legs move for a moment, but as soon as they start, they immediately slow down, and the wolf can see that the thing is hardening around them to keep the panther still. Frozen in place, Ivex's eyes dart back and forth until they meet the wolf's. $name can see him frown, his expression shifting to one of anger, but his face too freezes inside the thing. Whatever this blob is, it doesn't seem keen on letting the feline move. Good. It works even better than the wolf expected.
 
-$name wipes his paws and smiles triumphantly. Seeing Ivex trapped inside his own device is extremely pleasant. For a few moments, he watches the feline as he clearly struggles to move. His small muscles contract here or there, showing he's trying to put effort into moving his limbs, but none of it amounts to anything. What a weakling! After a while, it is clear that the feline is trapped and cannot get out. The wolf is ready to leave him there, for in fact, he doesn't even know how he would go about getting Ivex out of it. The mages in the adventurer's guild will surely figure something out when he delivers the panther and his tower to them in a few days. Taking a step back, the wolf is about to leave, but then something else catches his eye.
+$name wipes his paws and smiles triumphantly. Seeing Ivex trapped inside his own device is extremely pleasant. For a few moments, he watches the feline as he clearly struggles to move. His small muscles contract here or there, showing he's trying to put effort into moving his limbs, but none of it amounts to anything. What a weakling! After a while, it is clear that the feline is trapped and cannot get out. The wolf is ready to leave him there, for in fact, he doesn't even know how he would go about getting Ivex out of it. The mages in the Wayward Adventurers Guild will surely figure something out when he delivers the panther and his tower to them in a few days. Taking a step back, the wolf is about to leave, but then something else catches his eye.
 
 Ivex seems to start growing more frantic in his entrapment. As the wolf's eyes go over the feline, he can see why. Little by little, the blob seems to <b>dissolve</b> Ivex's clothing. It moves around the panther as a whole, its surface full of ripples as it does its work while keeping the mage still at the same time. Ivex's robes start tearing, then little by little, holes start appearing in the fabric and these grow wider and wider, expanding until, soon enough, there is nothing left. The wolf smirks. The panther is left not only trapped but also <b>naked</b>. The rope that bound him dissolve as well, which worries the wolf for a moment, but the panther can't even manage to move them out of the position they were while bound inside the slime.
 
@@ -6041,13 +6158,13 @@ Lucky for the wolf, he manages to find a worn, old pair of pants in the farmhous
 
 Gathering what supplies he can, the wolf sets off with everything in hand: Ivex's tower inside the large gemstone, the pouch of magic gemstones and, most importantly, Ivex.
 
-The journey back to the adventurer's guild takes a few days. It could go quicker, but after the deeply distressing effort to capture the mage, $name is not exactly in a hurry to get there anymore. The wolf takes his sweet time recovering from everything he went through inside the mage's crazy tower, and basking in his success.
+The journey back to the Wayward Adventurers Guild takes a few days. It could go quicker, but after the deeply distressing effort to capture the mage, $name is not exactly in a hurry to get there anymore. The wolf takes his sweet time recovering from everything he went through inside the mage's crazy tower, and basking in his success.
 
 A few times during his journey he goes back in to check on Ivex. Every time he does, the panther's eyes dart to him, but they are glazed. He's lost in an infinite loop of pleasure. Pleasure he can't have. The blob always looks like it's working its hardest to stimulate the panther, but with the chastity spell still on him, all he can provide is pre-cum as his cock always strains to grow hard, but can't. Other than his pleasurable torment, Ivex seems fine. Whatever magics he has going on in this system with the blob-things, it seems to be made to sustain who is inside and keep them well and healthy.
 
-When the wolf gets back to the guild, he gives them a thorough re-telling of what he went through and what he has in tow, the official mages in the adventurer's guild take a while to extract Ivex himself from his own torment, but from there, they throw him straight into a prison where his magic will be kept in check.
+When the wolf gets back to the Guild, he gives them a thorough re-telling of what he went through and what he has in tow, the official mages in the Wayward Adventurers Guild take a while to extract Ivex himself from his own torment, but from there, they throw him straight into a prison where his magic will be kept in check.
 
-They also handle his tower as a whole. The wolf does not stick around to see it, but the rumors of the insane tower a mage possessed spread like wildfire. Apparently, the mages of the guild had to go through an arduous, delicate process to save the over fifty people Ivex had trapped inside his tower in the same way he was trapped. All of them males, and all of them kept there to provide energy for the tower's existence with their seed inside these things that would perpetually extract it from them while, at the same time, stimulating their bodies to produce more. A truly twisted device.
+They also handle his tower as a whole. The wolf does not stick around to see it, but the rumors of the insane tower a mage possessed spread like wildfire. Apparently, the mages of the Guild had to go through an arduous, delicate process to save the over fifty people Ivex had trapped inside his tower in the same way he was trapped. All of them males, and all of them kept there to provide energy for the tower's existence with their seed inside these things that would perpetually extract it from them while, at the same time, stimulating their bodies to produce more. A truly twisted device.
 
 With a handsome amount of gold in his hands, the wolf moves on. The life of an adventurer is like that. Ivex wasn't the first mage he had to fight and it won't be the last. The events of the tower stick inside <<print $name>>'s mind, though, and they are enough to make him blush every now and then. He will make sure that such things never happen again.
 
@@ -6468,7 +6585,7 @@ Wiping his hands, the wolf looks down at Ivex. Bound, gagged and without his gem
 
 $name steps towards him to pick him up. Ivex still squirms and complains, obviously still angry over having lost. He no longer gets a choice, though.
 
-The wolf does. He wonders if Ivex has had enough punishment or if he should add a finishing touch to his reckoning. After all, it will be a few days' journey back to the adventurer's guild. Maybe adding something to... <b>entertain</b> Ivex in the meantime would be fun as well.
+The wolf does. He wonders if Ivex has had enough punishment or if he should add a finishing touch to his reckoning. After all, it will be a few days' journey back to the Wayward Adventurers Guild. Maybe adding something to... <b>entertain</b> Ivex in the meantime would be fun as well.
 
 Yeah... Ivex has certainly done enough to deserve an extra.
 
@@ -6496,11 +6613,11 @@ Lucky for the wolf, he manages to find a worn, old pair of pants in the farmhous
 
 Gathering what supplies he can, the wolf sets off with everything in hand: Ivex's tower inside the large gemstone, the pouch of magic gems and, most importantly, Ivex.
 
-The journey back to the adventurer's guild takes a few days. It could go quicker, but after the deeply distressing effort to capture the mage, $name is not exactly in a hurry to get there anymore. The wolf takes his sweet time recovering from everything he went through inside the mage's crazy tower, and basking in his success.
+The journey back to the Wayward Adventurers Guild takes a few days. It could go quicker, but after the deeply distressing effort to capture the mage, $name is not exactly in a hurry to get there anymore. The wolf takes his sweet time recovering from everything he went through inside the mage's crazy tower, and basking in his success.
 
-When he gets to the guild, both the adventurers and officers there are deeply amused by the way $name delivers Ivex to them. After a thorough re-telling of what he went through and what he has in tow, the official mages in the adventurer's guild take Ivex to a prison where his magic will be kept in check.
+When he gets to the Guild, both the adventurers and officers there are deeply amused by the way $name delivers Ivex to them. After a thorough re-telling of what he went through and what he has in tow, the official mages in the Wayward Adventurers Guild take Ivex to a prison where his magic will be kept in check.
 
-They also handle his tower. The wolf does not stick around to see it, but the rumors of the insane tower a mage possessed spread like wildfire. Apparently, the mages of the guild had to go through an arduous, delicate process to save the over fifty people Ivex had trapped inside his tower. All of them males.
+They also handle his tower. The wolf does not stick around to see it, but the rumors of the insane tower a mage possessed spread like wildfire. Apparently, the mages of the Guild had to go through an arduous, delicate process to save the over fifty people Ivex had trapped inside his tower. All of them males.
 
 With a handsome amount of gold in his pocket, the wolf moves on. The life of an adventurer is like that. Ivex wasn't the first mage he had to fight and it won't be the last. The events of the tower stick inside <<print $name>>'s mind, though, and they are enough to make him blush every now and then. He will make sure that such things never happen again.
 
@@ -6513,7 +6630,8 @@ Or, at least, he will try to.
 
 :: Credits [noreturn] {"position":"2600,700","size":"100,100"}
 <<link "Return to the game" $return>><</link>>\
-
+\
+<h1>Credits</h1>\
 The writing and development of this interactive story was made by me, [[Sleth|http://www.slethstories.com/]].
 
 The amazing artwork you see in the game, including the character art and the Mage's Tower logo, was done by commission by [[BlainWolf|https://twitter.com/Blain_Wolf]]. You can check out more of his stuff in his [[Twitter|https://twitter.com/Blain_Wolf]] or [[FurAffinity|https://www.furaffinity.net/user/blainwolf]] pages!
@@ -6523,7 +6641,7 @@ I'd also like to give a special, personal thanks to [[Raus|https://twitter.com/r
 Not only that, but I'd also like to extend my deepest gratitude to my patrons, who have been supporting me and my craft through the months it took to develop this interactive story! None of this would be possible without you all!
 
 First and foremost, my patrons that have supported me in these last 4 months it took for me to develop, learn and finish this project:
-
+\
 <b><ul>\
     <li>John Harris</li>
     <li>Timba Saber</li>
@@ -6569,9 +6687,9 @@ First and foremost, my patrons that have supported me in these last 4 months it 
     <li>Knight of the Dragon</li>
     <li>Raus</li>
 </ul></b>\
-
+\
 And, of course, also an honorable mention to everyone that has supported me and my writing in the these last years I have had my patreon going:
-
+\
 <ul>\
 <li>John Harris</li>
 <li>Timba Saber</li>
@@ -6641,37 +6759,36 @@ And, of course, also an honorable mention to everyone that has supported me and 
 <li>Martin Farley</li>
 <li>Raus</li>
 </ul>\
-
+\
 Thank you so much!
 
+<<link "Return to the game" $return>><</link>>
 
-:: Title Screen 1 {"position":"2625,25","size":"100,100"}
-<<silently>>
-<<if $personalEnding>>
-<<set $characterDisplay = "images/wolf.png">>
-<<else>>
-<<set $characterDisplay = "images/panther.png">>
-<</if>>
-<</silently>>
-<div class="title-container">
-<<timed 1s t8n>>\
-<img class="title-character" @src="$characterDisplay">\
-<<next 2s>>\
-<img class="title-logo" src="images/logo_tr.png">\
-<<next 3s>>
-<div class="title-options">\
-<<link "New Game">>
-  <<script>>
-    // [[Bound]]
-    Dialog.setup("Content Warning");
-	  Dialog.wiki("This interactive story contains content of an adult nature. If you are easily offended or are under the age of 18, please exit now.<br/><br/> Moreover, this story contains elements that depict dubious or lack of consent, as well as other fetish sexual topics such as mind control, CBT, chastity, and others. If these themes make you uncomfortable or are not enjoyable for you, proceed only at your own discretion.<br/><br/><span style= 'float: right;'><<"+"button Proceed>><<"+"goto 'Bound'>><<"+"script>>Dialog.close();<<"+"/script>><<"+"/button>></span>");
-    Dialog.open();
-  <</script>>
-<</link>>
-<<link 'Load Game'>><<script>>UI.saves()<</script>><</link>>
-[[Credits]]
-</div>\
-<</timed>>
+
+:: Choose Character {"position":"2500,325","size":"100,100"}
+<i>Choose Your Adventurer</i>\
+
+<dl>
+<dt>Drekkar</dt>
+<dd>A seasoned fighter, a large wolf that takes pride in his strength. He goes by the name of Drekkar, with his older name being more complex and difficult to pronounce. Hailing from the less advanced wolven tribes from the north, Drekkar left his kind early and adapted well to the wider world. He's known among his friends at the Wayward Adventurers Guild as "that crazy bastard who took down the Mad Wizard of Carcenvellathrop by punching him in the face". With a sword in hand, there's little Drekkar cannot accomplish. Now, however...
+
+</dd>
+
+<dt>Nero</dt>
+<dd>A slender wolf, and unusually handsome for a mage. But he's always valued his mind more than his body. Nero is an unacknowledged son of one of Lady Garloch's nephews (or so he says). He's equally at ease covering for absent professors at the prestigious Windbone Magic Academy as he is when singing with drunken sailors at a Seaside tavern. His talent for magic has turned out to be very useful in his career of discreetly handling difficult problems for patrons who have way more money than sense. But this time...
+</dd></dl>\
+
+
+:: Content Warning {"position":"2625,75","size":"100,100"}
+This interactive story contains content of an adult nature. If you are easily offended or are under the age of 18, please exit now.
+
+Moreover, this story contains elements that depict dubious or lack of consent, as well as other fetish sexual topics such as mind control, CBT, chastity, and others. If these themes make you uncomfortable or are not enjoyable for you, proceed only at your own discretion.
+
+<div style='float: right;'>\
+<<button Proceed>>
+    <<run Dialog.close()>>
+    <<goto [[Bound]]>>
+<</button>>\
 </div>
 
 


### PR DESCRIPTION
I made a bunch of quality-of-life changes in Nero's story, and decided they were interesting enough to bring into the released Drekkar's story.

This is split into two commits. The first is just storygraph cleanup: passages are moved, some unused passages are deleted, and some implicit passage links are turned into visible passage links.

The second commit has:
- Player visible changes:
  - "Restart" in the side menu is now "Reset", and the warning mentions it loses Archive unlocks.
  - Title screen fade-in is faster when you return to it.
  - Content warning is skipped if you've already seen it.
  - Version number is added to sidebar.
  - Small tweak to Drekkar's description. Also give his guild a specific name throughout.
  - Minor spacing adjustments.
  - Minor typo fixes.
- Debug/test changes:
  - Images load from published website.
  - History controls are available in sidebar.
  - "Goto Title" added to menu.
  - Debugview starts off.

I considered letting the player have "goto title", since there isn't a "restart without losing unlocks", but I think it's fine to force the player to finish an ending before restarting. It adds mild frustration, and it's not that many clicks.

Feel free to argue with any of my changes :)