### PR TITLE
Opaque background for social icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -245,9 +245,10 @@ var LZString={_keyStr:"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz01234
 
 #ui-bar-footer {
   position: absolute;
+  background-color: rgb(34, 34, 34);
   bottom: 0;
-  padding: 0 1.5em;
-  text-align:center;
+  padding: 0.5em 1.5em 0 1.5em;
+  text-align: center;
 }
 
 #ui-bar-footer span {

--- a/story.tw
+++ b/story.tw
@@ -173,9 +173,10 @@ The Mage's Tower
 
 #ui-bar-footer {
   position: absolute;
+  background-color: rgb(34, 34, 34);
   bottom: 0;
-  padding: 0 1.5em;
-  text-align:center;
+  padding: 0.5em 1.5em 0 1.5em;
+  text-align: center;
 }
 
 #ui-bar-footer span {


### PR DESCRIPTION
On short screens, like a phone in landscape mode, the social icons in the sidebar can overlap the menu items, and it's confusing without an opaque background.

before:

![2022-12-02-065649-The Mage's Tower](https://user-images.githubusercontent.com/111094276/205321584-6ef3706c-71ba-44ca-ab68-6463851ebb7a.png)

after:

![2022-12-02-065718-The Mage's Tower](https://user-images.githubusercontent.com/111094276/205321619-8f478b64-6efa-4ac2-99e9-f63922acee32.png)
